### PR TITLE
Fix crash due to zombie processes

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -268,7 +268,7 @@ def get_mount_points(repo_url):
     for proc in psutil.process_iter():
         try:
             name = proc.name()
-        except:
+        except Exception:
             # Getting the process name may fail (e.g. zombie process on macOS)
             continue
         if name == 'borg' or name.startswith('python'):

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -266,7 +266,12 @@ def format_archive_name(profile, archive_name_tpl):
 def get_mount_points(repo_url):
     mount_points = {}
     for proc in psutil.process_iter():
-        if proc.name() == 'borg' or proc.name().startswith('python'):
+        try:
+            name = proc.name()
+        except:
+            # Getting the process name may fail (e.g. zombie process on macOS)
+            continue
+        if name == 'borg' or name.startswith('python'):
             if 'mount' not in proc.cmdline():
                 continue
 


### PR DESCRIPTION
In `vorta.utils.get_mount_points` the call to `process.name()` may raise an exception (e.g. zombie processes on macOS). In that case, Vorta will crash. This PR fixes this by catching exceptions in `process.name()`: if we can't get the process name, this is obviously not an active borg mount.