### PR TITLE
New trigger for everyday backup irrespective of actual time

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
   psutil
   qdarkstyle
   setuptools
+  sqlalchemy
   secretstorage; sys_platform != 'darwin'
   pyobjc-core; sys_platform == 'darwin'
   pyobjc-framework-Cocoa; sys_platform == 'darwin'

--- a/src/vorta/__main__.py
+++ b/src/vorta/__main__.py
@@ -4,7 +4,7 @@ import sys
 
 import peewee
 from vorta._version import __version__
-from vorta.config import SETTINGS_DIR
+from vorta.config import DB_PATH
 from vorta.log import init_logger
 from vorta.models import init_db
 from vorta.updater import get_updater
@@ -32,7 +32,7 @@ def main():
     init_logger(foreground=want_foreground)
 
     # Init database
-    sqlite_db = peewee.SqliteDatabase(os.path.join(SETTINGS_DIR, 'settings.db'))
+    sqlite_db = peewee.SqliteDatabase(DB_PATH)
     init_db(sqlite_db)
 
     # Init app after database is available

--- a/src/vorta/assets/UI/scheduletab.ui
+++ b/src/vorta/assets/UI/scheduletab.ui
@@ -31,15 +31,15 @@ font-weight: bold;
 }</string>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="schedule">
       <property name="geometry">
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>663</width>
-        <height>354</height>
+        <width>669</width>
+        <height>361</height>
        </rect>
       </property>
       <property name="font">
@@ -82,6 +82,30 @@ font-weight: bold;
             <string>Backup manually</string>
            </property>
           </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QRadioButton" name="scheduleEverydayRadio">
+           <property name="text">
+            <string>Backup everyday</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -364,8 +388,8 @@ font-weight: bold;
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>663</width>
-        <height>354</height>
+        <width>669</width>
+        <height>361</height>
        </rect>
       </property>
       <attribute name="icon">
@@ -396,8 +420,8 @@ font-weight: bold;
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>663</width>
-        <height>354</height>
+        <width>669</width>
+        <height>361</height>
        </rect>
       </property>
       <attribute name="icon">
@@ -461,8 +485,8 @@ font-weight: bold;
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>663</width>
-        <height>354</height>
+        <width>669</width>
+        <height>361</height>
        </rect>
       </property>
       <attribute name="icon">

--- a/src/vorta/config.py
+++ b/src/vorta/config.py
@@ -7,6 +7,7 @@ dirs = appdirs.AppDirs(APP_NAME, APP_AUTHOR)
 SETTINGS_DIR = dirs.user_data_dir
 LOG_DIR = dirs.user_log_dir
 STATE_DIR = dirs.user_state_dir
+DB_PATH = os.path.join(SETTINGS_DIR, 'settings.db')
 
 if not os.path.exists(SETTINGS_DIR):
     os.makedirs(SETTINGS_DIR)

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -2,7 +2,7 @@ import logging
 from datetime import date, timedelta
 
 from apscheduler.schedulers.qt import QtScheduler
-from apscheduler.triggers import cron
+from apscheduler.triggers import cron, interval
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from vorta.borg.check import BorgCheckThread
 from vorta.borg.create import BorgCreateThread
@@ -71,6 +71,10 @@ class VortaScheduler(QtScheduler):
                 else:
                     trigger = cron.CronTrigger(hour=f'*/{profile.schedule_interval_hours}',
                                                minute=profile.schedule_interval_minutes)
+
+            elif profile.schedule_mode == 'everyday':
+                trigger = interval.IntervalTrigger(days=1)
+
             elif profile.schedule_mode == 'fixed':
                 trigger = cron.CronTrigger(hour=profile.schedule_fixed_hour,
                                            minute=profile.schedule_fixed_minute)

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -76,6 +76,10 @@ class VortaScheduler(QtScheduler):
         # filter out retry jobs so other parts of the code don't hiccup
         return [job for job in super().get_jobs() if self.is_regular_job(job.id)]
 
+    def get_retry_job(self, job_id):
+        retry_job_id = f'retry_{job_id}'
+        return self.get_job(retry_job_id)
+
     def retry_job(self, job_id, *args, **kwargs):
         job = self.get_job(f'{job_id}')
         if job is None:
@@ -172,7 +176,7 @@ class VortaScheduler(QtScheduler):
 
     def next_job_for_profile(self, profile_id):
         self.wakeup()
