### PR TITLE
Expand user path in python before setting BORG_RSH

### DIFF
--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -55,7 +55,8 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
         env['BORG_RSH'] = 'ssh -oStrictHostKeyChecking=no'
         ssh_key = params.get('ssh_key')
         if ssh_key is not None:
-            env['BORG_RSH'] += f' -i ~/.ssh/{ssh_key}'
+            ssh_key_path = os.path.expanduser(f'~/.ssh/{ssh_key}')
+            env['BORG_RSH'] += f' -i {ssh_key_path}'
 
         self.env = env
         self.cmd = cmd


### PR DESCRIPTION
We experienced some problems on MacOS 10.11.6, Borg 1.1.9 (installed with brew cask) where borg could not find the ssh key when there was a tilde in the path to the key file. Setting the `BORG_RSH` environment variable to expanded paths works. This patch fixes this for Vorta, we tested it on said setup.