### PR TITLE
Correctly set environment encoding (pyinstaller+macOS). Fixes #220

### DIFF
--- a/vorta.spec
+++ b/vorta.spec
@@ -21,7 +21,6 @@ a = Analysis(['src/vorta/__main__.py'],
                 ('src/vorta/i18n/qm/*', 'vorta/i18n/qm'),
              ],
              hiddenimports=[
-                 'vorta.views.collection_rc',
                  'vorta.views.dark.collection_rc',
                  'vorta.views.light.collection_rc',
              ],
@@ -60,6 +59,9 @@ app = BUNDLE(exe,
                  'CFBundleVersion': '0.6.16',
                  'NSAppleEventsUsageDescription': 'Please allow',
                  'SUFeedURL': 'https://borgbase.github.io/vorta/appcast.xml',
+                 'LSEnvironment': {
+                             'LC_CTYPE': 'en_US.UTF-8'
+                         }
              })
 
 if CREATE_VORTA_DIR:


### PR DESCRIPTION
Seems like Pyinstaller doesn't look at the system encoding and falls back to `C`. I noticed this with QLocale as well. Translations still work, but the `locale.getpreferredencoding(False)` falls back to ASCII, when we need UTF-8. There is a workaround to set an env var in the bundle.

Let's see if this error also occurs with Linux binaries.

See also https://github.com/pyinstaller/pyinstaller/issues/3592#issuecomment-400229431

I'm not using the `LANG` parameter to use the correct translations. Would appreciate some testing on macOS.

Test DMG: https://files.qmax.us/vorta-0.6.16.dmg