### PR TITLE
Implement autostart on linux

### DIFF
--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+from PyQt5 import QtCore
+from setuptools import Distribution
+from setuptools.command.install import install
+
+
+GNOME_STARTUP_FILE = """[Desktop Entry]
+Name=Vorta
+GenericName=Backup Software
+"Exec={}/vorta
+Terminal=false
+Icon=vorta
+Categories=Utility
+Type=Application
+StartupNotify=false
+X-GNOME-Autostart-enabled=true
+"""
+
+
+def open_app_at_startup(enabled=True):
+    """
+    This function adds/removes the current app bundle from Login items in macOS or Linux (Gnome desktop)
+    """
+    if sys.platform == 'darwin':
+        from Foundation import NSDictionary
+
+        from Cocoa import NSBundle, NSURL
+        from CoreFoundation import kCFAllocatorDefault
+        # CF = CDLL(find_library('CoreFoundation'))
+        from LaunchServices import (LSSharedFileListCreate, kLSSharedFileListSessionLoginItems,
+                                    LSSharedFileListInsertItemURL, kLSSharedFileListItemHidden,
+                                    kLSSharedFileListItemLast, LSSharedFileListItemRemove)
+
+        app_path = NSBundle.mainBundle().bundlePath()
+        url = NSURL.alloc().initFileURLWithPath_(app_path)
+        login_items = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, None)
+        props = NSDictionary.dictionaryWithObject_forKey_(True, kLSSharedFileListItemHidden)
+
+        new_item = LSSharedFileListInsertItemURL(login_items, kLSSharedFileListItemLast,
+                                                 None, None, url, props, None)
+        if not enabled:
+            LSSharedFileListItemRemove(login_items, new_item)
+    elif sys.platform.startswith('linux'):
+        config_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.ConfigLocation)
+        autostart_file_path = Path(config_path) / 'autostart' / 'vorta.desktop'
+        if enabled:
+            dir_entry_point = get_setuptools_script_dir()
+            autostart_file_path.write_text(GNOME_STARTUP_FILE.format(dir_entry_point))
+        else:
+            if autostart_file_path.exists():
+                autostart_file_path.unlink()
+
+
+# Get entry point of vorta
+# From https://stackoverflow.com/questions/
+#      25066084/get-entry-point-script-file-location-in-setuputils-package
+class OnlyGetScriptPath(install):
+    def run(self):
+        # does not call install.run() by design
+        self.distribution.install_scripts = self.install_scripts
+
+
+def get_setuptools_script_dir():
+    dist = Distribution({'cmdclass': {'install': OnlyGetScriptPath}})
+    dist.dry_run = True  # not sure if necessary, but to be safe
+    dist.parse_config_files()
+    command = dist.get_command_obj('install')
+    command.ensure_finalized()
+    command.run()
+    return dist.install_scripts

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -211,15 +211,15 @@ def get_misc_settings():
             'key': 'enable_notifications_success', 'value': False, 'type': 'checkbox',
             'label': trans_late('settings',
                                 'Also notify about successful background tasks')
+        },
+        {
+            'key': 'autostart', 'value': False, 'type': 'checkbox',
+            'label': trans_late('settings',
+                                'Automatically start Vorta at login')
         }
     ]
     if sys.platform == 'darwin':
         settings += [
-            {
-                'key': 'autostart', 'value': False, 'type': 'checkbox',
-                'label': trans_late('settings',
-                                    'Automatically start Vorta at login')
-            },
             {
                 'key': 'check_for_updates', 'value': True, 'type': 'checkbox',
                 'label': trans_late('settings',

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -248,7 +248,7 @@ def open_app_at_startup(enabled=True):
                                                  None, None, url, props, None)
         if not enabled:
             LSSharedFileListItemRemove(login_items, new_item)
-    elif sys.platform == 'linux':
+    elif sys.platform.startswith('linux'):
         config_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.ConfigLocation)
         autostart_file_path = Path(config_path) / 'autostart' / 'vorta.desktop'
         if enabled:

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -265,7 +265,8 @@ def open_app_at_startup(enabled=True):
                                       f"X-GNOME-Autostart-enabled=true\n")
             autostart_file_path.write_text(autostart_file_content)
         else:
-            autostart_file_path.unlink()
+            if autostart_file_path.exists():
+                autostart_file_path.unlink()
 
 
 def format_archive_name(profile, archive_name_tpl):

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -2,7 +2,8 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QCheckBox
 
 from vorta.i18n import translate
-from vorta.utils import get_asset, open_app_at_startup
+from vorta.utils import get_asset
+from vorta.autostart import open_app_at_startup
 from vorta.models import SettingsModel, BackupProfileMixin, get_misc_settings
 from vorta._version import __version__
 from vorta.views.utils import get_theme_class


### PR DESCRIPTION
Implements autostart on linux using [XDG Autostart](https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html), which should be supported by all [popular desktop environments](https://wiki.archlinux.org/index.php/Autostarting)
Icon is currently not displayed when entry is viewed with gnome tweaks.
We would probably have to insert the absolute path to vorta's icon for that.