### PR TITLE
Cant pass None to QLocale any more. Will result in loading "C" locale.

### DIFF
--- a/src/vorta/i18n/__init__.py
+++ b/src/vorta/i18n/__init__.py
@@ -60,7 +60,7 @@ def init_translations(app):
         locale = QLocale(env_lang)
     else:
         locale = QLocale()
-    
+
     qm_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'qm'))
     ui_langs = locale.uiLanguages()
     succeeded = translator.load(locale, 'vorta', prefix='.', directory=qm_path)  # e.g. vorta/i18n/qm/vorta.de_DE.qm

--- a/src/vorta/i18n/__init__.py
+++ b/src/vorta/i18n/__init__.py
@@ -54,7 +54,13 @@ def init_translations(app):
     application = app
     translator = QTranslator() if trans_scale == 100 else VortaTranslator()
 
-    locale = QLocale(os.environ.get('LANG', None))
+    # Use LANG var if set, else let Qt detect it.
+    env_lang = os.environ.get('LANG', False)
+    if env_lang:
+        locale = QLocale(env_lang)
+    else:
+        locale = QLocale()
+    
     qm_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'qm'))
     ui_langs = locale.uiLanguages()
     succeeded = translator.load(locale, 'vorta', prefix='.', directory=qm_path)  # e.g. vorta/i18n/qm/vorta.de_DE.qm


### PR DESCRIPTION
Sometimes we use the LANG env var to set the UI language. Previously QLocale would auto-detect the language when receiving None (LANG var not set). This doesn't work any more. So do a check if LANG is set and then let Qt detect it.

Reported by user Moritz M.