### PR TITLE
Add disk space override button, fixes #533

### DIFF
--- a/src/vorta/assets/UI/misctab.ui
+++ b/src/vorta/assets/UI/misctab.ui
@@ -22,6 +22,16 @@
      <property name="topMargin">
       <number>10</number>
      </property>
+     <item>
+      <widget class="QCheckBox" name="overrideFreeSpace">
+       <property name="toolTip">
+        <string>Does not work on remote repositories for security reasons</string>
+       </property>
+       <property name="text">
+        <string>Disable free space calculations during backup</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -36,6 +46,13 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="errorText">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/vorta/borg/config.py
+++ b/src/vorta/borg/config.py
@@ -1,0 +1,23 @@
+from .borg_thread import BorgThread
+from vorta.models import BackupProfileMixin, BackupProfileModel
+
+class BorgConfigThread(BorgThread):
+    @classmethod
+    def prepare(cls, profile, values):
+        ret = super().prepare(profile)
+        if not ret['ok']:
+            return ret
+        else:
+            ret['ok'] = False  # Set back to false, so we can do our own checks here.
+
+        cmd = ['borg', 'config', '--info', '--log-json']
+        cmd.append(f'{profile.repo.url}')
+        cmd.extend(values)
+
+        ret['ok'] = True
+        ret['cmd'] = cmd
+
+        return ret
+
+    def process_result(self, result):
+        return result['cmd']

--- a/src/vorta/borg/config.py
+++ b/src/vorta/borg/config.py
@@ -1,6 +1,7 @@
 from .borg_thread import BorgThread
 from vorta.models import BackupProfileMixin, BackupProfileModel
 
+
 class BorgConfigThread(BorgThread):
     @classmethod
     def prepare(cls, profile, values):

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -72,7 +72,7 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
         params = BorgConfigThread.prepare(self.profile(), values)
         if params['ok']:
             thread = BorgConfigThread(params['cmd'], params, parent=self)
-            if len(values) % 2 == 1:  # To check if its getting the value
+            if len(values) == 1:  # To check if its getting the value
                 thread.result.connect(self.set_checkbox_state)
             self.thread = thread  # Needs to be connected to self for tests to work.
             self.thread.start()


### PR DESCRIPTION
Since configuration is stored on a per-repository basis, I had to use a different method of saving and loading the config options. I think the way this is the best option to do it, other than reading and parsing the raw config text. 

I had to exclude the config thread as it has to load the state on startup, otherwise Vorta thinks a backup is running when its not.