### PR TITLE
Adds a checkbox for mount option override, fixes #520

### DIFF
--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -179,6 +179,16 @@
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="overrideMountOpts">
+         <property name="text">
+          <string>Override mount permissions</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="mountErrors">
          <property name="enabled">
           <bool>true</bool>

--- a/src/vorta/borg/mount.py
+++ b/src/vorta/borg/mount.py
@@ -8,7 +8,7 @@ class BorgMountThread(BorgThread):
         self.updated.emit(self.tr('Mounting archive into folder...'))
 
     @classmethod
-    def prepare(cls, profile):
+    def prepare(cls, profile, overrideMountOpts):
         ret = super().prepare(profile)
         if not ret['ok']:
             return ret
@@ -16,6 +16,9 @@ class BorgMountThread(BorgThread):
             ret['ok'] = False  # Set back to false, so we can do our own checks here.
 
         cmd = ['borg', '--log-json', 'mount', '-o', f"umask=0277,uid={os.getuid()}", f"{profile.repo.url}"]
+
+        if not overrideMountOpts:
+            del cmd[3:5]
 
         ret['ok'] = True
         ret['cmd'] = cmd

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -235,7 +235,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
 
     def mount_action(self):
         profile = self.profile()
-        params = BorgMountThread.prepare(profile)
+        params = BorgMountThread.prepare(profile, self.overrideMountOpts.isChecked())
         if not params['ok']:
             self._set_status(params['message'])
             return


### PR DESCRIPTION
There are 3 issues with this pull:
1. Adding the checkbox adds clutter to the UI
2. What should the default setting should be, as either setting can break permissions.
3. Does the average user knows what mount permissions are? Possible solution would be add a tooltip along the likes of "Toggle this if any permission denied errors pop up".
I'd like some input before going further, mostly on issue 2