### PR TITLE
 Improvements to the archive tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 .DS_Store
 .idea/
+bin/
 build/
 dist/
 docs/
 *.autosave
-bin/macosx64/Sparkle.framework
-bin/macosx64/borg
 __pycache__
 .eggs
 vorta.egg-info

--- a/.tx/config
+++ b/.tx/config
@@ -3,7 +3,7 @@ host = https://www.transifex.com
 
 [vorta.vorta]
 file_filter = src/vorta/i18n/ts/vorta.<lang>.ts
-minimum_perc = 0
+minimum_perc = 90
 source_file = src/vorta/i18n/ts/vorta.en_US.ts
 source_lang = en_US
 type = QT

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
 graft src/vorta/assets
+
+# Include all compiled .qm language files, but exclude the source language – en_US.
+recursive-include src/vorta/i18n/qm *.qm
+exclude src/vorta/i18n/qm/vorta.en_US.qm
+
 recursive-exclude tests *

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export QT_SELECT=5
 .PHONY : help
 .DEFAULT_GOAL := help
 
-Vorta.app:
+Vorta.app: translations-to-qm
 	#pyrcc5 -o src/vorta/views/collection_rc.py src/vorta/assets/icons/collection.qrc
 	pyinstaller --clean --noconfirm vorta.spec
 	cp -R bin/macosx64/Sparkle.framework dist/Vorta.app/Contents/Frameworks/
@@ -22,7 +22,7 @@ github-release: Vorta.dmg
 	git push upstream gh-pages
 	git checkout master
 
-pypi-release:
+pypi-release: translations-to-qm
 	python setup.py sdist
 	twine upload dist/vorta-0.6.5.tar.gz
 

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@ from setuptools import setup, find_packages
 setup(
     include_package_data=True,
     packages=find_packages('src'),
-    package_dir={'': 'src'}
+    package_dir={'': 'src'},
+    package_data={'vorta.i18n': ['qm/*.qm']}
 )

--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -94,6 +94,11 @@ font-weight: bold;
          </column>
          <column>
           <property name="text">
+           <string></string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
            <string>Name</string>
           </property>
          </column>

--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -94,7 +94,7 @@ font-weight: bold;
          </column>
          <column>
           <property name="text">
-           <string></string>
+           <string>Mounted</string>
           </property>
          </column>
          <column>

--- a/src/vorta/assets/UI/repotab.ui
+++ b/src/vorta/assets/UI/repotab.ui
@@ -23,30 +23,99 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QFormLayout" name="formLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetNoConstraint</enum>
+     </property>
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+     </property>
+     <property name="rowWrapPolicy">
+      <enum>QFormLayout::DontWrapRows</enum>
+     </property>
+     <property name="labelAlignment">
+      <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+     </property>
      <property name="topMargin">
       <number>0</number>
      </property>
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_14">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">margin-top: 4;</string>
+       </property>
        <property name="text">
-        <string>SSH Key:</string>
+        <string>Repository:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>0</number>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="topMargin">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
         <number>0</number>
        </property>
-       <property name="bottomMargin">
-        <number>0</number>
+       <property name="horizontalSpacing">
+        <number>-1</number>
        </property>
-       <item>
+       <property name="verticalSpacing">
+        <number>1</number>
+       </property>
+       <item row="1" column="1">
+        <widget class="QLabel" name="label_5">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remote or local backup repository. For simple and secure backup hosting, try &lt;a href=&quot;https://www.borgbase.com/?utm_source=vorta&amp;amp;utm_medium=app&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;BorgBase&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="margin">
+          <number>0</number>
+         </property>
+         <property name="indent">
+          <number>5</number>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
         <widget class="QComboBox" name="repoSelector">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -64,7 +133,7 @@
          </item>
         </widget>
        </item>
