### PR TITLE
Display progress information

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -31,6 +31,7 @@ class VortaApp(QtSingleApplication):
     backup_finished_event = QtCore.pyqtSignal(dict)
     backup_cancelled_event = QtCore.pyqtSignal()
     backup_log_event = QtCore.pyqtSignal(str)
+    backup_progress_event = QtCore.pyqtSignal(int, str)
 
     def __init__(self, args_raw, single_app=False):
 

--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -31,7 +31,7 @@ class VortaApp(QtSingleApplication):
     backup_finished_event = QtCore.pyqtSignal(dict)
     backup_cancelled_event = QtCore.pyqtSignal()
     backup_log_event = QtCore.pyqtSignal(str)
-    backup_progress_event = QtCore.pyqtSignal(int, str)
+    backup_progress_event = QtCore.pyqtSignal(str)
 
     def __init__(self, args_raw, single_app=False):
 

--- a/src/vorta/assets/UI/mainwindow.ui
+++ b/src/vorta/assets/UI/mainwindow.ui
@@ -258,6 +258,9 @@
         <property name="textVisible">
          <bool>true</bool>
         </property>
+        <property name="format">
+         <string/>
+        </property>
        </widget>
       </item>
       <item row="0" column="0">
@@ -289,5 +292,6 @@
    </property>
   </action>
  </widget>
+ <resources/>
  <connections/>
 </ui>

--- a/src/vorta/assets/UI/mainwindow.ui
+++ b/src/vorta/assets/UI/mainwindow.ui
@@ -210,59 +210,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QProgressBar" name="createProgress">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="palette">
-         <palette>
-          <active>
-           <colorrole role="Highlight">
-            <brush brushstyle="SolidPattern">
-             <color alpha="255">
-              <red>255</red>
-              <green>151</green>
-              <blue>41</blue>
-             </color>
-            </brush>
-           </colorrole>
-          </active>
-          <inactive>
-           <colorrole role="Highlight">
-            <brush brushstyle="SolidPattern">
-             <color alpha="255">
-              <red>255</red>
-              <green>151</green>
-              <blue>41</blue>
-             </color>
-            </brush>
-           </colorrole>
-          </inactive>
-          <disabled>
-           <colorrole role="Highlight">
-            <brush brushstyle="SolidPattern">
-             <color alpha="255">
-              <red>220</red>
-              <green>220</green>
-              <blue>220</blue>
-             </color>
-            </brush>
-           </colorrole>
-          </disabled>
-         </palette>
-        </property>
-        <property name="value">
-         <number>0</number>
-        </property>
-        <property name="textVisible">
-         <bool>true</bool>
-        </property>
-        <property name="format">
-         <string/>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QPushButton" name="createStartBtn">
         <property name="enabled">
@@ -273,6 +220,22 @@
         </property>
         <property name="checkable">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="createProgress">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
         </property>
        </widget>
       </item>

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -207,7 +207,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
                                 f'Deduplicated: {pretty_bytes(parsed["deduplicated_size"])}, '
                                 f'Files: {parsed["nfiles"]}'
                             )
-                            self.progress_event(0, msg)
+                            self.progress_event(msg)
                     except json.decoder.JSONDecodeError:
                         msg = line.strip()
                         if msg:  # Log only if there is something to log.
@@ -251,7 +251,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
     def log_event(self, msg):
         self.updated.emit(msg)
 
-    def progress_event(self, value, fmt):
+    def progress_event(self, msg):
         pass
 
     def started_event(self):

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -37,6 +37,9 @@ class BorgCreateThread(BorgThread):
     def log_event(self, msg):
         self.app.backup_log_event.emit(msg)
 
+    def progress_event(self, value, fmt):
+        self.app.backup_progress_event.emit(value, fmt)
+
     def started_event(self):
         self.app.backup_started_event.emit()
         self.app.backup_log_event.emit(self.tr('Backup started.'))
@@ -113,7 +116,7 @@ class BorgCreateThread(BorgThread):
             ret['message'] = trans_late('messages', 'Your current Borg version does not support ZStd compression.')
             return ret
 
-        cmd = ['borg', 'create', '--list', '--info', '--log-json', '--json', '--filter=AM', '-C', profile.compression]
+        cmd = ['borg', 'create', '--list', '--progress', '--info', '--log-json', '--json', '--filter=AM', '-C', profile.compression]
 
         # Add excludes
         # Partly inspired by borgmatic/borgmatic/borg/create.py

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -37,8 +37,8 @@ class BorgCreateThread(BorgThread):
     def log_event(self, msg):
         self.app.backup_log_event.emit(msg)
 
