### PR TITLE
Add tooltip to "add profile" button (#183)

### DIFF
--- a/src/vorta/assets/UI/mainwindow.ui
+++ b/src/vorta/assets/UI/mainwindow.ui
@@ -64,7 +64,7 @@
       </item>
       <item>
        <widget class="QToolButton" name="profileAddButton">
-        <property name="text">
+        <property name="toolTip">
          <string>Add Profile</string>
         </property>
         <property name="icon">


### PR DESCRIPTION
**Background:**
Currently the "rename" and "delete" profile buttons have mouse-over
tooltips. This commit adds a tooltip to the "add profile" button

**Modifications:**
* Change the string property on `profileAddButton` from `text` to `toolTip`.

**Steps to test:**
* Launch Vorta and mouse-over the "+" button.
<img width="191" alt="screen shot 2019-02-10 at 8 23 12 am" src="https://user-images.githubusercontent.com/1526881/52536313-c4bc2480-2d0d-11e9-9f39-b5b41b07c35a.png">


Fixes https://github.com/borgbase/vorta/issues/183