### PR TITLE
get_private_keys: do not try to read sockets

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -84,13 +84,12 @@ def get_private_keys():
     available_private_keys = []
     if os.path.isdir(ssh_folder):
         for key in os.listdir(ssh_folder):
-            if not os.path.isfile(os.path.join(ssh_folder, key)):
+            key_file = os.path.join(ssh_folder, key)
+            if not os.path.isfile(key_file):
                 continue
             for key_format in key_formats:
                 try:
-                    parsed_key = key_format.from_private_key_file(
-                        os.path.join(ssh_folder, key)
-                    )
+                    parsed_key = key_format.from_private_key_file(key_file)
                     key_details = {
                         'filename': key,
                         'format': parsed_key.get_name(),

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -84,6 +84,8 @@ def get_private_keys():
     available_private_keys = []
     if os.path.isdir(ssh_folder):
         for key in os.listdir(ssh_folder):
+            if not os.path.isfile(os.path.join(ssh_folder, key)):
+                continue
             for key_format in key_formats:
                 try:
                     parsed_key = key_format.from_private_key_file(


### PR DESCRIPTION
I store my ControlMaster sockets in `~/.ssh/` due to `ControlPath ~/.ssh/%r@%h:%p` in my ssh config. While trying to read private key files, Vorta stumbled upon these sockets and crashed on startup:

```
  File "/Users/seb/.pyenv/versions/3.6.8/lib/python3.6/site-packages/paramiko/pkey.py", line 278, in _read_private_key_file
    with open(filename, "r") as f:
OSError: [Errno 102] Operation not supported on socket: '/Users/seb/.ssh/seb@asdf'
```