### PR TITLE
Add error message when Borg binary is missing. Fixes #333

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
 install_requires =
   appdirs
   paramiko
-  pyqt5
+  pyqt5 < 5.15
   peewee
   python-dateutil
   apscheduler

--- a/src/vorta/assets/UI/sourcetab.ui
+++ b/src/vorta/assets/UI/sourcetab.ui
@@ -100,7 +100,7 @@
         <string/>
        </property>
        <property name="placeholderText">
-        <string>**/.DS_Store</string>
+        <string>E.g. **/.DS_Store</string>
        </property>
       </widget>
      </item>
@@ -113,7 +113,7 @@
         </sizepolicy>
        </property>
        <property name="placeholderText">
-        <string>.nobackup</string>
+        <string>E.g. CACHE or .nobackup</string>
        </property>
       </widget>
      </item>

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -13,7 +13,7 @@ import peewee as pw
 from playhouse.migrate import SqliteMigrator, migrate
 
 from vorta.i18n import trans_late
-from vorta.utils import is_system_tray_available, slugify
+from vorta.utils import slugify
 
 SCHEMA_VERSION = 14
 

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -346,8 +346,6 @@ def init_db(con=None):
     # Create missing settings and update labels. Leave setting values untouched.
     for setting in get_misc_settings():
         s, created = SettingsModel.get_or_create(key=setting['key'], defaults=setting)
-        if created and setting['key'] == "enable_notifications_success":
-            s.value = not bool(is_system_tray_available())
         s.label = setting['label']
         s.save()
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -12,4 +12,4 @@ def test_add_folder(qapp, qtbot, tmpdir, monkeypatch, choose_file_dialog):
     tab = main.sourceTab
 
     qtbot.mouseClick(tab.sourceAddFolder, QtCore.Qt.LeftButton)
-    qtbot.waitUntil(lambda: tab.sourceFilesWidget.count() == 2)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.count() == 2, timeout=5000)


### PR DESCRIPTION
- Display a proper error message when there is an issue with the Borg binary (wrong return code, not found, ..) #333 
- Fix PyQt to versions below 5.15 for now
- Small change to file exclusion placeholder text. #314 