### PR TITLE
Initialize the network status monitor lazily

### DIFF
--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -4,7 +4,7 @@ from dateutil import parser
 import subprocess
 
 from vorta.i18n import trans_late
-from vorta.utils import format_archive_name, borg_compat, network_status_monitor
+from vorta.utils import format_archive_name, borg_compat, get_network_status_monitor
 from vorta.models import SourceFileModel, ArchiveModel, WifiSettingModel, RepoModel
 from .borg_thread import BorgThread
 
@@ -78,6 +78,7 @@ class BorgCreateThread(BorgThread):
             ret['message'] = trans_late('messages', 'Add some folders to back up first.')
             return ret
 
+        network_status_monitor = get_network_status_monitor()
         current_wifi = network_status_monitor.get_current_wifi()
         if current_wifi is not None:
             wifi_is_disallowed = WifiSettingModel.select().where(

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -29,10 +29,18 @@ QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)  # use highdpi i
 
 keyring = VortaKeyring.get_keyring()
 logger.info('Using %s Keyring implementation.', keyring.__class__.__name__)
-network_status_monitor = NetworkStatusMonitor.get_network_status_monitor()
-logger.info('Using %s NetworkStatusMonitor implementation.', network_status_monitor.__class__.__name__)
-
 borg_compat = BorgCompatibility()
+
+
+_network_status_monitor = None
+
+
+def get_network_status_monitor():
+    global _network_status_monitor
+    if _network_status_monitor is None:
+        _network_status_monitor = NetworkStatusMonitor.get_network_status_monitor()
+        logger.info('Using %s NetworkStatusMonitor implementation.', _network_status_monitor.__class__.__name__)
+    return _network_status_monitor
 
 
 def nested_dict():
@@ -127,7 +135,7 @@ def get_sorted_wifis(profile):
 
     from vorta.models import WifiSettingModel
 
-    system_wifis = network_status_monitor.get_known_wifis()
+    system_wifis = get_network_status_monitor().get_known_wifis()
     if system_wifis is None:
         # Don't show any networks if we can't get the current list
         return []

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -5,7 +5,7 @@ from PyQt5.QtGui import QKeySequence
 from vorta.borg.borg_thread import BorgThread
 from vorta.i18n import trans_late
 from vorta.models import BackupProfileModel, SettingsModel
-from vorta.utils import borg_compat, get_asset, is_system_tray_available, network_status_monitor
+from vorta.utils import borg_compat, get_asset, is_system_tray_available, get_network_status_monitor
 from vorta.views.utils import get_colored_icon
 from vorta.views.partials.loading_button import LoadingButton
 
@@ -79,7 +79,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.profileAddButton.clicked.connect(self.profile_add_action)
 
         # OS-specific startup options:
-        if not network_status_monitor.is_network_status_available():
+        if not get_network_status_monitor().is_network_status_available():
             # Hide Wifi-rule section in schedule tab.
             self.scheduleTab.wifiListLabel.hide()
             self.scheduleTab.wifiListWidget.hide()


### PR DESCRIPTION
This avoids problems with `vorta -d` and fork. The problems were mentioned here: https://github.com/borgbase/vorta/issues/629#issuecomment-688998973