-        job = self.get_job(str(profile_id))
+        job = self.get_retry_job(str(profile_id)) or self.get_job(str(profile_id))
         if job is None:
             return self.tr('None scheduled')
         else:

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -95,7 +95,7 @@ class VortaScheduler(QtScheduler):
             args=[int(job_id)],
             trigger=trig,
             id=f"retry_{job_id}",
-            misfire_grace_time=180,
+            misfire_grace_time=None,
             coalesce=True,
             replace_existing=True,
         )
@@ -146,7 +146,7 @@ class VortaScheduler(QtScheduler):
                     args=[profile.id],
                     trigger=trigger,
                     id=job_id,
-                    misfire_grace_time=180,
+                    misfire_grace_time=None,
                     coalesce=True,
                     replace_existing=True,
                 )

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -22,8 +22,9 @@ class VortaScheduler(QtScheduler):
         self.start()
         self.reload()
 
-    def tr(self, *args, **kwargs):
-        scope = self.__class__.__name__
+    @classmethod
+    def tr(cls, *args, **kwargs):
+        scope = cls.__class__.__name__
         return translate(scope, *args, **kwargs)
 
     def reload(self):
@@ -90,13 +91,14 @@ class VortaScheduler(QtScheduler):
         else:
             return job.next_run_time.strftime('%Y-%m-%d %H:%M')
 
-    def create_backup(self, profile_id):
+    @classmethod
+    def create_backup(cls, profile_id):
         notifier = VortaNotifications.pick()
         profile = BackupProfileModel.get(id=profile_id)
 
         logger.info('Starting background backup for %s', profile.name)
-        notifier.deliver(self.tr('Vorta Backup'),
-                         self.tr('Starting background backup for %s.') % profile.name,
+        notifier.deliver(cls.tr('Vorta Backup'),
+                         cls.tr('Starting background backup for %s.') % profile.name,
                          level='info')
 
         msg = BorgCreateThread.prepare(profile)
@@ -106,20 +108,21 @@ class VortaScheduler(QtScheduler):
             thread.start()
             thread.wait()
             if thread.process.returncode in [0, 1]:
-                notifier.deliver(self.tr('Vorta Backup'),
-                                 self.tr('Backup successful for %s.') % profile.name,
+                notifier.deliver(cls.tr('Vorta Backup'),
+                                 cls.tr('Backup successful for %s.') % profile.name,
                                  level='info')
                 logger.info('Backup creation successful.')
-                self.post_backup_tasks(profile_id)
+                cls.post_backup_tasks(profile_id)
             else:
-                notifier.deliver(self.tr('Vorta Backup'), self.tr('Error during backup creation.'), level='error')
+                notifier.deliver(cls.tr('Vorta Backup'), cls.tr('Error during backup creation.'), level='error')
                 logger.error('Error during backup creation.')
         else:
             logger.error('Conditions for backup not met. Aborting.')
             logger.error(msg['message'])
-            notifier.deliver(self.tr('Vorta Backup'), translate('messages', msg['message']), level='error')
+            notifier.deliver(cls.tr('Vorta Backup'), translate('messages', msg['message']), level='error')
 
-    def post_backup_tasks(self, profile_id):
+    @classmethod
+    def post_backup_tasks(cls, profile_id):
         """
         Pruning and checking after successful backup.
         """

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -18,6 +18,7 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
 
         self.schedulerRadioMapping = {
             'off': self.scheduleOffRadio,
+            'everyday': self.scheduleEverydayRadio,
             'interval': self.scheduleIntervalRadio,
             'fixed': self.scheduleFixedRadio
         }


### PR DESCRIPTION
This PR implements a new backup trigger method for relative backup intervals. The current methods require Vorta to be running at a specific time of the day which may be not an optimal schedule for non-server systems. I figured that the most useful and simple interval would be "everyday", but I'm totally open for a different scheme. It actually was the most simple solution for the UI so there's not much lost if we decide to change it. 

In order to implement this feature, I had to change how the apscheduler instance is built. In the current implementation up until now, a new instance had to be be populated with jobs assembled from the settings database at every start of Vorta. This way, apscheduler wasn't able to detect if a backup would have been triggered in the past. Now, the job schedule is persisted into a separate table in the settings database using apscheduler's persistent jobstore.  

While testing the code, I often ran into the situation that a job was triggered when Vorta started but immediately failed. This was due to a borg version check being run at the same time, blocking the backup job. Therefore, I also implemented a job retrying mechanism (see 36d6f3b). Although I didn't test it, this should also fix failing backups with multiple profiles being scheduled at the same or overlapping times.

This PR also paves the way for fixing #263 by implementing a persisted job store. The only thing left to do should be to increase `misfire_grace_time` when creating jobs.