### PR TITLE
Remove keyring dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 docs/
 *.autosave
 __pycache__
+.pytest_cache
 .eggs
 vorta.egg-info
 .coverage

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+from PyQt5 import QtCore
+from setuptools import Distribution
+from setuptools.command.install import install
+
+
+GNOME_STARTUP_FILE = """[Desktop Entry]
+Name=Vorta
+GenericName=Backup Software
+"Exec={}/vorta
+Terminal=false
+Icon=vorta
+Categories=Utility
+Type=Application
+StartupNotify=false
+X-GNOME-Autostart-enabled=true
+"""
+
+
+def open_app_at_startup(enabled=True):
+    """
+    This function adds/removes the current app bundle from Login items in macOS or Linux (Gnome desktop)
+    """
+    if sys.platform == 'darwin':
+        from Foundation import NSDictionary
+
+        from Cocoa import NSBundle, NSURL
+        from CoreFoundation import kCFAllocatorDefault
+        # CF = CDLL(find_library('CoreFoundation'))
+        from LaunchServices import (LSSharedFileListCreate, kLSSharedFileListSessionLoginItems,
+                                    LSSharedFileListInsertItemURL, kLSSharedFileListItemHidden,
+                                    kLSSharedFileListItemLast, LSSharedFileListItemRemove)
+
+        app_path = NSBundle.mainBundle().bundlePath()
+        url = NSURL.alloc().initFileURLWithPath_(app_path)
+        login_items = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, None)
+        props = NSDictionary.dictionaryWithObject_forKey_(True, kLSSharedFileListItemHidden)
+
+        new_item = LSSharedFileListInsertItemURL(login_items, kLSSharedFileListItemLast,
+                                                 None, None, url, props, None)
+        if not enabled:
+            LSSharedFileListItemRemove(login_items, new_item)
+    elif sys.platform.startswith('linux'):
+        config_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.ConfigLocation)
+        autostart_file_path = Path(config_path) / 'autostart' / 'vorta.desktop'
+        if enabled:
+            dir_entry_point = get_setuptools_script_dir()
+            autostart_file_path.write_text(GNOME_STARTUP_FILE.format(dir_entry_point))
+        else:
+            if autostart_file_path.exists():
+                autostart_file_path.unlink()
+
+
+# Get entry point of vorta
+# From https://stackoverflow.com/questions/
+#      25066084/get-entry-point-script-file-location-in-setuputils-package
+class OnlyGetScriptPath(install):
+    def run(self):
+        # does not call install.run() by design
+        self.distribution.install_scripts = self.install_scripts
+
+
+def get_setuptools_script_dir():
+    dist = Distribution({'cmdclass': {'install': OnlyGetScriptPath}})
+    dist.dry_run = True  # not sure if necessary, but to be safe
+    dist.parse_config_files()
+    command = dist.get_command_obj('install')
+    command.ensure_finalized()
+    command.run()
+    return dist.install_scripts

--- a/src/vorta/keyring/keyring_backend.py
+++ b/src/vorta/keyring/keyring_backend.py
@@ -1,0 +1,29 @@
+"""
+Keyring backend implementation
+Based on the keyring package
+https://github.com/jaraco/keyring/blob/master/keyring/backend.py
+"""
+
+import abc
+
+from . import keyring_errors
+
+
+class KeyringBackend:
+    """The abstract base class of the keyring, every backend must implement
+    this interface.
+    """
+
+    @abc.abstractmethod
+    def get_password(self, service, username):
+        """Get password of the username for the service
+        """
+        return None
+
+    @abc.abstractmethod
+    def set_password(self, service, username, password):
+        """Set password for the username of the service.
+        If the backend cannot store passwords, raise
+        NotImplementedError.
+        """
+        raise keyring_errors.PasswordSetError("reason")

--- a/src/vorta/keyring/keyring_core.py
+++ b/src/vorta/keyring/keyring_core.py
@@ -1,0 +1,36 @@
+"""
+Core API functions and initialization routines.
+Based on the keyring package
+https://github.com/jaraco/keyring/blob/master/keyring/core.py
+"""
+
+from . import keyring_backend
+
+_keyring_backend = None
+
+
+def set_keyring(keyring):
+    """Set current keyring backend.
+    """
+    global _keyring_backend
+    if not isinstance(keyring, keyring_backend.KeyringBackend):
+        raise TypeError("The keyring must be a subclass of KeyringBackend")
+    _keyring_backend = keyring
+
+
+def get_keyring():
+    """Get current keyring backend.
+    """
+    return _keyring_backend
+
+
+def get_password(service_name, username):
+    """Get password from the specified service.
+    """
+    return _keyring_backend.get_password(service_name, username)
+
+
+def set_password(service_name, username, password):
+    """Set password for the user in the specified service.
+    """
+    _keyring_backend.set_password(service_name, username, password)

--- a/src/vorta/keyring/keyring_darwin.py
+++ b/src/vorta/keyring/keyring_darwin.py
@@ -63,9 +63,6 @@ class VortaDarwinKeyring(KeyringBackend):
             password = _resolve_password(password_length, password_buffer)
         return password
 
