### PR TITLE
Show/Hide the main window when clicking on the tray icon

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -82,6 +82,12 @@ class VortaApp(QApplication):
         self.main_window.show()
         self.main_window.raise_()
 
+    def toggle_main_window_visibility(self):
+        if self.main_window.isVisible():
+            self.main_window.hide()
+        else:
+            self.open_main_window_action()
+
     def backup_started_event_response(self):
         set_tray_icon(self.tray, active=True)
 

--- a/src/vorta/tray_menu.py
+++ b/src/vorta/tray_menu.py
@@ -1,4 +1,4 @@
-import sys
+import os
 from PyQt5.QtWidgets import QMenu, QSystemTrayIcon
 
 from .borg.borg_thread import BorgThread
@@ -18,14 +18,16 @@ class TrayMenu(QSystemTrayIcon):
 
         self.setContextMenu(menu)
 
-        if sys.platform != 'darwin':
-            self.activated.connect(self.on_activation)
+        self.activated.connect(self.on_activation)
         self.setVisible(True)
         self.show()
 
     def on_activation(self, reason):
         if reason == QSystemTrayIcon.Trigger:
-            self.app.toggle_main_window_visibility()
+            if os.environ.get('XDG_CURRENT_DESKTOP', '') == 'KDE':
+                self.app.toggle_main_window_visibility()
+            else:
+                self.on_user_click()
 
     def on_user_click(self):
         """Build system tray menu based on current state."""

--- a/src/vorta/tray_menu.py
+++ b/src/vorta/tray_menu.py
@@ -1,3 +1,4 @@
+import sys
 from PyQt5.QtWidgets import QMenu, QSystemTrayIcon
 
 from .borg.borg_thread import BorgThread
@@ -17,7 +18,8 @@ class TrayMenu(QSystemTrayIcon):
 
         self.setContextMenu(menu)
 
-        self.activated.connect(self.on_activation)
+        if sys.platform != 'darwin':
+            self.activated.connect(self.on_activation)
         self.setVisible(True)
         self.show()
 

--- a/src/vorta/tray_menu.py
+++ b/src/vorta/tray_menu.py
@@ -16,8 +16,14 @@ class TrayMenu(QSystemTrayIcon):
         menu.aboutToShow.connect(self.on_user_click)
 
         self.setContextMenu(menu)
+
+        self.activated.connect(self.on_activation)
         self.setVisible(True)
         self.show()
+
+    def on_activation(self, reason):
+        if reason == QSystemTrayIcon.Trigger:
+            self.app.toggle_main_window_visibility()
 
     def on_user_click(self):
         """Build system tray menu based on current state."""


### PR DESCRIPTION
This makes it easier to open the Vorta main window just by clicking
on the tray icon (instead of having to right-click and then click on
Settings). Also, vorta now has the common behaviour of closing the
main window if it's already visible when the user clicks on the tray
icon.