### PR TITLE
Ignore Python processes owned by other users when finding mount point

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -242,8 +242,9 @@ def get_mount_points(repo_url):
                             mount_point = proc.cmdline()[idx + 1]
                             mount_points[archive_name] = mount_point
                         break
-        except psutil.ZombieProcess:
+        except (psutil.ZombieProcess, psutil.AccessDenied):
             # Getting process details may fail (e.g. zombie process on macOS)
+            # or because the process is owned by another user.
             # Also see https://github.com/giampaolo/psutil/issues/783
             continue
 


### PR DESCRIPTION
See #273

Tested by running a Python process as root. `$ sudo python`