### PR TITLE
Prevent profiles from sharing the same name

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -121,7 +121,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         window = EditProfileWindow(rename_existing_id=self.profileSelector.currentData())
         window.setParent(self, QtCore.Qt.Sheet)
         window.show()
-        if window.exec_() and window.edited_profile:
+        if window.exec_():
             self.profileSelector.setItemText(self.profileSelector.currentIndex(), window.profileNameField.text())
 
     def profile_delete_action(self):
@@ -146,7 +146,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         window = AddProfileWindow()
         window.setParent(self, QtCore.Qt.Sheet)
         window.show()
-        if window.exec_() and window.edited_profile:
+        if window.exec_():
             self.profileSelector.addItem(window.edited_profile.name, window.edited_profile.id)
             self.profileSelector.setCurrentIndex(self.profileSelector.count() - 1)
         else:

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -121,8 +121,8 @@ class MainWindow(MainWindowBase, MainWindowUI):
         window = EditProfileWindow(rename_existing_id=self.profileSelector.currentData())
         window.setParent(self, QtCore.Qt.Sheet)
         window.show()
-        if window.exec_():
-            self.profileSelector.setItemText(self.profileSelector.currentIndex(), window.edited_profile.name)
+        if window.exec_() and window.edited_profile:
+            self.profileSelector.setItemText(self.profileSelector.currentIndex(), window.profileNameField.text())
 
     def profile_delete_action(self):
         if self.profileSelector.count() > 1:

--- a/src/vorta/views/profile_add_edit_dialog.py
+++ b/src/vorta/views/profile_add_edit_dialog.py
@@ -15,6 +15,7 @@ class AddProfileWindow(AddProfileBase, AddProfileUI):
 
         self.buttonBox.rejected.connect(self.close)
         self.buttonBox.accepted.connect(self.save)
+        self.profileNameField.textChanged.connect(self.button_validation)
 
         self.buttonBox.button(QDialogButtonBox.Save).setText(self.tr("Save"))
         self.buttonBox.button(QDialogButtonBox.Cancel).setText(self.tr("Cancel"))
@@ -25,16 +26,21 @@ class AddProfileWindow(AddProfileBase, AddProfileUI):
             self.existing_id = rename_existing_id
             self.modalTitle.setText(self.tr('Rename Profile'))
 
+        # Disable button at start as name always invalid
+        self.buttonBox.button(QDialogButtonBox.Save).setEnabled(False)
+
     def _set_status(self, text):
         self.errorText.setText(text)
         self.errorText.repaint()
 
     def save(self):
-        if self.validate():
-            new_profile = BackupProfileModel(name=self.profileNameField.text())
-            new_profile.save()
-            self.edited_profile = new_profile
-            self.accept()
+        new_profile = BackupProfileModel(name=self.profileNameField.text())
+        new_profile.save()
+        self.edited_profile = new_profile
+        self.accept()
+
+    def button_validation(self):
+        self.buttonBox.button(QDialogButtonBox.Save).setEnabled(self.validate())
 
     def validate(self):
         name = self.profileNameField.text()
@@ -49,14 +55,14 @@ class AddProfileWindow(AddProfileBase, AddProfileUI):
             self._set_status(self.tr('A profile with this name already exists.'))
             return False
 
+        self._set_status(self.tr(''))
         return True
 
 
 class EditProfileWindow(AddProfileWindow):
     def save(self):
-        if self.validate():
-            renamed_profile = BackupProfileModel.get(id=self.existing_id)
-            renamed_profile.name = self.profileNameField.text()
-            renamed_profile.save()
-            self.edited_profile = renamed_profile
-            self.accept()
+        renamed_profile = BackupProfileModel.get(id=self.existing_id)
+        renamed_profile.name = self.profileNameField.text()
+        renamed_profile.save()
+        self.edited_profile = renamed_profile
+        self.accept()

--- a/src/vorta/views/profile_add_edit_dialog.py
+++ b/src/vorta/views/profile_add_edit_dialog.py
@@ -26,8 +26,8 @@ class AddProfileWindow(AddProfileBase, AddProfileUI):
             self.existing_id = rename_existing_id
             self.modalTitle.setText(self.tr('Rename Profile'))
 
-        # Disable button at start as name always invalid
-        self.buttonBox.button(QDialogButtonBox.Save).setEnabled(False)
+        # Call validate to set inital messages
+        self.buttonBox.button(QDialogButtonBox.Save).setEnabled(self.validate())
 
     def _set_status(self, text):
         self.errorText.setText(text)


### PR DESCRIPTION
My original fix for the bug is just the first commit, but I found another bug while fixing it.

The warnings for zero length or same profile name do not show up, as the save button seems to immediately close the window. My fix was to disable the save button when the profile name is invalid.

fixes #512 