### PR TITLE
Don't delete item from sources if item==None

### DIFF
--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -49,9 +49,9 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
 
     def source_remove(self):
         item = self.sourceFilesWidget.takeItem(self.sourceFilesWidget.currentRow())
-        db_item = SourceFileModel.get(dir=item.text())
-        db_item.delete_instance()
-        item = None
+        if item:
+            db_item = SourceFileModel.get(dir=item.text())
+            db_item.delete_instance()
 
     def save_exclude_patterns(self):
         profile = self.profile()


### PR DESCRIPTION
There's a minor bug in the the sources panel.

Clicking 'Remove' when no folders/files are selected causes vorta to crash because item is `None`