### PR TITLE
CI Fix-Set 10 minute test job time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently workflows can run for 6 hours before automatically being stopped. 
There is a limit of 5 macOS jobs at a time, while each action runs 3 macOS jobs, meaning that 2 mistakes can block macOS jobs for 6 hours. (I'm surprised no one else has done a similar thing before)
~~This wastes 360 minutes of run time while there are only 2000 minutes per month of time (I assume this is using the free plan).~~

For example, I accidentally pushed 3 infinite loops:
https://github.com/borgbase/vorta/actions/runs/174077306
https://github.com/borgbase/vorta/actions/runs/174058136
https://github.com/borgbase/vorta/actions/runs/174054779

~~Since the timeout is so high, I will end up wasting 1080 minutes of run time, while with this change I would have wasted only 30.~~

10 minutes is a decent compromise, as it allows for some code to be slow and for future expansion while mitigating infinite loops.