### PR TITLE
Refactor Linux autostart

### DIFF
--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -42,7 +42,8 @@ def open_app_at_startup(enabled=True):
         if is_flatpak:
             autostart_path = Path.home() / '.config' / 'autostart'
         else:
-            autostart_path = Path(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config/autostart'))
+            autostart_path = Path(os.environ.get(
+                "XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config') + "/autostart")
 
         if not autostart_path.exists():
             autostart_path.mkdir()

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -51,7 +51,7 @@ def open_app_at_startup(enabled=True):
         autostart_file_path = autostart_path / 'vorta.desktop'
 
         if enabled:
-            # Replace to start in background and for flatpak if appropriate
+            # Replace to for flatpak if appropriate and start in background
             desktop_file_text = desktop_file_text.replace(
                 "Exec=vorta", "Exec=flatpak run com.borgbase.Vorta --daemonize" if is_flatpak
                 else "Exec=vorta --daemonize")

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -1,19 +1,10 @@
 import sys
+import os
 from pathlib import Path
 
-LINUX_STARTUP_FILE = """\
-[Desktop Entry]
-Name=Vorta
-GenericName=Backup Software
-Exec={} --daemonize
-Terminal=false
-Icon=com.borgbase.Vorta
-Categories=Utility
-Type=Application
-StartupNotify=false
+AUTOSTART_DELAY = """StartupNotify=false
 X-GNOME-Autostart-enabled=true
-X-GNOME-Autostart-Delay=20
-"""
+X-GNOME-Autostart-Delay=20"""
 
 
 def open_app_at_startup(enabled=True):
@@ -42,7 +33,16 @@ def open_app_at_startup(enabled=True):
             LSSharedFileListItemRemove(login_items, new_item)
 
     elif sys.platform.startswith('linux'):
-        autostart_path = Path.home() / '.config' / 'autostart'
+        is_flatpak = Path('/.flatpak-info').exists()
+
+        desktop_file_text = open(os.path.join(os.path.dirname(
+            __file__), "assets/metadata/com.borgbase.Vorta.desktop")).read()
+
+        # Find XDG_CONFIG_HOME unless when running in flatpak
+        if is_flatpak:
+            autostart_path = Path.home() / '.config' / 'autostart'
+        else:
+            autostart_path = Path(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~") + '.config/autostart'))
 
         if not autostart_path.exists():
             autostart_path.mkdir()
@@ -50,12 +50,13 @@ def open_app_at_startup(enabled=True):
         autostart_file_path = autostart_path / 'vorta.desktop'
 
         if enabled:
-            if Path('/.flatpak-info').exists():
-                # Vorta runs as flatpak
-                autostart_file_path.write_text(LINUX_STARTUP_FILE.format('flatpak run com.borgbase.Vorta'))
-            else:
-                autostart_file_path.write_text(LINUX_STARTUP_FILE.format('vorta'))
+            # Replace to start in background and for flatpak if appropriate
+            desktop_file_text = desktop_file_text.replace(
+                "Exec=vorta", "Exec=flatpak run com.borgbase.Vorta --daemonize" if is_flatpak else "Exec=vorta --daemonize")
+            # Add autostart delay
+            desktop_file_text += (AUTOSTART_DELAY)
 
+            autostart_file_path.write_text(desktop_file_text)
         else:
             if autostart_file_path.exists():
                 autostart_file_path.unlink()

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -42,7 +42,7 @@ def open_app_at_startup(enabled=True):
         if is_flatpak:
             autostart_path = Path.home() / '.config' / 'autostart'
         else:
-            autostart_path = Path(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~") + '.config/autostart'))
+            autostart_path = Path(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config/autostart'))
 
         if not autostart_path.exists():
             autostart_path.mkdir()
@@ -52,7 +52,8 @@ def open_app_at_startup(enabled=True):
         if enabled:
             # Replace to start in background and for flatpak if appropriate
             desktop_file_text = desktop_file_text.replace(
-                "Exec=vorta", "Exec=flatpak run com.borgbase.Vorta --daemonize" if is_flatpak else "Exec=vorta --daemonize")
+                "Exec=vorta", "Exec=flatpak run com.borgbase.Vorta --daemonize" if is_flatpak
+                else "Exec=vorta --daemonize")
             # Add autostart delay
             desktop_file_text += (AUTOSTART_DELAY)
 

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -35,30 +35,31 @@ def open_app_at_startup(enabled=True):
     elif sys.platform.startswith('linux'):
         is_flatpak = Path('/.flatpak-info').exists()
 
-        desktop_file_text = open(os.path.join(os.path.dirname(
-            __file__), "assets/metadata/com.borgbase.Vorta.desktop")).read()
+        with open(os.path.join(os.path.dirname(__file__),
+                               "assets/metadata/com.borgbase.Vorta.desktop")) as desktop_file:
+            desktop_file_text = desktop_file.read()
 
-        # Find XDG_CONFIG_HOME unless when running in flatpak
-        if is_flatpak:
-            autostart_path = Path.home() / '.config' / 'autostart'
-        else:
-            autostart_path = Path(os.environ.get(
-                "XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config') + "/autostart")
+            # Find XDG_CONFIG_HOME unless when running in flatpak
+            if is_flatpak:
+                autostart_path = Path.home() / '.config' / 'autostart'
+            else:
+                autostart_path = Path(os.environ.get(
+                    "XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config') + "/autostart")
 
-        if not autostart_path.exists():
-            autostart_path.mkdir()
+            if not autostart_path.exists():
+                autostart_path.mkdir()
 
-        autostart_file_path = autostart_path / 'vorta.desktop'
+            autostart_file_path = autostart_path / 'vorta.desktop'
 
-        if enabled:
-            # Replace to for flatpak if appropriate and start in background
-            desktop_file_text = desktop_file_text.replace(
-                "Exec=vorta", "Exec=flatpak run com.borgbase.Vorta --daemonize" if is_flatpak
-                else "Exec=vorta --daemonize")
-            # Add autostart delay
-            desktop_file_text += (AUTOSTART_DELAY)
+            if enabled:
+                # Replace to for flatpak if appropriate and start in background
+                desktop_file_text = desktop_file_text.replace(
+                    "Exec=vorta", "Exec=flatpak run com.borgbase.Vorta --daemonize" if is_flatpak
+                    else "Exec=vorta --daemonize")
+                # Add autostart delay
+                desktop_file_text += (AUTOSTART_DELAY)
 
-            autostart_file_path.write_text(desktop_file_text)
-        else:
-            if autostart_file_path.exists():
-                autostart_file_path.unlink()
+                autostart_file_path.write_text(desktop_file_text)
+            else:
+                if autostart_file_path.exists():
+                    autostart_file_path.unlink()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -15,8 +15,8 @@ def test_autostart(qapp, qtbot):
         checkbox = tab.checkboxLayout.itemAt(x).widget()
         checkbox.__class__ = QCheckBox
         if checkbox.text().startswith("Automatically"):
-           if checkbox.isChecked():
-               qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
+            if checkbox.isChecked():
+                qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
             qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
             break
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -15,6 +15,8 @@ def test_autostart(qapp, qtbot):
         checkbox = tab.checkboxLayout.itemAt(x).widget()
         checkbox.__class__ = QCheckBox
         if checkbox.text().startswith("Automatically"):
+           if checkbox.isChecked():
+               qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
             qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
             break
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -16,14 +16,14 @@ def test_autostart(qapp, qtbot):
         checkbox = tab.checkboxLayout.itemAt(x).widget()
         checkbox.__class__ = QCheckBox
         if checkbox.text().startswith("Automatically"):
-            if checkbox.isChecked():
-                qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
-            qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
+            # Have to use pos to click checkbox correctly
+            # https://stackoverflow.com/questions/19418125/pysides-qtest-not-checking-box/24070484#24070484
+            qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton, pos=QtCore.QPoint(2, checkbox.height() / 2))
             break
 
     autostart_path = Path(os.environ.get(
         "XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config') + "/autostart") / "vorta.desktop"
-    assert(autostart_path.exists())
+    qtbot.waitUntil(lambda: autostart_path.exists(), timeout=5000)
 
     with open(autostart_path) as desktop_file:
         desktop_file_text = desktop_file.read()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,9 +13,7 @@ def test_autostart(qapp, qtbot):
 
     for x in range(0, tab.checkboxLayout.count()):
         checkbox = tab.checkboxLayout.itemAt(x).widget()
-        print(checkbox)
         checkbox.__class__ = QCheckBox
-        print(checkbox)
         if checkbox.text().startswith("Automatically"):
             qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
             break

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,6 +2,7 @@ from PyQt5 import QtCore
 from PyQt5.QtWidgets import QCheckBox
 from pathlib import Path
 import pytest
+import os
 import sys
 
 
@@ -20,7 +21,8 @@ def test_autostart(qapp, qtbot):
             qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
             break
 
-    autostart_path = Path.home() / ".config" / "autostart" / "vorta.desktop"
+    autostart_path = Path(os.environ.get(
+        "XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config') + "/autostart") / "vorta.desktop"
     assert(autostart_path.exists())
 
     with open(autostart_path) as desktop_file:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,29 @@
+from PyQt5 import QtCore
+from PyQt5.QtWidgets import QCheckBox
+from pathlib import Path
+import pytest
+import sys
+
+
+@pytest.mark.skipif(sys.platform != 'linux', reason="Autostart files only generated in Linux")
+def test_autostart(qapp, qtbot):
+    main = qapp.main_window
+    main.tabWidget.setCurrentIndex(4)
+    tab = main.miscTab
+
+    for x in range(0, tab.checkboxLayout.count()):
+        checkbox = tab.checkboxLayout.itemAt(x).widget()
+        print(checkbox)
+        checkbox.__class__ = QCheckBox
+        print(checkbox)
+        if checkbox.text().startswith("Automatically"):
+            qtbot.mouseClick(checkbox, QtCore.Qt.LeftButton)
+            break
+
+    autostart_path = Path.home() / ".config" / "autostart" / "vorta.desktop"
+    assert(autostart_path.exists())
+
+    with open(autostart_path) as desktop_file:
+        desktop_file_text = desktop_file.read()
+
+        assert(desktop_file_text.startswith("[Desktop Entry]"))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,7 +7,7 @@ import sys
 
 
 @pytest.mark.skipif(sys.platform != 'linux', reason="Autostart files only generated in Linux")
-def test_autostart(qapp, qtbot):
+def test_linux_autostart(qapp, qtbot):
     main = qapp.main_window
     main.tabWidget.setCurrentIndex(4)
     tab = main.miscTab


### PR DESCRIPTION
Changed it so it reads the desktop file in src/assets/metadata instead of hardcoding it. It also uses XDG_CONFIG_HOME for non-flatpak installs (Can't do in flatpak since it gets overridden). 
Also added a test, it might break in the future since clicking qcheckboxes is weird. 