### PR TITLE
Display "NaN" if size of borgrepository is out of bounds

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -98,11 +98,17 @@ def pretty_bytes(size):
         return ''
     power = 1000  # GiB is base 2**10, GB is base 10**3.
     n = 0
-    Dic_powerN = {0: '', 1: 'K', 2: 'M', 3: 'G', 4: 'T'}
+    Dic_powerN = {0: '', 1: 'K', 2: 'M', 3: 'G'}
     while size >= power:
         size /= power
         n += 1
-    return f'{round(size, 1)} {Dic_powerN[n]}B'
+    try:
+        unit = Dic_powerN[n]
+        return f'{round(size, 1)} {unit}B'
+    except KeyError as e:
+        logger.error(e)
+        return "NaN"
+
 
 
 def get_asset(path):

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -98,7 +98,7 @@ def pretty_bytes(size):
         return ''
     power = 1000  # GiB is base 2**10, GB is base 10**3.
     n = 0
-    Dic_powerN = {0: '', 1: 'K', 2: 'M', 3: 'G'}
+    Dic_powerN = {0: '', 1: 'K', 2: 'M', 3: 'G', 4: 'T'}
     while size >= power:
         size /= power
         n += 1

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -110,7 +110,6 @@ def pretty_bytes(size):
         return "NaN"
 
 
-
 def get_asset(path):
     if getattr(sys, 'frozen', False):
         # we are running in a bundle


### PR DESCRIPTION
Fixes https://github.com/borgbase/vorta/issues/416

It just displays NaN now, instead of crashing the application completely:

![grafik](https://user-images.githubusercontent.com/5877910/78348634-aca70480-75a2-11ea-840f-64f5a0e06d9a.png)