-    def delete_password(self, service, repo_url):
-        pass
-
 
 def _resolve_password(password_length, password_buffer):
     from ctypes import c_char

--- a/src/vorta/keyring/keyring_darwin.py
+++ b/src/vorta/keyring/keyring_darwin.py
@@ -8,7 +8,7 @@ objc modules.
 Adapted from https://gist.github.com/apettinen/5dc7bf1f6a07d148b2075725db6b1950
 """
 
-from keyring.backend import KeyringBackend
+from .keyring_backend import KeyringBackend
 
 
 class VortaDarwinKeyring(KeyringBackend):
@@ -41,10 +41,6 @@ class VortaDarwinKeyring(KeyringBackend):
         # Get the login keychain
         result, login_keychain = SecKeychainOpen(b'login.keychain', None)
         self.login_keychain = login_keychain
-
-    @classmethod
-    def priority(cls):
-        return 5
 
     def set_password(self, service, repo_url, password):
         if not self.login_keychain: self._set_keychain()

--- a/src/vorta/keyring/keyring_db.py
+++ b/src/vorta/keyring/keyring_db.py
@@ -9,7 +9,7 @@ class VortaDBKeyring(KeyringBackend):
     """
 
     def set_password(self, service, repo_url, password):
-        from .models import RepoPassword
+        from ..models import RepoPassword
         keyring_entry, created = RepoPassword.get_or_create(
             url=repo_url,
             defaults={'password': password}
@@ -18,7 +18,7 @@ class VortaDBKeyring(KeyringBackend):
         keyring_entry.save()
 
     def get_password(self, service, repo_url):
-        from .models import RepoPassword
+        from ..models import RepoPassword
         try:
             keyring_entry = RepoPassword.get(url=repo_url)
             return keyring_entry.password

--- a/src/vorta/keyring/keyring_db.py
+++ b/src/vorta/keyring/keyring_db.py
@@ -24,6 +24,3 @@ class VortaDBKeyring(KeyringBackend):
             return keyring_entry.password
         except Exception:
             return None
-
-    def delete_password(self, service, repo_url):
-        pass

--- a/src/vorta/keyring/keyring_db.py
+++ b/src/vorta/keyring/keyring_db.py
@@ -1,15 +1,12 @@
-import keyring
+from .keyring_backend import KeyringBackend
 
 
-class VortaDBKeyring(keyring.backend.KeyringBackend):
+class VortaDBKeyring(KeyringBackend):
     """
     Our own fallback keyring service. Uses the main database
     to store repo passwords if no other (more secure) backend
     is available.
     """
-    @classmethod
-    def priority(cls):
-        return 5
 
     def set_password(self, service, repo_url, password):
         from .models import RepoPassword

--- a/src/vorta/keyring/keyring_errors.py
+++ b/src/vorta/keyring/keyring_errors.py
@@ -1,0 +1,23 @@
+class KeyringError(Exception):
+    """Base class for exceptions in keyring
+    """
+
+
+class PasswordSetError(KeyringError):
+    """Raised when the password can't be set.
+    """
+
+
+class PasswordDeleteError(KeyringError):
+    """Raised when the password can't be deleted.
+    """
+
+
+class InitError(KeyringError):
+    """Raised when the keyring could not be initialised
+    """
+
+
+class KeyringLocked(KeyringError):
+    """Raised when the keyring could not be initialised
+    """

--- a/src/vorta/keyring/keyring_errors.py
+++ b/src/vorta/keyring/keyring_errors.py
@@ -1,3 +1,10 @@
+"""
+Custom errors
+Based on the keyring package
+https://github.com/jaraco/keyring/blob/master/keyring/errors.py
+"""
+
+
 class KeyringError(Exception):
     """Base class for exceptions in keyring
     """

--- a/src/vorta/keyring/keyring_secretstorage.py
+++ b/src/vorta/keyring/keyring_secretstorage.py
@@ -1,0 +1,21 @@
+from .keyring_backend import KeyringBackend
+import secretstorage
+
+class VortaSecretStorageKeyring(KeyringBackend):
+    """A wrapper for the secretstorage package to support the custom keyring backend"""
+
+    def set_password(self, service, repo_url, password):
+        connection = secretstorage.dbus_init()
+        collection = secretstorage.get_default_collection(connection)
+        attributes = {'application': service, 'repo_url': repo_url}
+        collection.create_item(f"vorta-{repo_url}", attributes, password.encode(), replace=True)
+
+    def get_password(self, service, repo_url):
+        connection = secretstorage.dbus_init()
+        collection = secretstorage.get_default_collection(connection)
+        attributes = {'application': service, 'repo_url': repo_url}
+        try:
+            items = collection.search_items(attributes)
+            return next(items).get_secret().decode()
+        except Exception:
+            return None

--- a/src/vorta/keyring/keyring_secretstorage.py
+++ b/src/vorta/keyring/keyring_secretstorage.py
@@ -1,6 +1,7 @@
 from .keyring_backend import KeyringBackend
 import secretstorage
 
+
 class VortaSecretStorageKeyring(KeyringBackend):
     """A wrapper for the secretstorage package to support the custom keyring backend"""
 

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -211,15 +211,15 @@ def get_misc_settings():
             'key': 'enable_notifications_success', 'value': False, 'type': 'checkbox',
             'label': trans_late('settings',
                                 'Also notify about successful background tasks')
+        },
+        {
+            'key': 'autostart', 'value': False, 'type': 'checkbox',
+            'label': trans_late('settings',
+                                'Automatically start Vorta at login')
         }
     ]
     if sys.platform == 'darwin':
         settings += [
-            {
-                'key': 'autostart', 'value': False, 'type': 'checkbox',
-                'label': trans_late('settings',
-                                    'Automatically start Vorta at login')
-            },
             {
                 'key': 'check_for_updates', 'value': True, 'type': 'checkbox',
                 'label': trans_late('settings',

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -248,7 +248,7 @@ def open_app_at_startup(enabled=True):
                                                  None, None, url, props, None)
         if not enabled:
             LSSharedFileListItemRemove(login_items, new_item)
-    elif sys.platform == 'linux':
+    elif sys.platform.startswith('linux'):
         config_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.ConfigLocation)
         autostart_file_path = Path(config_path) / 'autostart' / 'vorta.desktop'
         if enabled:

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -22,7 +22,7 @@ from PyQt5 import QtCore
 import subprocess
 import vorta.keyring.keyring_core as keyring
 from vorta.keyring.keyring_db import VortaDBKeyring
-
+import secretstorage
 
 """
 Set the most appropriate Keyring backend for the current system.
@@ -36,6 +36,13 @@ fall back to a simple database keystore if needed.
 if sys.platform == 'darwin':
     from vorta.keyring.keyring_darwin import VortaDarwinKeyring
     keyring.set_keyring(VortaDarwinKeyring())
+elif sys.platform.startswith("linux"):
+    from vorta.keyring.keyring_secretstorage import VortaSecretStorageKeyring
+    try:
+        secretstorage.dbus_init()
+        keyring.set_keyring(VortaSecretStorageKeyring())
+    except secretstorage.SecretServiceNotAvailableException:
+        keyring.set_keyring(VortaDBKeyring())
 else:  # Fall back to saving password to database.
     keyring.set_keyring(VortaDBKeyring())
 

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -20,7 +20,7 @@ from PyQt5.QtWidgets import QFileDialog
 from PyQt5.QtGui import QIcon
 from PyQt5 import QtCore
 import subprocess
-import keyring
+import vorta.keyring.keyring_core as keyring
 from vorta.keyring.keyring_db import VortaDBKeyring
 
 

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -21,7 +21,7 @@ from PyQt5.QtGui import QIcon
 from PyQt5 import QtCore
 import subprocess
 import keyring
-from vorta.keyring_db import VortaDBKeyring
+from vorta.keyring.keyring_db import VortaDBKeyring
 
 
 """
@@ -34,20 +34,8 @@ For Linux not every system has SecretService available, so it will
 fall back to a simple database keystore if needed.
 """
 if sys.platform == 'darwin':
-    # from keyring.backends import OS_X
-    # keyring.set_keyring(OS_X.Keyring())
-    from vorta.keyring_darwin import VortaDarwinKeyring
+    from vorta.keyring.keyring_darwin import VortaDarwinKeyring
     keyring.set_keyring(VortaDarwinKeyring())
-elif sys.platform == 'win32':
-    from keyring.backends import Windows
-    keyring.set_keyring(Windows.WinVaultKeyring())
-elif sys.platform == 'linux':
-    from keyring.backends import SecretService
-    try:
-        SecretService.Keyring.priority()  # Test if keyring works.
-        keyring.set_keyring(SecretService.Keyring())
-    except Exception:
-        keyring.set_keyring(VortaDBKeyring())
 else:  # Fall back to saving password to database.
     keyring.set_keyring(VortaDBKeyring())
 

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -265,7 +265,8 @@ def open_app_at_startup(enabled=True):
                                       f"X-GNOME-Autostart-enabled=true\n")
             autostart_file_path.write_text(autostart_file_content)
         else:
-            autostart_file_path.unlink()
+            if autostart_file_path.exists():
+                autostart_file_path.unlink()
 
 
 def format_archive_name(profile, archive_name_tpl):

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -2,7 +2,8 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QCheckBox
 
 from vorta.i18n import translate
-from vorta.utils import get_asset, open_app_at_startup
+from vorta.utils import get_asset
+from vorta.autostart import open_app_at_startup
 from vorta.models import SettingsModel, BackupProfileMixin, get_misc_settings
 from vorta._version import __version__
 from vorta.views.utils import get_theme_class


### PR DESCRIPTION
Before this pull-request can be merged, two things need to be evaluated:

1. Test if the keyring on macOS still works.

2. The secretservice throws an exception when started from BorgThread. This can be tested by creating a new repository on a Linux machine. The processresult method in BorgInitThread will start set_password. This will start secretstorage.dbus_init() in VortaSecretStorageKeyring, which throws an unhandled exception. This does not happen when secretstorage.dbus_init() is started at any other part of the program.
It would be necessary to find out if this behaviour can be circumvented or if another backend needs to be used.
