### PR TITLE
do not fork into background with any fat binary

### DIFF
--- a/src/vorta/__main__.py
+++ b/src/vorta/__main__.py
@@ -15,9 +15,10 @@ def main():
     args = parse_args()
 
     frozen_binary = getattr(sys, 'frozen', False)
-    need_foreground = frozen_binary and sys.platform in ('darwin', 'linux')
     want_foreground = getattr(args, 'foreground', False)
-    if not (want_foreground or need_foreground):
+    # We assume that a frozen binary is a fat single-file binary made with
+    # PyInstaller. These are not compatible with forking into background here:
+    if not (want_foreground or frozen_binary):
         print('Forking to background (see system tray).')
         if os.fork():
             sys.exit()


### PR DESCRIPTION
this avoids that someone e.g. porting to freebsd (which is also
supported by PyInstaller) will stumble over the platform check.

likely this is a very general problem with the fat binaries:

i suspect it is due to the pyinstaller bootloader / wrapper
cleaning up the temporary directory _MEIxxxxx where it extracted
all the needed files after the main process terminates (sys.exit()),
being unaware that we have just generated a background process also
relying on these files.

for the linux case, this led to some strange exception from pytz
that the current timezone is not supported (likely because it failed
to load some pytz tz definition file which was already gone).