### PR TITLE
pyinstaller / vorta.spec: make platform independent

### DIFF
--- a/src/vorta/__main__.py
+++ b/src/vorta/__main__.py
@@ -15,10 +15,9 @@ def main():
     args = parse_args()
 
     frozen_binary = getattr(sys, 'frozen', False)
-    # Don't fork if user specifies it or when running from onedir app bundle on macOS.
-    if (hasattr(args, 'foreground') and args.foreground) or (frozen_binary and sys.platform == 'darwin'):
-        pass
-    else:
+    need_foreground = frozen_binary and sys.platform in ('darwin', 'linux')
+    want_foreground = getattr(args, 'foreground', False)
+    if not (want_foreground or need_foreground):
         print('Forking to background (see system tray).')
         if os.fork():
             sys.exit()

--- a/vorta.spec
+++ b/vorta.spec
@@ -1,27 +1,37 @@
 # -*- mode: python -*-
 
-block_cipher = None
+import os
+
+CREATE_VORTA_DIR = False  # create dist/vorta-dir/ output?
+BLOCK_CIPHER = None
+
+# it is assumed that the cwd is the git repo dir:
+REPO_DIR = os.path.abspath('.')
+SRC_DIR = os.path.join(REPO_DIR, 'src')
+
 
 a = Analysis(['src/vorta/__main__.py'],
-             pathex=['/Users/manu/Workspace/vorta/src'],
+             pathex=[SRC_DIR],
              binaries=[
-                ('bin/macosx64/borg', 'bin'),
+                ('bin/borg', 'bin'),  # (<borg fat binary for this platform>, <dest. folder>)
              ],
              datas=[
                 ('src/vorta/assets/UI/*', 'assets/UI'),
                 ('src/vorta/assets/icons/*', 'assets/icons'),
              ],
-             hiddenimports=['vorta.views.collection_rc',
+             hiddenimports=[
+                 'vorta.views.collection_rc',
              ],
              hookspath=[],
              runtime_hooks=[],
              excludes=[],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
-             cipher=block_cipher,
+             cipher=BLOCK_CIPHER,
              noarchive=False)
-pyz = PYZ(a.pure, a.zipped_data,
-             cipher=block_cipher)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=BLOCK_CIPHER)
+
 exe = EXE(pyz,
           a.scripts,
           a.binaries,
@@ -34,22 +44,22 @@ exe = EXE(pyz,
           strip=False,
           upx=True,
           runtime_tmpdir=None,
-          console=True )
+          console=True)
 
 app = BUNDLE(exe,
              name='Vorta.app',
              icon='src/vorta/assets/icons/app-icon.icns',
              bundle_identifier='com.borgbase.client.macos',
              info_plist={
-                     'NSHighResolutionCapable': 'True',
-                     'LSUIElement': '1',
-                     'CFBundleShortVersionString': '0.6.4',
-                     'CFBundleVersion': '0.6.4',
-                     'NSAppleEventsUsageDescription': 'Please allow',
-                     'SUFeedURL': 'https://borgbase.github.io/vorta/appcast.xml'
-                     },
-             )
-if False:
+                 'NSHighResolutionCapable': 'True',
+                 'LSUIElement': '1',
+                 'CFBundleShortVersionString': '0.6.4',
+                 'CFBundleVersion': '0.6.4',
+                 'NSAppleEventsUsageDescription': 'Please allow',
+                 'SUFeedURL': 'https://borgbase.github.io/vorta/appcast.xml',
+             })
+
+if CREATE_VORTA_DIR:
     coll = COLLECT(exe,
                    a.binaries,
                    a.zipfiles,


### PR DESCRIPTION
- cwd must be the repo dir, `__FILE__` is not available here
- the borg binary for the platform must be in bin/borg (no matter
  whether we build for Linux or macOS or ...)
- moved some settings to top of the file
- whitespace clean up

fixes #76.