### PR TITLE
Programmatically detect theme color (for macOS)

### DIFF
--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -242,7 +242,7 @@ def init_db(con):
     for setting in get_misc_settings():
         s, created = SettingsModel.get_or_create(key=setting['key'], defaults=setting)
         if created and setting['key'] == "use_light_icon":
-            s.value = uses_dark_mode()
+            s.value = bool(uses_dark_mode())
         s.label = setting['label']
         s.save()
 

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -11,7 +11,7 @@ import peewee as pw
 from playhouse.migrate import SqliteMigrator, migrate
 
 from vorta.i18n import trans_late
-from vorta.utils import slugify
+from vorta.utils import slugify, detect_use_light_icon
 
 SCHEMA_VERSION = 10
 
@@ -241,6 +241,8 @@ def init_db(con):
     # Create missing settings and update labels. Leave setting values untouched.
     for setting in get_misc_settings():
         s, created = SettingsModel.get_or_create(key=setting['key'], defaults=setting)
+        if created and setting['key'] == "use_light_icon":
+            s.value = detect_use_light_icon()
         s.label = setting['label']
         s.save()
 

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -11,7 +11,7 @@ import peewee as pw
 from playhouse.migrate import SqliteMigrator, migrate
 
 from vorta.i18n import trans_late
-from vorta.utils import slugify, detect_use_light_icon
+from vorta.utils import slugify, uses_dark_mode
 
 SCHEMA_VERSION = 10
 
@@ -242,7 +242,7 @@ def init_db(con):
     for setting in get_misc_settings():
         s, created = SettingsModel.get_or_create(key=setting['key'], defaults=setting)
         if created and setting['key'] == "use_light_icon":
-            s.value = detect_use_light_icon()
+            s.value = uses_dark_mode()
         s.label = setting['label']
         s.save()
 

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -208,10 +208,9 @@ def set_tray_icon(tray, active=False):
     tray.setIcon(icon)
 
 
-def detect_use_light_icon():
+def uses_dark_mode():
     """
-    This function detects if we should use a light tray icon (e.g. when running
-    macOS in dark mode).
+    This function detects if we are running in dark mode (e.g. macOS dark mode).
     """
     if sys.platform == 'darwin':
         from Foundation import NSUserDefaults

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -211,12 +211,14 @@ def set_tray_icon(tray, active=False):
 def uses_dark_mode():
     """
     This function detects if we are running in dark mode (e.g. macOS dark mode).
+
+    Returns None if the interface style cannot be determined, otherwise a boolean.
     """
     if sys.platform == 'darwin':
         from Foundation import NSUserDefaults
         stdud = NSUserDefaults.standardUserDefaults()
         return stdud.stringForKey_("AppleInterfaceStyle") == "Dark"
-    return False
+    return None
 
 
 def open_app_at_startup(enabled=True):

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -208,6 +208,18 @@ def set_tray_icon(tray, active=False):
     tray.setIcon(icon)
 
 
+def detect_use_light_icon():
+    """
+    This function detects if we should use a light tray icon (e.g. when running
+    macOS in dark mode).
+    """
+    if sys.platform == 'darwin':
+        from Foundation import NSUserDefaults
+        stdud = NSUserDefaults.standardUserDefaults()
+        return stdud.stringForKey_("AppleInterfaceStyle") == "Dark"
+    return False
+
+
 def open_app_at_startup(enabled=True):
     """
     This function adds/removes the current app bundle from Login items in macOS


### PR DESCRIPTION
When I first ran Vorta, I didn't see the macOS menu bar icon at all because I'm using dark mode. So I thought the app doesn't work. Until I realized that I have to configure the app explicitly to use a light icon. Could be confusing for end users.

This code sets `use_light_icon=True` if macOS dark mode is detected on the first run of the app.