### PR TITLE
Adding Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For available packages and instructions, see [INSTALL.md](https://github.com/bor
 
 ## Get in touch
 - If you have questions or simply want to talk about Vorta hit us up at [Matrix](https://matrix.to/#/#vorta:matrix.org)
-- If your questions are Borg-specific it might be advisable to join the #borgbackup IRC channel on chat.freenode.net instead (Note: borg currently requires registered nicknames). Matrix is very suitable to be used as an always-on IRC-client as explained in this [tutorial](https://gist.github.com/fstab/ce805d3001600ac147b79d413668770d).
+- If your questions are Borg-specific it might be advisable to join the #borgbackup IRC channel on chat.freenode.net instead. Matrix is very suitable to be used as an always-on IRC-client, simply [register/identify to NickServ](https://github.com/matrix-org/matrix-appservice-irc/wiki/End-user-FAQ#how-do-i-registeridentify-to-nickserv) and then join the room `#freenode_#borgbackup:matrix.org`.
 
 ## License and Credits
 - Thank you to all the people who already contributed to Vorta: [code](https://github.com/borgbase/vorta/graphs/contributors), [translations](https://github.com/borgbase/vorta/issues/159)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For available packages and instructions, see [INSTALL.md](https://github.com/bor
 ## Development and Bugs
 - Report bugs and submit feature ideas by opening a new [Github issue](https://github.com/borgbase/vorta/issues/new/choose).
 - Want to contribute to Vorta? Great! See [CONTRIBUTING.md](https://github.com/borgbase/vorta/blob/master/CONTRIBUTING.md)
+- Get in touch with us via [Matrix](https://matrix.to/#/#vorta:matrix.org)
 
 ## License and Credits
 - Thank you to all the people who already contributed to Vorta: [code](https://github.com/borgbase/vorta/graphs/contributors), [translations](https://github.com/borgbase/vorta/issues/159)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ For available packages and instructions, see [INSTALL.md](https://github.com/bor
 ## Development and Bugs
 - Report bugs and submit feature ideas by opening a new [Github issue](https://github.com/borgbase/vorta/issues/new/choose).
 - Want to contribute to Vorta? Great! See [CONTRIBUTING.md](https://github.com/borgbase/vorta/blob/master/CONTRIBUTING.md)
-- Get in touch with us via [Matrix](https://matrix.to/#/#vorta:matrix.org)
+
+## Get in touch
+- If you have questions or simply want to talk about Vorta hit us up at [Matrix](https://matrix.to/#/#vorta:matrix.org)
+- If your questions are Borg-specific it might be advisable to join the #borgbackup IRC channel on chat.freenode.net instead (Note: borg currently requires registered nicknames). Matrix is very suitable to be used as an always-on IRC-client as explained in this [tutorial](https://gist.github.com/fstab/ce805d3001600ac147b79d413668770d).
 
 ## License and Credits
 - Thank you to all the people who already contributed to Vorta: [code](https://github.com/borgbase/vorta/graphs/contributors), [translations](https://github.com/borgbase/vorta/issues/159)


### PR DESCRIPTION
I would like to propose to add a Vorta-specific chat rooms.
Benefits should be clear: Discussing stuff which does not belong in a chat room, support, attract beta testers,...

Why Matrix?

It seems like the most popular chat protocol for open source projects is IRC, but it is not beginner-friendly and you have to be online to receive messages.
Matrix is as easy to use as modern messengers (similar to Slack), supports all operating systems (including iOS and Android), it offers a web client and if there are too many people who miss IRC: Matrix also offers an IRC Bridge. 

I already created a room for this purpose.

I noticed that especially GNOME projects are moving to Matrix (https://wiki.gnome.org/Initiatives/Matrix), I am not sure about other projects.