### PR TITLE
Remove leftover Sentry references. Fixes #127

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ For available packages and instructions, see [INSTALL.md](INSTALL.md)
 ## Development and Bug Reports
 - Report bugs and submit feature ideas by opening a new [Github issue](https://github.com/borgbase/vorta/issues/new/choose).
 - Want to contribute to Vorta? Great! See [CONTRIBUTING.md](CONTRIBUTING.md)
-- During beta-testing, crash reports are sent to [Sentry](https://sentry.io) to quickly find bugs. You can disable bug reports under the **Misc** settings tab. Your repo password will always be scrubbed *before* the test report is transmitted.
 
 ## License and Credits
 - Ⓒ 2018 [Manuel Riel](https://twitter.com/_m3nu) for [BorgBase.com](https://www.borgbase.com). All rights reserved.

--- a/requirements.d/conda.yml
+++ b/requirements.d/conda.yml
@@ -18,6 +18,3 @@ dependencies:
   - pyobjc-core
   - pyobjc-framework-Cocoa
   - pyinstaller
-  - pip:
-      - sentry-sdk
-

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -184,16 +184,7 @@ def _apply_schema_update(current_schema, version_after, *operations):
         current_schema.save()
 
 
-def init_db(con):
-    db.initialize(con)
-    db.connect()
-    db.create_tables([RepoModel, RepoPassword, BackupProfileModel, SourceFileModel, SettingsModel,
-                      ArchiveModel, WifiSettingModel, EventLogModel, SchemaVersion])
-
-    if BackupProfileModel.select().count() == 0:
-        default_profile = BackupProfileModel(name='Default')
-        default_profile.save()
-
+def get_misc_settings():
     # Default settings for all platforms.
     settings = [
         {
@@ -221,8 +212,21 @@ def init_db(con):
              'label': 'Include pre-release versions when checking for updates.'},
         ]
 
+    return settings
+
+
+def init_db(con):
+    db.initialize(con)
+    db.connect()
+    db.create_tables([RepoModel, RepoPassword, BackupProfileModel, SourceFileModel, SettingsModel,
+                      ArchiveModel, WifiSettingModel, EventLogModel, SchemaVersion])
+
+    if BackupProfileModel.select().count() == 0:
+        default_profile = BackupProfileModel(name='Default')
+        default_profile.save()
+
     # Create missing settings and update labels. Leave setting values untouched.
-    for setting in settings:
+    for setting in get_misc_settings():
         s, created = SettingsModel.get_or_create(key=setting['key'], defaults=setting)
         s.label = setting['label']
         s.save()

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -1,7 +1,7 @@
 from PyQt5 import uic
 from PyQt5.QtWidgets import QCheckBox
 from vorta.utils import get_asset, open_app_at_startup
-from vorta.models import SettingsModel, BackupProfileMixin
+from vorta.models import SettingsModel, BackupProfileMixin, get_misc_settings
 from vorta._version import __version__
 
 uifile = get_asset('UI/misctab.ui')
@@ -16,6 +16,9 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
         self.versionLabel.setText(__version__)
 
         for setting in SettingsModel.select().where(SettingsModel.type == 'checkbox'):
+            x = filter(lambda s: s['key'] == setting.key, get_misc_settings())
+            if not list(x):  # Skip settings that aren't specified in vorta.models.
+                continue
             b = QCheckBox(setting.label)
             b.setCheckState(setting.value)
             b.setTristate(False)


### PR DESCRIPTION
And don't show settings that exist in the DB, but not in `vorta.models`.