### PR TITLE
Fix umount

### DIFF
--- a/src/vorta/borg/umount.py
+++ b/src/vorta/borg/umount.py
@@ -1,3 +1,4 @@
+import os.path
 import psutil
 from .borg_thread import BorgThread
 
@@ -19,7 +20,7 @@ class BorgUmountThread(BorgThread):
         partitions = psutil.disk_partitions(all=True)
         for p in partitions:
             if p.device == 'borgfs':
-                ret['active_mount_points'].append(p.mountpoint)
+                ret['active_mount_points'].append(os.path.normpath(p.mountpoint))
 
         if len(ret['active_mount_points']) == 0:
             ret['message'] = 'No active Borg mounts found.'

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -1,3 +1,4 @@
+import os.path
 import sys
 from datetime import timedelta
 from PyQt5 import uic, QtCore
@@ -221,7 +222,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                 self._set_status(params['message'])
                 return
 
-            if self.mount_point in params['active_mount_points']:
+            if os.path.normpath(self.mount_point) in params['active_mount_points']:
                 params['cmd'].append(self.mount_point)
                 thread = BorgUmountThread(params['cmd'], params, parent=self)
                 thread.updated.connect(self.mountErrors.setText)

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -201,7 +201,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                     thread.result.connect(self.mount_result)
                     thread.start()
 
-        dialog = choose_file_dialog(self, "Choose Mount Point")
+        dialog = choose_file_dialog(self, "Choose Mount Point", want_folder=True)
         dialog.open(receive)
 
     def mount_result(self, result):
@@ -298,7 +298,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                         else:
                             self._set_status(params['message'])
 
-                dialog = choose_file_dialog(self, "Choose Extraction Point")
+                dialog = choose_file_dialog(self, "Choose Extraction Point", want_folder=True)
                 dialog.open(receive)
 
     def extract_archive_result(self, result):


### PR DESCRIPTION
unmounting an archive didn't work for me because a directory like '/foo/' is compared to the items in the list of mounted directories, which contained '/foo' . This PR fixes this problem by normalizing the paths before comparison.

Also, use the wants_folder parameter when asking the user for a mount point or an extraction point