-       <item>
+       <item row="0" column="2">
         <widget class="QToolButton" name="repoRemoveToolbutton">
          <property name="toolTip">
           <string>Unlink Repository (This doesn't delete any data. You can always add a repo again later.)</string>
@@ -83,97 +152,37 @@
        </item>
       </layout>
      </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="label_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-        </font>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
        </property>
        <property name="styleSheet">
-        <string notr="true">margin-bottom: 10;
-margin-left: 5</string>
+        <string notr="true">margin-top: 4;</string>
        </property>
        <property name="text">
-        <string>To securely access remote repositories. Keep default to use all your existing keys. Or create new key.</string>
+        <string>SSH Key:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>0</number>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLabel" name="label_5">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-        </font>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">margin-bottom: 10;
-margin-left: 5</string>
-       </property>
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remote or local backup repository. For simple and secure backup hosting, try &lt;a href=&quot;https://www.borgbase.com/?utm_source=vorta&amp;amp;utm_medium=app&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;BorgBase&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="margin">
+      <layout class="QGridLayout" name="gridLayout_4">
+       <property name="verticalSpacing">
         <number>0</number>
        </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Compression:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QComboBox" name="sshComboBox"/>
-       </item>
-       <item>
+       <item row="0" column="2">
         <widget class="QToolButton" name="sshKeyToClipboardButton">
          <property name="toolTip">
           <string>Copy public SSH key to clipboard.</string>
@@ -196,54 +205,58 @@ margin-left: 5</string>
          </property>
         </widget>
        </item>
-      </layout>
-     </item>
-     <item row="1" column="0">
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="4" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QComboBox" name="repoCompression"/>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="sshComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>To securely access remote repositories. Keep default to use all your existing keys. Or create new key.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="indent">
+          <number>5</number>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Repository:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="label_4">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-        </font>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
        </property>
        <property name="styleSheet">
-        <string notr="true">margin-bottom: 10;
-margin-left: 5</string>
+        <string notr="true">margin-top: 4;</string>
        </property>
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Compression used for new data. Can be changed and doesn't affect deduplication. Read &lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-compression&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;more&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Compression:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -251,7 +264,57 @@ margin-left: 5</string>
        <property name="wordWrap">
         <bool>true</bool>
        </property>
+       <property name="indent">
+        <number>0</number>
+       </property>
       </widget>
+     </item>
+     <item row="2" column="1">
+      <layout class="QGridLayout" name="gridLayout_5">
+       <property name="verticalSpacing">
+        <number>0</number>
+       </property>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="repoCompression">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Compression used for new data. Can be changed and doesn't affect deduplication. Read &lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-compression&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;more&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="indent">
+          <number>5</number>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/src/vorta/borg/umount.py
+++ b/src/vorta/borg/umount.py
@@ -1,3 +1,4 @@
+import os.path
 import psutil
 from .borg_thread import BorgThread
 from ..i18n import trans_late
@@ -20,7 +21,7 @@ class BorgUmountThread(BorgThread):
         partitions = psutil.disk_partitions(all=True)
         for p in partitions:
             if p.device == 'borgfs':
-                ret['active_mount_points'].append(p.mountpoint)
+                ret['active_mount_points'].append(os.path.normpath(p.mountpoint))
 
         if len(ret['active_mount_points']) == 0:
             ret['message'] = trans_late('messages', 'No active Borg mounts found.')

--- a/src/vorta/i18n/ts/vorta.de.ts
+++ b/src/vorta/i18n/ts/vorta.de.ts
@@ -1,0 +1,1190 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.0">
+<context>
+    <name>AddProfileWindow</name>
+    <message>
+        <location filename="../../views/profile_add_edit_dialog.py" line="22"/>
+        <source>Rename Profile</source>
+        <translation>Profil umbenennen</translation>
+    </message>
+    <message>
+        <location filename="../../views/profile_add_edit_dialog.py" line="39"/>
+        <source>Please enter a profile name.</source>
+        <translation>Bitte einen Profilnamen eingeben.</translation>
+    </message>
+    <message>
+        <location filename="../../views/profile_add_edit_dialog.py" line="45"/>
+        <source>A profile with this name already exists.</source>
+        <translation>Ein Profil mit diesem Namen existiert bereits.</translation>
+    </message>
+</context>
+<context>
+    <name>AddRepoWindow</name>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="46"/>
+        <source>Repository Path:</source>
+        <translation>Repository-Pfad:</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="49"/>
+        <source>Choose Location of Borg Repository</source>
+        <translation>Wähle den Speicherort des Borg-Repositories</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="56"/>
+        <source>Repository URL:</source>
+        <translation>Repository-URL:</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="82"/>
+        <source>Unable to add your repository.</source>
+        <translation>Kann dieses Repository nicht hinzufügen.</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="85"/>
+        <source>Repokey-Blake2 (Recommended, key stored in repository)</source>
+        <translation>Repokey-Blake2 (empfohlen, Schlüssel wird im Repository gespeichert)</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="87"/>
+        <source>Repokey</source>
+        <translation>Repokey</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="89"/>
+        <source>Keyfile-Blake2 (Key stored in home directory)</source>
+        <translation>Keyfile-Blake2 (Schlüssel wird im Home-Verzeichnis gespeichert)</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="91"/>
+        <source>Keyfile</source>
+        <translation>Keyfile</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="93"/>
+        <source>None (not recommended)</source>
+        <translation>Keine (nicht empfohlen)</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="104"/>
+        <source>Please enter a valid repo URL or select a local path.</source>
+        <translation>Bitte eine gültige Repo-URL eingeben oder einen lokalen Pfad auswählen.</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="110"/>
+        <source>Please use a longer password.</source>
+        <translation>Bitte längeres Passwort benutzen.</translation>
+    </message>
+</context>
+<context>
+    <name>AddRepository</name>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="14"/>
+        <source>Dialog</source>
+        <translation>Dialog</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="29"/>
+        <source>Initialize New Backup Repository</source>
+        <translation>Initialisiere Neues Backup-Repository</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="53"/>
+        <source>Repository URL:</source>
+        <translation>Repository-URL:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="68"/>
+        <source>csvis8xq@csvis8xq.repo.borgbase.com:repo</source>
+        <translation>csvis8xq@csvis8xq.repo.borgbase.com:repo</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="75"/>
+        <source>Choose a local path as repository.</source>
+        <translation>Wähle einen lokalen Pfad als Repository.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="89"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="102"/>
+        <source>Encryption:</source>
+        <translation>Verschlüsselung:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="119"/>
+        <source>Password</source>
+        <translation>Passwort</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="136"/>
+        <source>SSH Key:</source>
+        <translation>SSH-Schlüssel:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="150"/>
+        <source>Automatically choose SSH Key (default)</source>
+        <translation>SSH-Schlüssel automatisch auswählen (Standardeinstellung)</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="196"/>
+        <source>Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repoadd.ui" line="203"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+</context>
+<context>
+    <name>ArchiveTab</name>
+    <message>
+        <location filename="../../views/archive_tab.py" line="81"/>
+        <source>Archives for %s</source>
+        <translation>Archive für %s</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="103"/>
+        <source>Archives</source>
+        <translation>Archive</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="112"/>
+        <source>Preview: %s</source>
+        <translation>Vorschau: %s</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="116"/>
+        <source>Error in archive name template.</source>
+        <translation>Fehler in der Archiv-Namens-Vorlage.</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="158"/>
+        <source>Pruning finished.</source>
+        <translation>Ausdünnen beendet.</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="175"/>
+        <source>Refreshed archives.</source>
+        <translation>Archive aufgefrischt.</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="205"/>
+        <source>Choose Mount Point</source>
+        <translation>Einhängepunkt auswählen</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="211"/>
+        <source>Mounted successfully.</source>
+        <translation>Erfolgreich eingehängt.</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="212"/>
+        <source>Unmount</source>
+        <translation>Unmount</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="233"/>
+        <source>Mount point not active. Try restarting Vorta.</source>
+        <translation>Einhängepunkt nicht aktiv. Versuche, Vortra neu zu starten.</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="239"/>
+        <source>Un-mounted successfully.</source>
+        <translation>Erfolgreich ausgehängt.</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="240"/>
+        <source>Mount</source>
+        <translation>Einhängen</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="275"/>
+        <source>Select an archive to restore first.</source>
+        <translation>Zuerst ein Archiv zum Wiederherstellen auswählen.</translation>
+    </message>
+    <message>
+        <location filename="../../views/archive_tab.py" line="302"/>
+        <source>Choose Extraction Point</source>
+        <translation>Extrahierungs-Punkt auswählen</translation>
+    </message>
+</context>
+<context>
+    <name>BorgCheckThread</name>
+    <message>
+        <location filename="../../borg/check.py" line="11"/>
+        <source>Starting consistency check..</source>
+        <translation>Starte Konsistenz-Prüfung..</translation>
+    </message>
+</context>
+<context>
+    <name>BorgCreateThread</name>
+    <message>
+        <location filename="../../borg/create.py" line="35"/>
+        <source>Backup finished.</source>
+        <translation>Datensicherung beendet.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/create.py" line="42"/>
+        <source>Backup started.</source>
+        <translation>Datensicherung gestartet.</translation>
+    </message>
+</context>
+<context>
+    <name>BorgExtractThread</name>
+    <message>
+        <location filename="../../borg/extract.py" line="11"/>
+        <source>Downloading files from archive..</source>
+        <translation>Lade Dateien aus dem Archiv herunter..</translation>
+    </message>
+    <message>
+        <location filename="../../borg/extract.py" line="16"/>
+        <source>Restored files from archive.</source>
+        <translation>Dateien aus Archiv wieder hergestellt.</translation>
+    </message>
+</context>
+<context>
+    <name>BorgInfoThread</name>
+    <message>
+        <location filename="../../borg/info.py" line="13"/>
+        <source>Validating existing repo...</source>
+        <translation>Validiere existierendes Repo...</translation>
+    </message>
+</context>
+<context>
+    <name>BorgInitThread</name>
+    <message>
+        <location filename="../../borg/init.py" line="10"/>
+        <source>Setting up new repo...</source>
+        <translation>Setze neues Repo auf...</translation>
+    </message>
+</context>
+<context>
+    <name>BorgListArchiveThread</name>
+    <message>
+        <location filename="../../borg/list_archive.py" line="11"/>
+        <source>Getting archive content..</source>
+        <translation>Hole Archiv-Inhalt..</translation>
+    </message>
+    <message>
+        <location filename="../../borg/list_archive.py" line="15"/>
+        <source>Done getting archive content.</source>
+        <translation>Archiv-Inhalt holen erledigt.</translation>
+    </message>
+</context>
+<context>
+    <name>BorgListRepoThread</name>
+    <message>
+        <location filename="../../borg/list_repo.py" line="13"/>
+        <source>Refreshing archives...</source>
+        <translation>Frische Archive auf...</translation>
+    </message>
+    <message>
+        <location filename="../../borg/list_repo.py" line="18"/>
+        <source>Refreshing archives done.</source>
+        <translation>Auffrischen der Archive erledigt.</translation>
+    </message>
+</context>
+<context>
+    <name>BorgMountThread</name>
+    <message>
+        <location filename="../../borg/mount.py" line="7"/>
+        <source>Mounting archive into folder...</source>
+        <translation>Hänge Archiv in Ordner ein...</translation>
+    </message>
+</context>
+<context>
+    <name>BorgPruneThread</name>
+    <message>
+        <location filename="../../borg/prune.py" line="12"/>
+        <source>Pruning old archives...</source>
+        <translation>Dünne alte Archive aus...</translation>
+    </message>
+    <message>
+        <location filename="../../borg/prune.py" line="17"/>
+        <source>Pruning done.</source>
+        <translation>Ausdünnen erledigt.</translation>
+    </message>
+</context>
+<context>
+    <name>BorgThread</name>
+    <message>
+        <location filename="../../borg/borg_thread.py" line="221"/>
+        <source>Task started</source>
+        <translation>Aufgabe gestartet</translation>
+    </message>
+</context>
+<context>
+    <name>BorgUmountThread</name>
+    <message>
+        <location filename="../../borg/umount.py" line="9"/>
+        <source>Unmounting archive...</source>
+        <translation>Hänge Archiv aus...</translation>
+    </message>
+</context>
+<context>
+    <name>Dialog</name>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="14"/>
+        <source>Dialog</source>
+        <translation>Dialog</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/extractdialog.ui" line="25"/>
+        <source>Archive:</source>
+        <translation>Archiv:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/extractdialog.ui" line="38"/>
+        <source>nyx2.local-2018-11-16T09:49:58 from November 16, 2018</source>
+        <translation>nyx2.local-2018-11-16T09:49:58 from November 16, 2018</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/extractdialog.ui" line="63"/>
+        <source>Note: If you select a top-level folder and deselect its children, they will still be restored.</source>
+        <translation>Bitte beachten: Wenn Sie einen Ordner auf oberster Ebene selektieren und alle Elemente darunter deselektieren, werden sie trotzdem wieder hergestellt.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/extractdialog.ui" line="88"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/extractdialog.ui" line="95"/>
+        <source>Extract</source>
+        <translation>Extrahieren</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/profileadd.ui" line="38"/>
+        <source>Add Backup Profile</source>
+        <translation>Backup-Profil hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/profileadd.ui" line="87"/>
+        <source>Profile Name</source>
+        <translation>Profil-Name</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="46"/>
+        <source>Generate SSH Key</source>
+        <translation>SSH-Schlüssel erzeugen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="58"/>
+        <source>Key Format:</source>
+        <translation>Schlüssel-Format:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="75"/>
+        <source>Key Length:</source>
+        <translation>Schlüssel-Länge:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="97"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;2048 or 4096 for RSA, 384 or 521 for ECDSA. Fixed for Ed25519. &lt;a href=&quot;https://stribika.github.io/2015/01/04/secure-secure-shell.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;More&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;2048 oder 4096 für RSA, 384 oder 521 für ECDSA. Fest für Ed25519. &lt;a href=&quot;https://stribika.github.io/2015/01/04/secure-secure-shell.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Mehr&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="110"/>
+        <source>Output File:</source>
+        <translation>Ausgabe-Datei:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="122"/>
+        <source>Don&apos;t change this if you want SSH to automatically find the key.</source>
+        <translation>Dies nicht ändern, wenn Sie wollen, daß SSH automatisch den Key findet.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="131"/>
+        <source>Close</source>
+        <translation>Schließen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sshadd.ui" line="144"/>
+        <source>Generate and copy to Clipboard</source>
+        <translation>Erzeugen und auf Zwischenablage kopieren</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/profileadd.ui" line="59"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Backup profiles allow for granular backups from different sources to different destinations. You could e.g. back up essential documents to a remote repository via Wifi, while doing a full backup onto a local storage device.&lt;/p&gt;&lt;p&gt;Repositories and SSH keys are shared between profiles. Source folders, active destination repo, allowed networks, pruning, validation and scheduling are per-profile.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Datensicherungs-Profile erlauben granuläre Datensicherungen von verschiedenen Quellen zu verschiedenen Zielen. Sie könnten z.B. wichtige Dokumente in ein entferntes Repository über WLAN sichern und eine volle Datensicherung auf ein lokales Speichermedium machen.&lt;/p&gt;&lt;p&gt;Repositories und SSH-Schlüssel werden zwischen Profilen geteilt. Quell-Ordner, aktives Ziel-Repo, erlaubte Netzwerke, Ausdünnen, Validierung und Planung sind pro Profil.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>ExistingRepoWindow</name>
+    <message>
+        <location filename="../../views/repo_add_dialog.py" line="121"/>
+        <source>Connect to existing Repository</source>
+        <translation>Mit existierendem Repository verbinden</translation>
+    </message>
+</context>
+<context>
+    <name>Form</name>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="54"/>
+        <source>Archives</source>
+        <translation>Archive</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="82"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="87"/>
+        <source>Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="92"/>
+        <source>Duration</source>
+        <translation>Dauer</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="97"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="110"/>
+        <source>Extract</source>
+        <translation>Extrahieren</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="127"/>
+        <source>Mount</source>
+        <translation>Einhängen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="138"/>
+        <source>Check</source>
+        <translation>Prüfen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="162"/>
+        <source>Prune</source>
+        <translation>Ausdünnen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="182"/>
+        <source>Refresh</source>
+        <translation>Auffrischen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="203"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To mount archives, first install &amp;quot;FUSE for macOS&amp;quot; from &lt;a href=&quot;https://osxfuse.github.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Um Archive einzuhängen, installieren Sie zu erst &amp;quot;FUSE for macOS&amp;quot; von &lt;a href=&quot;https://osxfuse.github.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;hier&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="226"/>
+        <source>Prune Options and Archive Naming</source>
+        <translation>Ausdünnungs-Optionen und Archiv-Namensgebung</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="232"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pruning removes older archives. You can choose the number of hourly, daily, etc. archives to preserve. Usually you will keep more newer and fewer old archives. Read &lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/prune.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;more&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ausdünnen entfernt ältere Archive. Sie können die Anzahl der stündlichen, täglichen, etc. Archive wählen, die Sie behalten möchten. Üblicherweise werden Sie mehr neue und weniger alte Archive behalten. &lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/prune.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Mehr&lt;/span&gt;&lt;/a&gt; lesen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="253"/>
+        <source>Keep</source>
+        <translation>Behalte</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="277"/>
+        <source>Use -1 for unlimited.</source>
+        <translation>Benutze -1 für nicht begrenzt.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="270"/>
+        <source> hourly, </source>
+        <translation>stündliche,</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="287"/>
+        <source> daily, </source>
+        <translation>tägliche,</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="301"/>
+        <source> weekly, </source>
+        <translation>wöchentliche,</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="315"/>
+        <source> monthly and</source>
+        <translation>monatliche und</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="329"/>
+        <source> annual archives.</source>
+        <translation>jährliche Archive.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="356"/>
+        <source>No matter what, keep all archives of the last:</source>
+        <translation>Außerdem, behalte alle Archive der letzten:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="366"/>
+        <source>24H, 1d, 52w, 12m, 1y</source>
+        <translation>24H, 1d, 52w, 12m, 1y</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="406"/>
+        <source>Archive Name:</source>
+        <translation>Archiv-Name:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="450"/>
+        <source>Available variables: hostname, profile_id, profile_slug, now, utc_now, user</source>
+        <translation>Verfügbare Variablen: hostname, profile_id, profile_slug, now, utc_now, user</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="416"/>
+        <source>{hostname}-{profile_slug}-</source>
+        <translation>{hostname}-{profile_slug}-</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="475"/>
+        <source>TextLabel</source>
+        <translation>TextLabel</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="453"/>
+        <source>{hostname}-{profile_slug}-{now:%Y-%m-%dT%H:%M:%S}</source>
+        <translation>{hostname}-{profile_slug}-{now:%Y-%m-%dT%H:%M:%S}</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/archivetab.ui" line="460"/>
+        <source>Prune Prefix:</source>
+        <translation>Ausdünnungs-Präfix:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/misctab.ui" line="55"/>
+        <source>Version:</source>
+        <translation>Version:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/misctab.ui" line="62"/>
+        <source>0.0</source>
+        <translation>0.0</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/misctab.ui" line="72"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(&lt;a href=&quot;https://github.com/borgbase/vorta/issues/new/choose&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Report&lt;/span&gt;&lt;/a&gt; a Bug)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(&lt;a href=&quot;https://github.com/borgbase/vorta/issues/new/choose&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Melden&lt;/span&gt;&lt;/a&gt; eines Fehlers)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="37"/>
+        <source>SSH Key:</source>
+        <translation>SSH-Schlüssel:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="62"/>
+        <source>Select Backup Destination</source>
+        <translation>Wähle Datensicherungs-Ziel</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="70"/>
+        <source>Unlink Repository (This doesn&apos;t delete any data. You can always add a repo again later.)</source>
+        <translation>Repository abkoppeln (Dies löscht keinerlei Daten. Sie können jederzeit ein Repo später wieder hinzufügen.)</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="73"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="104"/>
+        <source>To securely access remote repositories. Keep default to use all your existing keys. Or create new key.</source>
+        <translation>Um sicher auf entfernte Repositories zuzugreifen. Behalte die Standardeinstellung, um alle Ihre existierenden Schlüssel zu verwenden. Oder erzeuge neuen Schlüssel.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="132"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remote or local backup repository. For simple and secure backup hosting, try &lt;a href=&quot;https://www.borgbase.com/?utm_source=vorta&amp;amp;utm_medium=app&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;BorgBase&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entferntes oder lokales Datensicherungs-Repository. Probieren Sie &lt;a href=&quot;https://www.borgbase.com/?utm_source=vorta&amp;amp;utm_medium=app&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;BorgBase&lt;/span&gt;&lt;/a&gt; für einfaches und sicheres Hosting von Datensicherungen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="164"/>
+        <source>Compression:</source>
+        <translation>Kompression:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="179"/>
+        <source>Copy public SSH key to clipboard.</source>
+        <translation>Kopiere öffentlichen SSH-Schlüssel auf Zwischenablage.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="185"/>
+        <source>Copy</source>
+        <translation>Kopieren</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="224"/>
+        <source>Repository:</source>
+        <translation>Repository:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="246"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Compression used for new data. Can be changed and doesn&apos;t affect deduplication. Read &lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-compression&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;more&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kompression, die für neue Daten benutzt wird. Kann geändert werden und beeinflusst nicht die Deduplikation. Lesen Sie &lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-compression&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;mehr&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="294"/>
+        <source>Encryption:</source>
+        <translation>Verschlüsselung:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="334"/>
+        <source>Original Size:</source>
+        <translation>Ursprüngliche Größe:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="348"/>
+        <source>Deduplicated Size:</source>
+        <translation>Deduplizierte Größe:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/repotab.ui" line="355"/>
+        <source>Compressed Size:</source>
+        <translation>Komprimierte Größe:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="57"/>
+        <source>Schedule</source>
+        <translation>Planung</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="80"/>
+        <source>Backup manually.</source>
+        <translation>Manuell sichern</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="97"/>
+        <source>Backup every </source>
+        <translation>Sichern alle</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="120"/>
+        <source>hours at</source>
+        <translation>Stunden, um</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="140"/>
+        <source>minutes past the hour.</source>
+        <translation>Minuten nach der vollen Stunde.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="164"/>
+        <source>Backup daily at</source>
+        <translation>Täglich sichern um</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="194"/>
+        <source>Validate repository data every</source>
+        <translation>Repository validieren alle</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="220"/>
+        <source>weeks.</source>
+        <translation>Wochen.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="247"/>
+        <source>Prune old Archives after each backup.</source>
+        <translation>Alte Archive nach jedem Backup ausdünnen.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="287"/>
+        <source>Apply</source>
+        <translation>Anwenden</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="316"/>
+        <source>Next Backup:</source>
+        <translation>Nächstes Backup:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="323"/>
+        <source>Off</source>
+        <translation>Aus</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="371"/>
+        <source>Networks</source>
+        <translation>Netzwerke</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="380"/>
+        <source>Allowed Networks:</source>
+        <translation>Erlaubte Netzwerke:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="400"/>
+        <source>Log</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="421"/>
+        <source>Time</source>
+        <translation>Zeit</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="426"/>
+        <source>Category</source>
+        <translation>Kategorie</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="431"/>
+        <source>Subcommand</source>
+        <translation>Unter-Kommando</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="436"/>
+        <source>Repository</source>
+        <translation>Repository</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="441"/>
+        <source>Returncode</source>
+        <translation>Returncode</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="462"/>
+        <source>Shell Commands</source>
+        <translation>Shell-Kommandos</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="468"/>
+        <source>Run custom shell commands before and after each backup. The actual backup and post-backup command will only run, if the pre-backup command exits without error (return code 0).</source>
+        <translation>Kundenspezifische Shell-Kommandos vor und nach jeder Datensicherung ausführen. Das backup- und post-backup-Kommando wird nur ausgeführt, wenn das pre-backup-Kommando sich ohne Fehler beendet hat (rc 0).</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="487"/>
+        <source>Pre-backup command to run BEFORE backups.</source>
+        <translation>pre-backup-Kommando, das VOR den Datensicherungen ausgeführt wird.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="497"/>
+        <source>Post-backup command to run AFTER backups.</source>
+        <translation>post-backup-Kommando, das NACH den Datensicherungen ausgeführt wird.</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/scheduletab.ui" line="509"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Available env variables: &lt;span style=&quot; font-family:&apos;Courier&apos;;&quot;&gt;$repo_url, $profile_name, $profile_slug, $returncode&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verfügbare Umgebungs-Variablen: &lt;span style=&quot; font-family:&apos;Courier&apos;;&quot;&gt;$repo_url, $profile_name, $profile_slug, $returncode&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="20"/>
+        <source>Source folders and files to back up</source>
+        <translation>Zu sichernde Quell-Ordner und -Dateien</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="47"/>
+        <source>Add Folder</source>
+        <translation>Ordner hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="54"/>
+        <source>Add File</source>
+        <translation>Datei hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="61"/>
+        <source>Remove</source>
+        <translation>Entfernen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="77"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exclude Patterns (&lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-patterns&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;more&lt;/span&gt;&lt;/a&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ausschluss-Muster (&lt;a href=&quot;https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-patterns&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;mehr&lt;/span&gt;&lt;/a&gt;)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="87"/>
+        <source>Exclude If Present (exclude folders with these files)</source>
+        <translation>Ausschließen, Wenn Vorhanden (schließe Ordner mit diesen Dateien aus)</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="103"/>
+        <source>**/.DS_Store</source>
+        <translation>**/.DS_Store</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/sourcetab.ui" line="116"/>
+        <source>.nobackup</source>
+        <translation>.nobackup</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../views/main_window.py" line="54"/>
+        <source>+ Add New Profile</source>
+        <translation>+ Neues Profil hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../../views/main_window.py" line="75"/>
+        <source>Backup in progress.</source>
+        <translation>Backup läuft</translation>
+    </message>
+    <message>
+        <location filename="../../views/main_window.py" line="143"/>
+        <source>Task cancelled</source>
+        <translation>Aufgabe abgebrochen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="20"/>
+        <source>MainWindow</source>
+        <translation>MainWindow</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="51"/>
+        <source>Current Profile:</source>
+        <translation>Aktuelles Profil:</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="82"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="124"/>
+        <source>Repository</source>
+        <translation>Repository</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="129"/>
+        <source>Sources</source>
+        <translation>Quellen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="134"/>
+        <source>Schedule</source>
+        <translation>Zeitplan</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="139"/>
+        <source>Archives</source>
+        <translation>Archive</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="144"/>
+        <source>Misc</source>
+        <translation>Diverses</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="195"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="258"/>
+        <source>Start Backup</source>
+        <translation>Datensicherung starten</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="272"/>
+        <source>Latest</source>
+        <translation>Neuestes</translation>
+    </message>
+    <message>
+        <location filename="../../assets/UI/mainwindow.ui" line="277"/>
+        <source>Reset App</source>
+        <translation>App zurücksetzen</translation>
+    </message>
+</context>
+<context>
+    <name>RepoTab</name>
+    <message>
+        <location filename="../../views/repo_tab.py" line="24"/>
+        <source>+ Initialize New Repository</source>
+        <translation>Neues Repository initialisieren</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="25"/>
+        <source>+ Add Existing Repository</source>
+        <translation>Existierendes Repository hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="33"/>
+        <source>LZ4 (default)</source>
+        <translation>LZ4 (Standardeinstellung)</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="34"/>
+        <source>Zstandard (medium)</source>
+        <translation>Zstandard (mittel)</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="35"/>
+        <source>LZMA (high)</source>
+        <translation>LZMA (hoch)</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="36"/>
+        <source>No Compression</source>
+        <translation>Keine Kompression</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="74"/>
+        <source>Automatically choose SSH Key (default)</source>
+        <translation>SSH-Schlüssel automatisch auswählen (Standardeinstellung)</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="75"/>
+        <source>Create New Key</source>
+        <translation>Neuen Schlüssel erzeugen</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="107"/>
+        <source>Public Key Copied to Clipboard</source>
+        <translation>Öffentlicher Schlüssel auf Zwischenablage kopiert</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="108"/>
+        <source>The selected public SSH key was copied to the clipboard. Use it to set up remote repo permissions.</source>
+        <translation>Der ausgewählte öffentliche SSH-Schlüssel wurde auf die Zwischenablage kopiert. Benutze dies, um die Zugriffsrechte des fernen Repositories einzurichten.</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="113"/>
+        <source>Couldn&apos;t find public key.</source>
+        <translation>Konnte öffentlichen Schlüssel nicht finden.</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="115"/>
+        <source>Select a public key from the dropdown first.</source>
+        <translation>Wähle zuerst einen öffentlichen Schlüssel aus der Liste aus.</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="172"/>
+        <source>Repository was Unlinked</source>
+        <translation>Repository-Verbindung wurde gelöst</translation>
+    </message>
+    <message>
+        <location filename="../../views/repo_tab.py" line="173"/>
+        <source>You can always connect it again later.</source>
+        <translation>Sie können es jederzeit später wieder verbinden.</translation>
+    </message>
+</context>
+<context>
+    <name>SSHAddWindow</name>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="34"/>
+        <source>ED25519 (Recommended)</source>
+        <translation>ED25519 (Empfohlen)</translation>
+    </message>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="35"/>
+        <source>RSA (Legacy)</source>
+        <translation>RSA (alt)</translation>
+    </message>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="36"/>
+        <source>ECDSA</source>
+        <translation>ECDSA</translation>
+    </message>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="45"/>
+        <source>High (Recommended)</source>
+        <translation>Hoch (Empfohlen)</translation>
+    </message>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="46"/>
+        <source>Medium</source>
+        <translation>Mittel</translation>
+    </message>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="59"/>
+        <source>Key file already exists. Not overwriting.</source>
+        <translation>Schlüssel-Datei existiert bereits, überschreibe nicht.</translation>
+    </message>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="71"/>
+        <source>New key was copied to clipboard and written to %s.</source>
+        <translation>Neuer Schlüssel wurde auf die Zwischenablage kopiert und geschrieben nach %s.</translation>
+    </message>
+    <message>
+        <location filename="../../views/ssh_dialog.py" line="73"/>
+        <source>Error during key generation.</source>
+        <translation>Fehler bei der Schlüssel-Erzeugung.</translation>
+    </message>
+</context>
+<context>
+    <name>SourceTab</name>
+    <message>
+        <location filename="../../views/source_tab.py" line="46"/>
+        <source>Choose directory to back up</source>
+        <translation>Zu sicherndes Verzeichnis auswählen</translation>
+    </message>
+    <message>
+        <location filename="../../views/source_tab.py" line="46"/>
+        <source>Choose file to back up</source>
+        <translation>Zu sichernde Datei auswählen</translation>
+    </message>
+</context>
+<context>
+    <name>TrayMenu</name>
+    <message>
+        <location filename="../../tray_menu.py" line="32"/>
+        <source>Backup in Progress</source>
+        <translation>Datensicherung läuft</translation>
+    </message>
+    <message>
+        <location filename="../../tray_menu.py" line="33"/>
+        <source>Cancel Backup</source>
+        <translation>Datensicherung abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../../tray_menu.py" line="36"/>
+        <source>Next Task: %s</source>
+        <translation>Nächste Aufgabe: %s</translation>
+    </message>
+    <message>
+        <location filename="../../tray_menu.py" line="45"/>
+        <source>Backup Now</source>
+        <translation>Datensicherung starten</translation>
+    </message>
+    <message>
+        <location filename="../../tray_menu.py" line="48"/>
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../../tray_menu.py" line="53"/>
+        <source>Exit</source>
+        <translation>Beenden</translation>
+    </message>
+</context>
+<context>
+    <name>VortaScheduler</name>
+    <message>
+        <location filename="../../scheduler.py" line="55"/>
+        <source>Vorta Scheduler</source>
+        <translation>Vorta Planer</translation>
+    </message>
+    <message>
+        <location filename="../../scheduler.py" line="55"/>
+        <source>Background scheduler was changed.</source>
+        <translation>Planung für Hintergrund-Jobs hat sich geändert.</translation>
+    </message>
+    <message>
+        <location filename="../../scheduler.py" line="89"/>
+        <source>None scheduled</source>
+        <translation>Keine geplant.</translation>
+    </message>
+    <message>
+        <location filename="../../scheduler.py" line="120"/>
+        <source>Vorta Backup</source>
+        <translation>Vorta Datensicherung</translation>
+    </message>
+    <message>
+        <location filename="../../scheduler.py" line="98"/>
+        <source>Starting background backup for %s.</source>
+        <translation>Starte Datensicherung (Hintergrund) für %s.</translation>
+    </message>
+    <message>
+        <location filename="../../scheduler.py" line="109"/>
+        <source>Backup successful for %s.</source>
+        <translation>Datensicherung erfolgreich abgeschlossen für %s.</translation>
+    </message>
+    <message>
+        <location filename="../../scheduler.py" line="115"/>
+        <source>Error during backup creation.</source>
+        <translation>Fehler während der Datensicherung aufgetreten.</translation>
+    </message>
+</context>
+<context>
+    <name>messages</name>
+    <message>
+        <location filename="../../borg/borg_thread.py" line="92"/>
+        <source>Backup is already in progress.</source>
+        <translation>Backup wird bereits ausgeführt.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/borg_thread.py" line="96"/>
+        <source>Borg binary was not found.</source>
+        <translation>Borg-Programm wurde nicht gefunden.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/borg_thread.py" line="100"/>
+        <source>Add a backup repository first.</source>
+        <translation>Zuerst ein Datensicherungs-Repository hinzufügen.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/borg_thread.py" line="107"/>
+        <source>Please make sure you grant Vorta permission to use the Keychain.</source>
+        <translation>Bitte sicherstellen, daß Vorta erlaubt wird, den Schlüsselbund zu benutzen.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/create.py" line="78"/>
+        <source>Add some folders to back up first.</source>
+        <translation>Füge zuerst einige zu sichernde Ordner hinzu.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/create.py" line="93"/>
+        <source>Current Wifi is not allowed.</source>
+        <translation>Aktuelles WLAN ist nicht erlaubt.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/create.py" line="97"/>
+        <source>Repo folder not mounted or moved.</source>
+        <translation>Repo-Ordner nicht eingehängt oder verschoben.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/create.py" line="133"/>
+        <source>Pre-backup command returned non-zero exit code.</source>
+        <translation>Pre-backup-Kommando hat einen Return-Code ungleich Null zurückgegeben.</translation>
+    </message>
+    <message>
+        <location filename="../../borg/create.py" line="136"/>
+        <source>Starting backup..</source>
+        <translation>Starte Datensicherung..</translation>
+    </message>
+    <message>
+        <location filename="../../borg/umount.py" line="26"/>
+        <source>No active Borg mounts found.</source>
+        <translation>Keine aktiven Borg-Einhängepunkte gefunden.</translation>
+    </message>
+</context>
+<context>
+    <name>settings</name>
+    <message>
+        <location filename="../../models.py" line="204"/>
+        <source>Use light system tray icon (applies after restart, useful for dark themes).</source>
+        <translation>Helles System-Tray-Icon benutzen (wird nach Neustart angewandt, nützlich für dunkle Themes).</translation>
+    </message>
+    <message>
+        <location filename="../../models.py" line="209"/>
+        <source>Display notifications when background tasks fail.</source>
+        <translation>Benachrichtigungen anzeigen, wenn Hintergrund-Aufgaben fehlschlagen.</translation>
+    </message>
+    <message>
+        <location filename="../../models.py" line="214"/>
+        <source>Also notify about successful background tasks.</source>
+        <translation>Auch über erfolgreiche Hintergrund-Aufgaben benachrichtigen.</translation>
+    </message>
+    <message>
+        <location filename="../../models.py" line="222"/>
+        <source>Add Vorta to Login Items in Preferences &gt; Users and Groups &gt; Login Items.</source>
+        <translation>Füge Vorta zu Login Items in Preferences &gt; Users and Groups &gt; Login Items hinzu.</translation>
+    </message>
+    <message>
+        <location filename="../../models.py" line="227"/>
+        <source>Check for updates on startup.</source>
+        <translation>Prüfe beim Start auf Aktualisierungen.</translation>
+    </message>
+    <message>
+        <location filename="../../models.py" line="232"/>
+        <source>Include pre-release versions when checking for updates.</source>
+        <translation>Auch Vorab-Versionen mit einbeziehen bei der Prüfung auf Aktualisierungen.</translation>
+    </message>
+</context>
+</TS>

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -10,6 +10,7 @@ import getpass
 from collections import defaultdict
 from functools import reduce
 import operator
+import psutil
 
 from paramiko.rsakey import RSAKey
 from paramiko.ecdsakey import ECDSAKey
@@ -247,3 +248,32 @@ def format_archive_name(profile, archive_name_tpl):
         'user': getpass.getuser()
     }
     return archive_name_tpl.format(**available_vars)
+
+
+def open_folder(folder):
+    """Open a file browser on a folder."""
+    cmd = 'open' if sys.platform == 'darwin' else 'xdg-open'
+    subprocess.Popen([cmd, folder])
+
+
+def get_mount_points(repo_url):
+    mount_points = {}
+    for proc in psutil.process_iter():
+        if proc.name() != 'borg':
+            continue
+
+        if 'mount' not in proc.cmdline():
+            continue
+
+        for idx, parameter in enumerate(proc.cmdline()):
+            if parameter.startswith(repo_url + '::'):
+                archive_name = parameter[len(repo_url) + 2:]
+
+                # The borg mount command specifies that the mount_point
+                # parameter comes after the archive name
+                if len(proc.cmdline()) > idx + 1:
+                    mount_point = proc.cmdline()[idx + 1]
+                    mount_points[archive_name] = mount_point
+                break
+
+    return mount_points

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -259,21 +259,19 @@ def open_folder(folder):
 def get_mount_points(repo_url):
     mount_points = {}
     for proc in psutil.process_iter():
-        if proc.name() != 'borg':
-            continue
+        if proc.name() == 'borg' or proc.name().startswith('python'):
+            if 'mount' not in proc.cmdline():
+                continue
 
-        if 'mount' not in proc.cmdline():
-            continue
+            for idx, parameter in enumerate(proc.cmdline()):
+                if parameter.startswith(repo_url + '::'):
+                    archive_name = parameter[len(repo_url) + 2:]
 
-        for idx, parameter in enumerate(proc.cmdline()):
-            if parameter.startswith(repo_url + '::'):
-                archive_name = parameter[len(repo_url) + 2:]
-
-                # The borg mount command specifies that the mount_point
-                # parameter comes after the archive name
-                if len(proc.cmdline()) > idx + 1:
-                    mount_point = proc.cmdline()[idx + 1]
-                    mount_points[archive_name] = mount_point
-                break
+                    # The borg mount command specifies that the mount_point
+                    # parameter comes after the archive name
+                    if len(proc.cmdline()) > idx + 1:
+                        mount_point = proc.cmdline()[idx + 1]
+                        mount_points[archive_name] = mount_point
+                    break
 
     return mount_points

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -84,11 +84,12 @@ def get_private_keys():
     available_private_keys = []
     if os.path.isdir(ssh_folder):
         for key in os.listdir(ssh_folder):
+            key_file = os.path.join(ssh_folder, key)
+            if not os.path.isfile(key_file):
+                continue
             for key_format in key_formats:
                 try:
-                    parsed_key = key_format.from_private_key_file(
-                        os.path.join(ssh_folder, key)
-                    )
+                    parsed_key = key_format.from_private_key_file(key_file)
                     key_details = {
                         'filename': key,
                         'format': parsed_key.get_name(),

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -32,15 +32,13 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.toolBox.setCurrentIndex(0)
 
         self.folder_icon = QIcon(':/icons/folder-open.svg')
-        self.archiveTable.setHorizontalHeaderItem(3, QTableWidgetItem(self.folder_icon, ''))
         header = self.archiveTable.horizontalHeader()
         header.setVisible(True)
         header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(3, QHeaderView.Fixed)
+        header.setSectionResizeMode(3, QHeaderView.ResizeToContents)
         header.setMinimumSectionSize(32)
-        header.resizeSection(3, 32)
         header.setSectionResizeMode(4, QHeaderView.Stretch)
         header.setStretchLastSection(True)
 
@@ -106,7 +104,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                 self.archiveTable.setItem(row, 2, QTableWidgetItem(formatted_duration))
                 mount_point = self.mount_points.get(archive.name)
                 if mount_point is not None:
-                    item = QTableWidgetItem(self.folder_icon, '')
+                    item = QTableWidgetItem(f'…{mount_point[-5:]}')
                 else:
                     item = QTableWidgetItem('')
                 self.archiveTable.setItem(row, 3, item)
@@ -242,7 +240,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             self.update_mount_button_text()
             archive_name = result['params']['current_archive']
             row = self.row_of_archive(archive_name)
-            item = QTableWidgetItem(self.folder_icon, '')
+            item = QTableWidgetItem(f"…{result['cmd'][-1][-5:]}")
             self.archiveTable.setItem(row, 3, item)
         else:
             self.mount_point = None

--- a/vorta.spec
+++ b/vorta.spec
@@ -18,6 +18,7 @@ a = Analysis(['src/vorta/__main__.py'],
              datas=[
                 ('src/vorta/assets/UI/*', 'assets/UI'),
                 ('src/vorta/assets/icons/*', 'assets/icons'),
+                ('src/vorta/i18n/qm/*', 'vorta/i18n/qm'),
              ],
              hiddenimports=[
                  'vorta.views.collection_rc',


### PR DESCRIPTION
* Fix for unmounting archives by normalizing the paths

Unmounting an archive didn't work for me because a directory like '/foo/' is compared to the items in the list of mounted directories, which contained '/foo' . This PR fixes this problem by normalizing the paths before comparison.

* Use the wants_folder parameter when asking the user for a mount point or an extraction point

* Improvements to the mount/unmount feature

Make it possible to mount more than one archive at the same time. When the user selects an archive, the mount button is updated and changes between Mount/Unmount actions depending on the state of the selected archive.

* Use a mount icon for mounted archives and check premounted archives  …
Add a column to show an icon in mounted archives.

* Use psutil to check on startup (and refreshes) the mounted archives,
so Vorta doesn't get out-of-sync with what's really mounted on the system.

* Add a context menu to the archive table (and open folder action)

Add a context menu to the archive table and a way to quickly open a file browser on the archive's mount point.

* Also open the mount point folder when double clicking on the mounted icon