### PR TITLE
Use naked en locale rather than en_US. Fixes #623

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ vorta.egg-info
 *.log
 htmlcov
 *.qm
-src/vorta/i18n/ts/vorta.en_US.ts
+src/vorta/i18n/ts/vorta.en.ts
 flatpak/app/
 flatpak/.flatpak-builder/
 

--- a/.tx/config
+++ b/.tx/config
@@ -4,7 +4,7 @@ host = https://www.transifex.com
 [vorta.vorta]
 file_filter = src/vorta/i18n/ts/vorta.<lang>.ts
 minimum_perc = 80
-source_file = src/vorta/i18n/ts/vorta.en_US.ts
-source_lang = en_US
+source_file = src/vorta/i18n/ts/vorta.en.ts
+source_lang = en
 type = QT
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 graft src/vorta/assets
 
-# Include all compiled .qm language files, but exclude the source language (en_US).
+# Include all compiled .qm language files, but exclude the source language (en).
 recursive-include src/vorta/i18n/qm *.qm
-exclude src/vorta/i18n/qm/vorta.en_US.qm
+exclude src/vorta/i18n/qm/vorta.en.qm
 
 recursive-exclude tests *

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ translations-from-source:  ## Extract strings from source code / UI files, merge
 	pylupdate5 -verbose -translate-function trans_late \
 			   $$VORTA_SRC/*.py $$VORTA_SRC/views/*.py $$VORTA_SRC/borg/*.py \
 			   $$VORTA_SRC/assets/UI/*.ui \
-			   -ts $$VORTA_SRC/i18n/ts/vorta.en_US.ts
+			   -ts $$VORTA_SRC/i18n/ts/vorta.en.ts
 
 translations-push: translations-from-source  ## Upload .ts to Transifex.
 	tx push -s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def local_en():
     Some tests use English strings. So override whatever language the current user
     has and run the tests with the English UI.
     """
-    os.environ['LANG'] = 'en_US'
+    os.environ['LANG'] = 'en'
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
When using English with a non-US region, our `en-US` default language file wasn't loaded.

This change renames the source language to just `en`.

See also https://doc.qt.io/qt-5/qtranslator.html#load-1