### PR TITLE
Avoid storing passphrase in keyring when using BORG_PASSCOMMAND

### DIFF
--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -1,4 +1,5 @@
 import re
+import os
 from PyQt5 import uic
 
 from vorta.utils import get_private_keys, get_asset, choose_file_dialog, borg_compat
@@ -113,7 +114,7 @@ class AddRepoWindow(AddRepoBase, AddRepoUI):
             return False
 
         if self.__class__ == AddRepoWindow:
-            if self.values['encryption'] != 'none':
+            if self.values['encryption'] != 'none' and not os.environ.get('BORG_PASSCOMMAND', False):
                 if len(self.values['password']) < 8:
                     self._set_status(self.tr('Please use a longer passphrase.'))
                     return False

--- a/tests/test_borg.py
+++ b/tests/test_borg.py
@@ -1,5 +1,8 @@
+import os
 import vorta.borg
 import vorta.models
+from vorta.borg.borg_thread import BorgThread
+from vorta.borg.info import BorgInfoThread
 from vorta.borg.prune import BorgPruneThread
 
 
@@ -16,3 +19,27 @@ def test_borg_prune(app, qtbot, mocker, borg_json_output):
         thread.run()
 
     assert blocker.args[0]['returncode'] == 0
+
+
+def test_borg_passcommand(app, monkeypatch):
+    dummy_borg_passcommand = 'true'
+
+    with monkeypatch.context() as m:
+        m.setattr(os, 'environ', {'BORG_PASSCOMMAND': dummy_borg_passcommand})
+        params = BorgThread.prepare(vorta.models.BackupProfileModel.select().first())
+        thread = BorgThread(['true'], params, app)
+
+        assert thread.env['BORG_PASSCOMMAND'] == dummy_borg_passcommand
+        assert 'BORG_PASSPHRASE' not in thread.env
+
+
+def test_borg_passcommand_info(app, monkeypatch):
+    dummy_borg_passcommand = 'true'
+
+    with monkeypatch.context() as m:
+        m.setattr(os, 'environ', {'BORG_PASSCOMMAND': dummy_borg_passcommand})
+        params = BorgInfoThread.prepare({'ssh_key': '', 'repo_url': '', 'password': '', 'extra_borg_arguments': ''})
+        thread = BorgInfoThread(params['cmd'], params)
+
+        assert thread.env['BORG_PASSCOMMAND'] == dummy_borg_passcommand
+        assert 'BORG_PASSPHRASE' not in thread.env

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -54,6 +54,7 @@ def test_repo_add_success(app, qtbot, mocker, borg_json_output):
     from vorta.utils import keyring
     assert keyring.get_password("vorta-repo", RepoModel.get(id=2).url) == LONG_PASSWORD
 
+
 def test_repo_add_success_with_borg_passcommand(app, qtbot, mocker, monkeypatch, borg_json_output):
 
     with monkeypatch.context() as m:
@@ -84,6 +85,7 @@ def test_repo_add_success_with_borg_passcommand(app, qtbot, mocker, monkeypatch,
 
         from vorta.utils import keyring
         assert keyring.get_password("vorta-repo", RepoModel.get(id=2).url) is None
+
 
 def test_repo_unlink(app, qtbot, monkeypatch):
     monkeypatch.setattr(QMessageBox, "exec_", lambda *args: QMessageBox.Yes)


### PR DESCRIPTION
This PR improves #288.

It prevents storing the passphrase in the keyring when adding a new repository and adds tests for using  the `BORG_PASSCOMMAND`.