### PR TITLE
Add @samuel-w as contributor and maintainer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,12 @@ The following authors made major code contributions to Vorta source code:
 - Numerous incremental features
 - Maintainer
 
+### [Samuel Woon](https://github.com/samuel-w)
+- Numerous incremental fixes and features
+- Manage issues
+- Maintainer
+
+
 ### Others
 For other contributors, see [here](https://github.com/borgbase/vorta/graphs/contributors).
 


### PR DESCRIPTION
With @samuel-w very active recently, I suggest to formalize his project contributions by adding him as maintainer with equivalent permissions. While his PRs have often benefitted from constructive feedback, he is also very receptive to the same, which I find more important than providing a perfect PR from the start. So everyone, please continue offering guidance to him.

Furthermore, I suggest adding @ThomasWaldmann as second project admin in the interest of redundancy, should I get hit by a bus.😵