### PR TITLE
Avoid starting Borg thread at the end of test.

### DIFF
--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -101,12 +101,10 @@ def test_archive_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choos
     )
 
     qtbot.mouseClick(tab.mountButton, QtCore.Qt.LeftButton)
-    qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Mounted'), timeout=5000)
+    qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Mounted'), timeout=10000)
 
     qtbot.mouseClick(tab.mountButton, QtCore.Qt.LeftButton)
-    # qtbot.waitUntil(lambda: tab.mountErrors.text() == 'No active Borg mounts found.')
-
-    qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), timeout=5000)
+    qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), timeout=10000)
 
 
 def test_archive_extract(qapp, qtbot, mocker, borg_json_output, monkeypatch):
@@ -127,12 +125,11 @@ def test_archive_extract(qapp, qtbot, mocker, borg_json_output, monkeypatch):
     mocker.patch.object(vorta.borg.borg_thread, 'Popen', return_value=popen_result)
     qtbot.mouseClick(tab.extractButton, QtCore.Qt.LeftButton)
 
-    qtbot.waitUntil(lambda: hasattr(tab, '_window'), timeout=5000)
+    qtbot.waitUntil(lambda: hasattr(tab, '_window'), timeout=10000)
 
     assert tab._window.treeView.model().rootItem.childItems[0].data(0) == 'Users'
     tab._window.treeView.model().rootItem.childItems[0].load_children()
     assert tab._window.archiveNameLabel.text().startswith('test-archive, 2000')
-    tab._window.accept()
 
 
 def test_archive_diff(qapp, qtbot, mocker, borg_json_output, monkeypatch):


### PR DESCRIPTION
This fixes most of the errors. Still getting a rarer "abort" error on macOS only. Fixes #464 