### PR TITLE
Prevent the same repo from being added twice

### DIFF
--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -5,6 +5,7 @@ from vorta.utils import get_private_keys, get_asset, choose_file_dialog, borg_co
 from vorta.borg.init import BorgInitThread
 from vorta.borg.info import BorgInfoThread
 from vorta.views.utils import get_theme_class
+from vorta.models import RepoModel
 
 uifile = get_asset('UI/repoadd.ui')
 AddRepoUI, AddRepoBase = uic.loadUiType(uifile, from_imports=True, import_from=get_theme_class())
@@ -110,6 +111,10 @@ class AddRepoWindow(AddRepoBase, AddRepoUI):
         """Pre-flight check for valid input and borg binary."""
         if self.is_remote_repo and not re.match(r'.+:.+', self.values['repo_url']):
             self._set_status(self.tr('Please enter a valid repo URL or select a local path.'))
+            return False
+
+        if RepoModel.get_or_none(RepoModel.url == self.values['repo_url']) != None:
+            self._set_status(self.tr('This repo has already been added.'))
             return False
 
         if self.__class__ == AddRepoWindow:

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -113,7 +113,7 @@ class AddRepoWindow(AddRepoBase, AddRepoUI):
             self._set_status(self.tr('Please enter a valid repo URL or select a local path.'))
             return False
 
-        if RepoModel.get_or_none(RepoModel.url == self.values['repo_url']) != None:
+        if RepoModel.get_or_none(RepoModel.url == self.values['repo_url']) is not None:
             self._set_status(self.tr('This repo has already been added.'))
             return False
 

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -25,9 +25,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         self.repoSelector.addItem(self.tr('+ Initialize New Repository'), 'new')
         self.repoSelector.addItem(self.tr('+ Add Existing Repository'), 'existing')
         self.repoSelector.insertSeparator(3)
-        for repo in RepoModel.select():
-            self.repoSelector.addItem(repo.url, repo.id)
-
+        self.set_repos()
         self.repoSelector.currentIndexChanged.connect(self.repo_select_action)
         self.repoRemoveToolbutton.clicked.connect(self.repo_unlink_action)
 
@@ -58,6 +56,13 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
 
         self.init_repo_stats()
         self.populate_from_profile()
+
+    def set_repos(self):
+        count = self.repoSelector.count()
+        for x in range(4, count):
+            self.repoSelector.removeItem(4)
+        for repo in RepoModel.select():
+            self.repoSelector.addItem(repo.url, repo.id)
 
     def populate_from_profile(self):
         profile = self.profile()
@@ -170,7 +175,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
             profile.repo = new_repo.id
             profile.save()
 
-            self.repoSelector.addItem(new_repo.url, new_repo.id)
+            self.set_repos()
             self.repoSelector.setCurrentIndex(self.repoSelector.count() - 1)
             self.repo_added.emit()
             self.init_repo_stats()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -59,6 +59,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
 
     def set_repos(self):
         count = self.repoSelector.count()
+        # The repositories are listed after the 4th entry in the repoSelector
         for x in range(4, count):
             self.repoSelector.removeItem(4)
         for repo in RepoModel.select():


### PR DESCRIPTION
The change to repo_add_dialog.py adds a check in the database
to see if the repo already exists, and blocks the ui with an
error message if so.

The change to repo_tab.py refactors the selector population logic
so that the selector stays in sync with the database and doesn't
leave the entry in the UI that triggers the crash.

Fixes #473 