### PR TITLE
Make Vorta icon rectangular

### DIFF
--- a/src/vorta/assets/icons/scalable/com.borgbase.Vorta.svg
+++ b/src/vorta/assets/icons/scalable/com.borgbase.Vorta.svg
@@ -1,1 +1,77 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 384"><defs><style>.cls-1{fill:#515151;}.cls-2{fill:#e65100;}.cls-3{fill:#ff9800;}</style></defs><title>vorta</title><path class="cls-1" d="M586.52,335.52v96a48,48,0,0,1-48,48h-480a48,48,0,0,1-48-48v-96a48,48,0,0,1,48-48h480A48,48,0,0,1,586.52,335.52Zm-48-80a79.47,79.47,0,0,1,30.77,6.16L472.77,116.89a48,48,0,0,0-39.94-21.37H164.2a48,48,0,0,0-39.93,21.37L27.74,261.68a79.52,79.52,0,0,1,30.78-6.16Zm-48,96a32,32,0,1,0,32,32A32,32,0,0,0,490.52,351.52Zm-96,0a32,32,0,1,0,32,32A32,32,0,0,0,394.52,351.52Z" transform="translate(-10.52 -95.52)"/><circle class="cls-2" cx="384.5" cy="288" r="32"/><circle class="cls-3" cx="480" cy="288" r="32"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="Layer_1"
+   data-name="Layer 1"
+   viewBox="0 0 576 576"
+   version="1.1"
+   sodipodi:docname="com.borgbase.Vorta.svg"
+   width="576"
+   height="576"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>vorta</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="836"
+     id="namedview15"
+     showgrid="false"
+     inkscape:zoom="0.61458333"
+     inkscape:cx="291.25424"
+     inkscape:cy="192"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#515151;}.cls-2{fill:#e65100;}.cls-3{fill:#ff9800;}</style>
+  </defs>
+  <title
+     id="title6">vorta</title>
+  <path
+     class="cls-1"
+     d="m 576,342 v 96 a 48,48 0 0 1 -48,48 H 48 A 48,48 0 0 1 0,438 v -96 a 48,48 0 0 1 48,-48 h 480 a 48,48 0 0 1 48,48 z m -48,-80 a 79.47,79.47 0 0 1 30.77,6.16 L 462.25,123.37 A 48,48 0 0 0 422.31,102 H 153.68 a 48,48 0 0 0 -39.93,21.37 L 17.22,268.16 A 79.52,79.52 0 0 1 48,262 Z m -48,96 a 32,32 0 1 0 32,32 32,32 0 0 0 -32,-32 z m -96,0 a 32,32 0 1 0 32,32 32,32 0 0 0 -32,-32 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     style="fill:#515151" />
+  <circle
+     class="cls-2"
+     cx="384.5"
+     cy="390"
+     r="32"
+     id="circle10"
+     style="fill:#e65100" />
+  <circle
+     class="cls-3"
+     cx="480"
+     cy="390"
+     r="32"
+     id="circle12"
+     style="fill:#ff9800" />
+</svg>


### PR DESCRIPTION
I tried to update the Vorta on flathub today, but noticed that with v0.6.24 the icon is stretched.
Please don't ask me why it worked until now, but by adding making the icon rectangular everything works again.

Because of that I will wait until v0.6.25 is released, before I update Vorta on flathub.