### PR TITLE
Notify of errors after system tray backup run. Fixes #105

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -14,6 +14,7 @@ from vorta.scheduler import VortaScheduler
 from vorta.tray_menu import TrayMenu
 from vorta.utils import borg_compat, parse_args
 from vorta.views.main_window import MainWindow
+from vorta.notifications import VortaNotifications
 
 APP_ID = os.path.join(STATE_DIR, "socket")
 
@@ -80,6 +81,8 @@ class VortaApp(QtSingleApplication):
             thread = BorgCreateThread(msg['cmd'], msg, parent=self)
             thread.start()
         else:
+            notifier = VortaNotifications.pick()
+            notifier.deliver(self.tr('Vorta Backup'), translate('messages', msg['message']), level='error')
             self.backup_log_event.emit(translate('messages', msg['message']))
 
     def open_main_window_action(self):

--- a/src/vorta/assets/UI/sourcetab.ui
+++ b/src/vorta/assets/UI/sourcetab.ui
@@ -100,7 +100,7 @@
         <string/>
        </property>
        <property name="placeholderText">
-        <string>E.g. **/.DS_Store</string>
+        <string>E.g. **/.cache</string>
        </property>
       </widget>
      </item>
@@ -113,7 +113,7 @@
         </sizepolicy>
        </property>
        <property name="placeholderText">
-        <string>E.g. CACHE or .nobackup</string>
+        <string>E.g. .nobackup</string>
        </property>
       </widget>
      </item>

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -9,8 +9,8 @@ from vorta.borg.list_repo import BorgListRepoThread
 from vorta.borg.prune import BorgPruneThread
 from vorta.i18n import translate
 
-from .models import BackupProfileModel, EventLogModel
-from .notifications import VortaNotifications
+from vorta.models import BackupProfileModel, EventLogModel
+from vorta.notifications import VortaNotifications
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
(and change example in source tab to be cross-platform: **/.cache and .nobackup)