### PR TITLE
Don't refresh after profile change anymore

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -99,7 +99,6 @@ class MainWindow(MainWindowBase, MainWindowUI):
     def profile_select_action(self, index):
         self.current_profile = BackupProfileModel.get(id=self.profileSelector.currentData())
         self.archiveTab.populate_from_profile()
-        self.archiveTab.list_action()
         self.repoTab.populate_from_profile()
         self.sourceTab.populate_from_profile()
         self.scheduleTab.populate_from_profile()


### PR DESCRIPTION
I actually wanted to package this with some error handling, but I now realise that this does not make sense without implementing error handling in general (see https://github.com/borgbase/vorta/issues/374).
Therefore this PR only removes the refresh after a profile change, which I found quite convenient but caused problems for @m3nu. 