### PR TITLE
Run in foreground by default

### DIFF
--- a/src/vorta/__main__.py
+++ b/src/vorta/__main__.py
@@ -22,8 +22,6 @@ def main():
         print(f"Vorta {__version__}")
         sys.exit()
 
-    # We assume that a frozen binary is a fat single-file binary made with
-    # PyInstaller. These are not compatible with forking into background here:
     if want_background:
         if os.fork():
             sys.exit()

--- a/src/vorta/__main__.py
+++ b/src/vorta/__main__.py
@@ -15,9 +15,8 @@ def main():
     args = parse_args()
     signal.signal(signal.SIGINT, signal.SIG_DFL)  # catch ctrl-c and exit
 
-    frozen_binary = getattr(sys, 'frozen', False)
     want_version = getattr(args, 'version', False)
-    want_foreground = getattr(args, 'foreground', False) and not getattr(args, 'daemonize', False)
+    want_background = getattr(args, 'daemonize', False)
 
     if want_version:
         print(f"Vorta {__version__}")
@@ -25,11 +24,11 @@ def main():
 
     # We assume that a frozen binary is a fat single-file binary made with
     # PyInstaller. These are not compatible with forking into background here:
-    if not (want_foreground or frozen_binary):
+    if want_background:
         if os.fork():
             sys.exit()
 
-    init_logger(foreground=want_foreground)
+    init_logger(background=want_background)
 
     # Init database
     sqlite_db = peewee.SqliteDatabase(os.path.join(SETTINGS_DIR, 'settings.db'))

--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -54,9 +54,8 @@ class VortaApp(QtSingleApplication):
             self.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
 
         args = parse_args()
-        if not (hasattr(args, 'daemonize') and args.daemonize):
-            if (hasattr(args, 'foreground') and args.foreground) or SettingsModel.get(key='foreground').value:
-                self.open_main_window_action()
+        if SettingsModel.get(key='foreground').value and not getattr(args, 'daemonize', False):
+            self.open_main_window_action()
 
         self.backup_started_event.connect(self.backup_started_event_response)
         self.backup_finished_event.connect(self.backup_finished_event_response)

--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -54,7 +54,9 @@ class VortaApp(QtSingleApplication):
             self.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
 
         args = parse_args()
-        if SettingsModel.get(key='foreground').value and not getattr(args, 'daemonize', False):
+        if getattr(args, 'daemonize', False):
+            pass
+        elif SettingsModel.get(key='foreground').value:
             self.open_main_window_action()
 
         self.backup_started_event.connect(self.backup_started_event_response)

--- a/src/vorta/log.py
+++ b/src/vorta/log.py
@@ -14,7 +14,7 @@ from .config import LOG_DIR
 logger = logging.getLogger()
 
 
-def init_logger(foreground=False):
+def init_logger(background=False):
     logger.setLevel(logging.DEBUG)
     logging.getLogger('peewee').setLevel(logging.INFO)
     logging.getLogger('apscheduler').setLevel(logging.INFO)
@@ -32,7 +32,9 @@ def init_logger(foreground=False):
     fh.setFormatter(formatter)
     logger.addHandler(fh)
 
-    if foreground:  # log to console, when running in foreground
+    if background:
+        pass
+    else:  # log to console, when running in foreground
         ch = logging.StreamHandler()
         ch.setLevel(logging.DEBUG)
         ch.setFormatter(formatter)

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -222,7 +222,7 @@ def get_misc_settings():
         {
             'key': 'foreground', 'value': False, 'type': 'checkbox',
             'label': trans_late('settings',
-                                'Run Vorta in the foreground when started manually')
+                                'Open main window on startup')
         },
     ]
     if sys.platform == 'darwin':

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -220,7 +220,7 @@ def get_misc_settings():
                                 'Automatically start Vorta at login')
         },
         {
-            'key': 'foreground', 'value': False, 'type': 'checkbox',
+            'key': 'foreground', 'value': True, 'type': 'checkbox',
             'label': trans_late('settings',
                                 'Open main window on startup')
         },
@@ -261,8 +261,6 @@ def init_db(con):
         if created and setting['key'] == "use_light_icon":
             # Check if macOS with enabled dark mode or Linux with GNOME DE
             s.value = bool(uses_dark_mode()) or 'GNOME' in os.environ.get('XDG_CURRENT_DESKTOP', '')
-        if created and setting['key'] == "foreground":
-            s.value = not bool(is_system_tray_available())
         if created and setting['key'] == "enable_notifications_success":
             s.value = not bool(is_system_tray_available())
         s.label = setting['label']

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -179,8 +179,8 @@ def parse_args():
                         action='store_true',
                         help="Show version and exit.")
     parser.add_argument('--daemonize', '-d',
-                            action='store_true',
-                            help="Fork to background and don't open window on startup.")
+                        action='store_true',
+                        help="Fork to background and don't open window on startup.")
 
     return parser.parse_known_args()[0]
 

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -178,13 +178,9 @@ def parse_args():
     parser.add_argument('--version', '-V',
                         action='store_true',
                         help="Show version and exit.")
-    parser.add_argument('--foreground', '-f',
-                        action='store_true',
-                        help="Don't fork into background and open main window on startup.")
-    if sys.platform.startswith("linux"):
-        parser.add_argument('--daemonize', '-d',
+    parser.add_argument('--daemonize', '-d',
                             action='store_true',
-                            help="Daemonize and don't open window on startup.")
+                            help="Fork to background and don't open window on startup.")
 
     return parser.parse_known_args()[0]
 


### PR DESCRIPTION
This changes the default startup behavior from forking to the background to always start in foreground unless the existing argument `--daemonize` is used. Reasons for this change:

- Forking a Python process is broken on macOS. (see [1](https://bugs.python.org/issue33725) and [2](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods)). There are rendering issues, random hangs or file access errors (seen with sqlite).
- Most uses seem to need it running in foreground: starting from Flatpak, starting from a macOS bundle, debugging.
- It removes some overly complicated startup conditions.
- There was always some confusion when users didn't see the system tray icon after starting it the first time.

Summary of changes:

- remove `--foreground` argument
- always run in foreground, unless existing `--daemonize` arg is used
- if no settings exist, open main window by default (can be changed under *Misc*)
- change description of `foreground` option to make it more clear. "Open main window on startup"
- change description of `--daemonize` arg to make it clear that the application will fork and never open a window (overrides `foreground` setting).

I hope this doesn't break anything. If there is anything else that can be simplified here, let me know.