-    def progress_event(self, value, fmt):
-        self.app.backup_progress_event.emit(value, fmt)
+    def progress_event(self, msg):
+        self.app.backup_progress_event.emit(msg)
 
     def started_event(self):
         self.app.backup_started_event.emit()

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -116,7 +116,18 @@ class BorgCreateThread(BorgThread):
             ret['message'] = trans_late('messages', 'Your current Borg version does not support ZStd compression.')
             return ret
 
-        cmd = ['borg', 'create', '--list', '--progress', '--info', '--log-json', '--json', '--filter=AM', '-C', profile.compression]
+        cmd = [
+            'borg',
+            'create',
+            '--list',
+            '--progress',
+            '--info',
+            '--log-json',
+            '--json',
+            '--filter=AM',
+            '-C',
+            profile.compression,
+        ]
 
         # Add excludes
         # Partly inspired by borgmatic/borgmatic/borg/create.py

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -86,7 +86,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         if BorgThread.is_running():
             self.createStartBtn.setEnabled(False)
             self.cancelButton.setEnabled(True)
-            self.set_status(self.tr('Backup in progress.'), progress_max=0)
+            self.set_status(self.tr('Backup in progress.'))
 
         self.set_icons()
 

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -107,7 +107,6 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.createProgress.setValue(value)
         self.createProgress.repaint()
 
-
     def _toggle_buttons(self, create_enabled=True):
         self.createStartBtn.setEnabled(create_enabled)
         self.createStartBtn.repaint()

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -61,6 +61,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.app.backup_started_event.connect(self.backup_started_event)
         self.app.backup_finished_event.connect(self.backup_finished_event)
         self.app.backup_log_event.connect(self.set_status)
+        self.app.backup_progress_event.connect(self.set_progress)
         self.app.backup_cancelled_event.connect(self.backup_cancelled_event)
 
         # Init profile list
@@ -97,12 +98,15 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.profileRenameButton.setIcon(get_colored_icon('edit'))
         self.profileDeleteButton.setIcon(get_colored_icon('trash'))
 
-    def set_status(self, text=None, progress_max=None):
-        if text:
-            self.createProgressText.setText(text)
-        if progress_max is not None:
-            self.createProgress.setRange(0, progress_max)
+    def set_status(self, text):
+        self.createProgressText.setText(text)
         self.createProgressText.repaint()
+
+    def set_progress(self, value=0, fmt=''):
+        self.createProgress.setFormat(self.tr(fmt))
+        self.createProgress.setValue(value)
+        self.createProgress.repaint()
+
 
     def _toggle_buttons(self, create_enabled=True):
         self.createStartBtn.setEnabled(create_enabled)
@@ -156,19 +160,19 @@ class MainWindow(MainWindowBase, MainWindowUI):
             self.profileSelector.setCurrentIndex(self.profileSelector.currentIndex())
 
     def backup_started_event(self):
-        self.set_status(progress_max=0)
+        self.set_progress()
         self._toggle_buttons(create_enabled=False)
 
     def backup_finished_event(self):
-        self.set_status(progress_max=100)
+        self.set_progress()
         self._toggle_buttons(create_enabled=True)
         self.archiveTab.populate_from_profile()
         self.repoTab.init_repo_stats()
 
     def backup_cancelled_event(self):
         self._toggle_buttons(create_enabled=True)
-        self.set_status(progress_max=100)
         self.set_status(self.tr('Task cancelled'))
+        self.set_progress()
 
     def closeEvent(self, event):
         # Save window state in SettingsModel

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -102,9 +102,8 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.createProgressText.setText(text)
         self.createProgressText.repaint()
 
-    def set_progress(self, value=0, fmt=''):
-        self.createProgress.setFormat(self.tr(fmt))
-        self.createProgress.setValue(value)
+    def set_progress(self, text=''):
+        self.createProgress.setText(self.tr(text))
         self.createProgress.repaint()
 
     def _toggle_buttons(self, create_enabled=True):


### PR DESCRIPTION
An implementation of what was described in 
https://github.com/borgbase/vorta/issues/594#issuecomment-686363495

See it live
![output](https://user-images.githubusercontent.com/1709142/92154713-84a81f80-ee26-11ea-9ac6-8f563b06be36.gif)

Closes #594 

On an unrelated note: the repo stats reporting a deduplicated size larger than the compressed size contradicts a bit the information from the progress report. Is this expected?