### PR TITLE
Bugfix for handling 0 byte modification in diff view

### DIFF
--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -44,7 +44,7 @@ class DiffResult(DiffResultBase, DiffResultUI):
                 unit = line_splitted[1]
                 # If present remove '+' or '-' sign at the front
                 if '+' in size or '-' in size:
-                    size = size[1:]   
+                    size = size[1:]
 
             if line_splitted[0].startswith("["):
                 size = 0

--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -40,9 +40,11 @@ class DiffResult(DiffResultBase, DiffResultUI):
                 unit = line_splitted[2]
             else:
                 change_type = "modified"
-                # Remove '+' or '-' sign at the front
-                size = line_splitted[0][1:]
+                size = line_splitted[0]
                 unit = line_splitted[1]
+                # If present remove '+' or '-' sign at the front
+                if '+' in size or '-' in size:
+                    size = size[1:]   
 
             if line_splitted[0].startswith("["):
                 size = 0


### PR DESCRIPTION
I encountered an exception being thrown when viewing diff of two archives.

The exception was
'''
vorta/views/diff_result.py", line 52, in parse_line
    size = int(size)
ValueError: invalid literal for int() with base 10: ''
'''

which was caused by diff line:

'''
0 B   -2.6 kB home/philroche/.config/google-chrome/Profile 1/QuotaManager-journal
'''

This commit fixes the issue by only stripping +/- from string if they exist.