### PR TITLE
Add create options

### DIFF
--- a/src/vorta/assets/UI/createtab.ui
+++ b/src/vorta/assets/UI/createtab.ui
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>791</width>
+    <height>497</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QToolBox" name="toolBox">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="createOptions">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>759</width>
+        <height>423</height>
+       </rect>
+      </property>
+      <attribute name="label">
+       <string>Create</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QCheckBox" name="checkBox">
+         <property name="text">
+          <string>Dry run</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_2">
+         <property name="text">
+          <string>No cache sync</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_4">
+         <property name="text">
+          <string>Exclude cache directories that contain a CACHEDIR.TAG</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_5">
+         <property name="text">
+          <string>Do not load or update the file metadata cache used to detect unchanged files</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_3">
+         <property name="text">
+          <string>Keep exclusion tags</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_6">
+         <property name="text">
+          <string>Stay in one file system</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_7">
+         <property name="text">
+          <string>Store only the numeric user and group identifiers</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_8">
+         <property name="text">
+          <string>Do not store file access time (atime)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_9">
+         <property name="text">
+          <string>Do not store file metadata change time (ctime)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_10">
+         <property name="text">
+          <string>Do not store file creation time</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_11">
+         <property name="text">
+          <string>Do not read and store bsdflags</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_12">
+         <property name="text">
+          <string>Ignore inode data in the file metadata cache used to detect unchanged files</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_13">
+         <property name="text">
+          <string>Backup block and char device files and files behind symlinks</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Write a checkpoint every</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="spinBox"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>seconds</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>773</width>
+        <height>417</height>
+       </rect>
+      </property>
+      <attribute name="label">
+       <string>Page 2</string>
+      </attribute>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/vorta/assets/UI/createtab.ui
+++ b/src/vorta/assets/UI/createtab.ui
@@ -15,163 +15,138 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QToolBox" name="toolBox">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="createOptions">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>759</width>
-        <height>423</height>
-       </rect>
-      </property>
-      <attribute name="label">
-       <string>Create</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QCheckBox" name="checkBox">
-         <property name="text">
-          <string>Dry run</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_2">
-         <property name="text">
-          <string>No cache sync</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_4">
-         <property name="text">
-          <string>Exclude cache directories that contain a CACHEDIR.TAG</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_5">
-         <property name="text">
-          <string>Do not load or update the file metadata cache used to detect unchanged files</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_3">
-         <property name="text">
-          <string>Keep exclusion tags</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_6">
-         <property name="text">
-          <string>Stay in one file system</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_7">
-         <property name="text">
-          <string>Store only the numeric user and group identifiers</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_8">
-         <property name="text">
-          <string>Do not store file access time (atime)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_9">
-         <property name="text">
-          <string>Do not store file metadata change time (ctime)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_10">
-         <property name="text">
-          <string>Do not store file creation time</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_11">
-         <property name="text">
-          <string>Do not read and store bsdflags</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_12">
-         <property name="text">
-          <string>Ignore inode data in the file metadata cache used to detect unchanged files</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="checkBox_13">
-         <property name="text">
-          <string>Backup block and char device files and files behind symlinks</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Write a checkpoint every</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="spinBox"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>seconds</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="page_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>773</width>
-        <height>417</height>
-       </rect>
-      </property>
-      <attribute name="label">
-       <string>Page 2</string>
-      </attribute>
-     </widget>
+    <widget class="QFrame" name="frame">
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="dryRun">
+        <property name="text">
+         <string>Dry run</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="cacheSync">
+        <property name="text">
+         <string>No cache sync</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="cacheTag">
+        <property name="text">
+         <string>Exclude cache directories that contain a CACHEDIR.TAG</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="filesCache">
+        <property name="text">
+         <string>Do not load or update the file metadata cache used to detect unchanged files</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="exclusionTags">
+        <property name="text">
+         <string>Keep exclusion tags</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="oneFS">
+        <property name="text">
+         <string>Stay in one file system</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QCheckBox" name="numericOwner">
+        <property name="text">
+         <string>Store only the numeric user and group identifiers</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="noatime">
+        <property name="text">
+         <string>Do not store file access time (atime)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QCheckBox" name="noctime">
+        <property name="text">
+         <string>Do not store file metadata change time (ctime)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QCheckBox" name="nobirthtime">
+        <property name="text">
+         <string>Do not store file creation time</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QCheckBox" name="nobsdflags">
+        <property name="text">
+         <string>Do not read and store bsdflags</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QCheckBox" name="ignoreInode">
+        <property name="text">
+         <string>Ignore inode data in the file metadata cache used to detect unchanged files</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QCheckBox" name="readSpecial">
+        <property name="text">
+         <string>Backup block and char device files and files behind symlinks</string>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Write a checkpoint every</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="checkpointInterval">
+          <property name="toolTip">
+           <string>0 disables checkpointing</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>999999999</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>seconds</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="15" column="0">
+       <widget class="QPushButton" name="saveButton">
+        <property name="text">
+         <string>Save</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/vorta/assets/UI/mainwindow.ui
+++ b/src/vorta/assets/UI/mainwindow.ui
@@ -116,7 +116,7 @@
     <item>
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>2</number>
+       <number>5</number>
       </property>
       <property name="documentMode">
        <bool>false</bool>
