### PR TITLE
Improve checks for +/- in diff line

### DIFF
--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -43,7 +43,7 @@ class DiffResult(DiffResultBase, DiffResultUI):
                 size = line_splitted[0]
                 unit = line_splitted[1]
                 # If present remove '+' or '-' sign at the front
-                if '+' in size or '-' in size:
+                if size[0] in ('+', '-'):
                     size = size[1:]
 
             if line_splitted[0].startswith("["):


### PR DESCRIPTION
There could exist a scenario when a +/- would be not at the start of the string.
Current code would fail in this case.

Instead we should check that the first character of the string is +/-.

This following on from PR # 356 https://github.com/borgbase/vorta/pull/356