### PR TITLE
Avoid deadlock when calling subprocess.Popen()

### DIFF
--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -143,7 +143,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
         logger.info('Running command %s', ' '.join(self.cmd))
 
         p = Popen(self.cmd, stdout=PIPE, stderr=PIPE, bufsize=1, universal_newlines=True,
-                  env=self.env, cwd=self.cwd, preexec_fn=os.setsid)
+                  env=self.env, cwd=self.cwd, start_new_session=True)
         self.process = p
 
         # Prevent blocking of stdout/err. Via https://stackoverflow.com/a/7730201/3983708

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -268,22 +268,23 @@ def get_mount_points(repo_url):
     for proc in psutil.process_iter():
         try:
             name = proc.name()
-        except Exception:
-            # Getting the process name may fail (e.g. zombie process on macOS)
+            if name == 'borg' or name.startswith('python'):
+                if 'mount' not in proc.cmdline():
+                    continue
+
+                for idx, parameter in enumerate(proc.cmdline()):
+                    if parameter.startswith(repo_url + '::'):
+                        archive_name = parameter[len(repo_url) + 2:]
+
+                        # The borg mount command specifies that the mount_point
+                        # parameter comes after the archive name
+                        if len(proc.cmdline()) > idx + 1:
+                            mount_point = proc.cmdline()[idx + 1]
+                            mount_points[archive_name] = mount_point
+                        break
+        except psutil._exceptions.ZombieProcess:
+            # Getting process details may fail (e.g. zombie process on macOS)
+            # Also see https://github.com/giampaolo/psutil/issues/783
             continue
-        if name == 'borg' or name.startswith('python'):
-            if 'mount' not in proc.cmdline():
-                continue
-
-            for idx, parameter in enumerate(proc.cmdline()):
-                if parameter.startswith(repo_url + '::'):
-                    archive_name = parameter[len(repo_url) + 2:]
-
-                    # The borg mount command specifies that the mount_point
-                    # parameter comes after the archive name
-                    if len(proc.cmdline()) > idx + 1:
-                        mount_point = proc.cmdline()[idx + 1]
-                        mount_points[archive_name] = mount_point
-                    break
 
     return mount_points


### PR DESCRIPTION
This (hopefully) avoids the deadlock situation mentioned in the [Python docs](https://docs.python.org/3.6/library/subprocess.html) and [this SO question](https://stackoverflow.com/questions/42257512/difference-between-subprocess-popen-preexec-fn-and-start-new-session-in-python):

> The preexec_fn parameter is not safe to use in the presence of threads in your application. The child process could deadlock before exec is called. If you must use it, keep it trivial! Minimize the number of libraries you call into.

In addition it avoids getting the details of terminated Borg processes when looking for mount points. Discussed [here](https://github.com/giampaolo/psutil/issues/783).