### PR TITLE
Cancel Borg thread at end of test.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,9 +52,15 @@ def local_en():
     os.environ['LANG'] = 'en'
 
 
-@pytest.fixture(scope="function", autouse=True)
-def cleanup(qapp, qtbot):
-    qtbot.waitSignal(qapp.backup_cancelled_event.emit())
+@pytest.fixture(scope='function', autouse=True)
+def cleanup(request, qapp, qtbot):
+    """
+    Ensure BorgThread is cancelled when new test starts.
+    """
+    def kill_borg_thread():
+        qapp.backup_cancelled_event.emit()
+        qtbot.waitUntil(lambda: not vorta.borg.borg_thread.BorgThread.is_running())
+    request.addfinalizer(kill_borg_thread)
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,12 +55,12 @@ def local_en():
 @pytest.fixture(scope='function', autouse=True)
 def cleanup(request, qapp, qtbot):
     """
-    Ensure BorgThread is cancelled when new test starts.
+    Ensure BorgThread is stopped when new test starts.
     """
-    def kill_borg_thread():
+    def ensure_borg_thread_stopped():
         qapp.backup_cancelled_event.emit()
         qtbot.waitUntil(lambda: not vorta.borg.borg_thread.BorgThread.is_running())
-    request.addfinalizer(kill_borg_thread)
+    request.addfinalizer(ensure_borg_thread_stopped)
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,11 @@ def local_en():
     os.environ['LANG'] = 'en'
 
 
+@pytest.fixture(scope="function", autouse=True)
+def cleanup(qapp, qtbot):
+    qtbot.waitSignal(qapp.backup_cancelled_event.emit())
+
+
 @pytest.fixture(scope='session')
 def qapp(tmpdir_factory, local_en):
     tmp_db = tmpdir_factory.mktemp('Vorta').join('settings.sqlite')

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -107,8 +107,6 @@ def test_archive_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choos
     qtbot.mouseClick(tab.mountButton, QtCore.Qt.LeftButton)
     qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), timeout=10000)
 
-    qtbot.waitSignal(qapp.backup_cancelled_event.emit())
-
 
 def test_archive_extract(qapp, qtbot, mocker, borg_json_output, monkeypatch):
     main = qapp.main_window

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -107,6 +107,8 @@ def test_archive_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choos
     qtbot.mouseClick(tab.mountButton, QtCore.Qt.LeftButton)
     qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), timeout=10000)
 
+    qtbot.waitSignal(qapp.backup_cancelled_event.emit())
+
 
 def test_archive_extract(qapp, qtbot, mocker, borg_json_output, monkeypatch):
     main = qapp.main_window


### PR DESCRIPTION
Cancel and confirm BorgThread is stopped at the end of each test to avoid false positive test errors.

Fixes #632