@@ -153,6 +153,11 @@
       <widget class="QWidget" name="miscTabSlot">
        <attribute name="title">
         <string>Misc</string>
+       </attribute>
+      </widget>
+      <widget class="QWidget" name="createTabSlot">
+       <attribute name="title">
+        <string>Create</string>
        </attribute>
       </widget>
      </widget>
@@ -289,5 +294,6 @@
    </property>
   </action>
  </widget>
+ <resources/>
  <connections/>
 </ui>

--- a/src/vorta/views/create_tab.py
+++ b/src/vorta/views/create_tab.py
@@ -1,0 +1,42 @@
+from PyQt5 import uic
+from ..utils import get_asset
+from vorta.models import RepoModel, BackupProfileMixin
+
+uifile = get_asset('UI/createtab.ui')
+CreateTabUI, CreateTabBase = uic.loadUiType(uifile)
+
+class CreateTab(CreateTabUI, CreateTabBase, BackupProfileMixin):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setupUi(parent)
+
+        self.saveButton.clicked.connect(self.testValues)
+
+    @property
+    def values(self):
+        self.buttonMapping = {
+            '--dry-run': self.dryRun,
+            '--no-cache-sync': self.cacheSync,
+            '--exclude-caches': self.cacheTag,
+            '--no-files-cache': self.filesCache,
+            '--keep-exclude-tags': self.exclusionTags,
+            '--one-file-system': self.oneFS,
+            '--numeric-owner': self.numericOwner,
+            '--noatime': self.noatime,
+            '--noctime': self.noctime,
+            '--nobirthtime': self.nobirthtime,
+            '--nobsdflags': self.nobsdflags,
+            '--ignore-inode': self.ignoreInode,
+            '--numeric-owner': self.numericOwner,
+            '--read-special': self.readSpecial
+        }
+        list = ['--checkpoint-interval', f'{self.checkpointInterval.value()}']
+        for label, obj in self.buttonMapping.items():
+            if obj.isChecked():
+                list.append(label)
+
+        return list
+
+    def testValues(self):
+        print(self.values)
+        

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -16,6 +16,7 @@ from .profile_add_edit_dialog import AddProfileWindow, EditProfileWindow
 from .repo_tab import RepoTab
 from .schedule_tab import ScheduleTab
 from .source_tab import SourceTab
+from .create_tab import CreateTab
 
 uifile = get_asset('UI/mainwindow.ui')
 MainWindowUI, MainWindowBase = uic.loadUiType(uifile)
@@ -47,6 +48,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.archiveTab = ArchiveTab(self.archiveTabSlot)
         self.scheduleTab = ScheduleTab(self.scheduleTabSlot)
         self.miscTab = MiscTab(self.miscTabSlot)
+        self.createTab = CreateTab(self.createTabSlot)
         self.miscTab.set_borg_details(borg_compat.version, borg_compat.path)
         self.tabWidget.setCurrentIndex(0)
 


### PR DESCRIPTION
I have an issue before I continue on this:
Should I create a new tab for just the options, as the putting it in the schedule tab as suggested in #274 makes the schedule tab cluttered and create options aren't really part of scheduling, but I also don't want to end up with an interface with 10 tabs

Now that I think about it, I could rename the new tab to Backup Options, and move the shell commands there as well

Looking for input, thanks

