### PR TITLE
appdata: Add money-purchasing to OARS data

### DIFF
--- a/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
+++ b/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
@@ -4,7 +4,9 @@
   <name>Vorta</name>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <content_rating type="oars-1.1"/>
+  <content_rating type="oars-1.1">
+    <content_attribute id="money-purchasing">mild</content_attribute>
+  </content_rating>
   <summary>Backup client</summary>
   <description>
     <p>


### PR DESCRIPTION
The first tab of the app contains:

> For simple and secure backup hosting, try [BorgBase]

which links to https://borgbase.com/, which advertises hosting for Borg
repositories, starting at $2/month. This nudge towards spending real
money should be reflected in the OARS data.

The “mild” level of money-purchasing is defined as:

> Mild: Users are encouraged to donate real money, e.g. using Patreon

The “intense” level is:

> Intense: Ability to spend real money in-app, e.g. buying new content or new levels

The spending of money is not in-app here, but there is some mild
encouragement.