### PR TITLE
Get borg version and path on startup. Link to log folder.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,4 @@ Steps to reproduce the behavior:
  - OS: [e.g. Ubuntu]
 
 **Additional context**
-If appropriate include logs from
-- Linux: `$HOME/.cache/Vorta/log`
-- macOS: `$HOME/Library/Logs/Vorta`
+If appropriate include logs. Can be found in Main Window > Misc Tab > Log.

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vorta.egg-info
 *.log
 htmlcov
 *.qm
+src/vorta/i18n/ts/vorta.en_US.ts

--- a/src/vorta/assets/UI/misctab.ui
+++ b/src/vorta/assets/UI/misctab.ui
@@ -14,6 +14,9 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="spacing">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QVBoxLayout" name="checkboxLayout">
      <property name="topMargin">
@@ -36,6 +39,12 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -52,7 +61,7 @@
      <item>
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Version:</string>
+        <string>Vorta Version:</string>
        </property>
       </widget>
      </item>
@@ -69,10 +78,67 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(&lt;a href=&quot;https://github.com/borgbase/vorta/issues/new/choose&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Report&lt;/span&gt;&lt;/a&gt; a Bug)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;| &lt;a href=&quot;https://github.com/borgbase/vorta/issues/new/choose&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Report&lt;/span&gt;&lt;/a&gt; a Bug |&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="openExternalLinks">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="logLink">
+       <property name="text">
+        <string>&lt;a href=&quot;file:///&quot;&gt;Log&lt;/a&gt;</string>
+       </property>
+       <property name="indent">
+        <number>0</number>
+       </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Borg Version:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="borgVersion">
+       <property name="text">
+        <string>1.1.8</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="borgPath">
+       <property name="text">
+        <string>/usr/bin/borg</string>
        </property>
       </widget>
      </item>

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -138,8 +138,9 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
         """Find packaged borg binary. Prefer globally installed."""
 
         # Look in current PATH.
-        if shutil.which('borg'):
-            return 'borg'
+        borg_in_path = shutil.which('borg')
+        if borg_in_path:
+            return borg_in_path
         else:
             # Look in pyinstaller package
             cwd = getattr(sys, '_MEIPASS', os.getcwd())

--- a/src/vorta/borg/version.py
+++ b/src/vorta/borg/version.py
@@ -1,0 +1,34 @@
+from .borg_thread import BorgThread
+from vorta.i18n import trans_late
+
+
+class BorgVersionThread(BorgThread):
+    """
+    Gets the path of the borg binary to be used and the borg version.
+
+    Used to display under 'Misc' and later for version-specific compatibility.
+    """
+
+    def finished_event(self, result):
+        self.result.emit(result)
+
+    @classmethod
+    def prepare(cls):
+        ret = {'ok': False}
+
+        if cls.prepare_bin() is None:
+            ret['message'] = trans_late('messages', 'Borg binary was not found.')
+            return ret
+
+        ret['cmd'] = ['borg', '--version']
+        ret['ok'] = True
+        return ret
+
+    def process_result(self, result):
+        if result['returncode'] == 0:
+            version = result['data'].strip().split(' ')[1]
+            path = self.prepare_bin()
+            result['data'] = {
+                'version': version,
+                'path': path
+            }

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -33,7 +33,8 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.sourceTab = SourceTab(self.sourceTabSlot)
         self.archiveTab = ArchiveTab(self.archiveTabSlot)
         self.scheduleTab = ScheduleTab(self.scheduleTabSlot)
-        self.miscTabSlot = MiscTab(self.miscTabSlot)
+        self.miscTab = MiscTab(self.miscTabSlot)
+        self.miscTab.set_borg_details(self.app.borg_details)
         self.tabWidget.setCurrentIndex(0)
 
         self.repoTab.repo_changed.connect(self.archiveTab.populate_from_profile)

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -7,6 +7,7 @@ from vorta.autostart import open_app_at_startup
 from vorta.models import SettingsModel, BackupProfileMixin, get_misc_settings
 from vorta._version import __version__
 from vorta.views.utils import get_theme_class
+from vorta.config import LOG_DIR
 
 uifile = get_asset('UI/misctab.ui')
 MiscTabUI, MiscTabBase = uic.loadUiType(uifile, from_imports=True, import_from=get_theme_class())
@@ -18,6 +19,7 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
         super().__init__(parent)
         self.setupUi(parent)
         self.versionLabel.setText(__version__)
+        self.logLink.setText(f"<a href='file://{LOG_DIR}'>Log</a>")
 
         for setting in SettingsModel.select().where(SettingsModel.type == 'checkbox'):
             x = filter(lambda s: s['key'] == setting.key, get_misc_settings())
@@ -36,3 +38,7 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
 
         if key == 'autostart':
             open_app_at_startup(new_value)
+
+    def set_borg_details(self, borg_details):
+        self.borgVersion.setText(borg_details['version'])
+        self.borgPath.setText(borg_details['path'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,11 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def app(tmpdir, qtbot):
+def app(tmpdir, qtbot, mocker):
     tmp_db = tmpdir.join('settings.sqlite')
     mock_db = peewee.SqliteDatabase(str(tmp_db))
     vorta.models.init_db(mock_db)
+    mocker.patch.object(vorta.application.VortaApp, 'set_borg_details_action', return_value=None)
 
     new_repo = RepoModel(url='i0fi93@i593.repo.borgbase.com:repo')
     new_repo.save()


### PR DESCRIPTION
Adds a new borg command `version` to get the path and version of the Borg binary in use. This command is run once when the application is created and then displayed in the Misc tab.

This should be useful for debugging and possibly later to account for breaking changes in Borg itself.

Last, there is now a link to the log-folder in the Misc-tab to make it easier to find.

Fixes #205, #230, #120 and possibly #121 .

<img width="804" alt="Screen Shot 2019-04-07 at 17 18 01" src="https://user-images.githubusercontent.com/3916435/55681659-8a60b380-595b-11e9-92bd-667e97afaeea.png">
