### PR TITLE
implement TRANS_SCALE env var for i18n UI layout checking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,15 @@ Translations are updated there: https://www.Transifex.com/borgbase/vorta/
 - Open a new issue on Github.
 - Edit the language on Transifex.
 
-### Data Flow to/from Transifex
+### Using and Testing Transifex Translations
 
-- Extract from source files: `make translations-from-source`
+- Extract from source files (needed after most code changes to update line number):
+  `make translations-from-source`
 - Push to Transifex: `make translations-push`
 - Pull finished translations from Transifex: `make translations-pull`
 - Compile: `make translations-to-qm`
+- Test with specific translation: `LANG=de vorta`
+- Scale strings to test UI: `LANG=de TRANS_SCALE=200 vorta --foreground`
 
 ### Notes for Developers
 

--- a/src/vorta/i18n/__init__.py
+++ b/src/vorta/i18n/__init__.py
@@ -8,11 +8,45 @@ from PyQt5.QtCore import QTranslator, QLocale
 
 logger = logging.getLogger(__name__)
 
+# To check if the UI layout copes flexibly with translated strings, an env var
+# TRANS_SCALE can be used - it will result in transformed translated strings, e.g.:
+# 100 = scale 100%, normal
+# N>0 = scale to N%
+# N<0 = additionally, do a RTL simulation at scale -N%
+# usage: TRANS_SCALE=200 LANG=de_DE vorta --foreground
+trans_scale = int(os.environ.get('TRANS_SCALE', '100'))
+
+
+class VortaTranslator(QTranslator):
+    def translate(self, context, text, disambiguation=None, n=-1):
+        translated = super().translate(context, text, disambiguation=disambiguation, n=n)
+        scale = trans_scale
+        if scale == 100:  # normal, production usage
+            return translated
+
+        # for UI layout debugging:
+        has_placeholders = '%' in translated
+        has_html = translated.startswith('<') and translated.endswith('>')
+        if has_placeholders or has_html:
+            # not supported kinds of strings, just return normal:
+            return translated
+        if scale < 0:
+            # for simple RTL checking: reverse translated string
+            translated = translated[::-1]
+            scale = -scale
+        if 0 < scale < 100:
+            step = 100 // scale
+            scale = None
+        else:
+            step = None
+            scale = scale // 100
+        return translated * scale if step is None else translated[::step]
+
 
 def init_translations(app):
     global application, translator, locale  # if we don't keep a reference on these, it stops working. pyqt bug?
     application = app
-    translator = QTranslator()
+    translator = VortaTranslator()
     locale = QLocale()
     qm_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'qm'))
     ui_langs = locale.uiLanguages()

--- a/src/vorta/i18n/__init__.py
+++ b/src/vorta/i18n/__init__.py
@@ -47,7 +47,7 @@ def init_translations(app):
     global application, translator, locale  # if we don't keep a reference on these, it stops working. pyqt bug?
     application = app
     translator = VortaTranslator()
-    locale = QLocale()
+    locale = QLocale(os.environ.get('LANG', None))
     qm_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'qm'))
     ui_langs = locale.uiLanguages()
     succeeded = translator.load(locale, 'vorta', prefix='.', directory=qm_path)  # e.g. vorta/i18n/qm/vorta.de_DE.qm

--- a/src/vorta/log.py
+++ b/src/vorta/log.py
@@ -17,6 +17,7 @@ def init_logger(foreground=False):
     logger.setLevel(logging.DEBUG)
     logging.getLogger('peewee').setLevel(logging.INFO)
     logging.getLogger('apscheduler').setLevel(logging.INFO)
+    logging.getLogger('PyQt5').setLevel(logging.INFO)
 
     # create logging format
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
check how the UI behaves for longer / shorter strings, for RTL strings.

does currently only work IF a language is loaded from a .qm file, otherwise there won't be a translator object / it won't call its .translate method.

works:
```
LANG=de_DE TRANS_SCALE=200 vorta --foreground
```
