### PR TITLE
Enable sorting of archive table columns (#349)

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -59,6 +59,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.archiveTable.setAlternatingRowColors(True)
         self.archiveTable.cellDoubleClicked.connect(self.cell_double_clicked)
         self.archiveTable.itemSelectionChanged.connect(self.update_mount_button_text)
+        self.archiveTable.setSortingEnabled(True)
 
         self.mountButton.clicked.connect(self.mount_action)
         self.listButton.clicked.connect(self.list_action)


### PR DESCRIPTION
This enables column sorting for the table on the archive list page.
However, all columns are sorted by lexical string order. For example,
this means that archives with "52 MB" are ranked greater than "332 MB".

I wasn't able to figure out how to implement custom sorting behaviors. I did a fair amount of research and it doesn't look like PyQt supports this feature.

Completes: https://github.com/borgbase/vorta/issues/349