### PR TITLE
Reduce icon memory usage

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "type:bug"
+  - "type:docs"
+  - "type:enhancement"
+  - "type:feature"
+  - "type:refactor"
+  - "type:task"
+# Label to use when marking an issue as stale
+staleLabel: "status:stale"
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -10,4 +10,8 @@ def get_colored_icon(icon_name):
     if uses_dark_mode():
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
     svg_img = QImage.fromData(svg_str)
+
+    # Reduce image size to 1/7th, from 1792 to 64
+    svg_img = svg_img.scaled(svg_img.size() / 28)
+
     return QIcon(QPixmap(svg_img))

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -11,7 +11,7 @@ def get_colored_icon(icon_name):
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
     svg_img = QImage.fromData(svg_str)
 
-    # Reduce image size to 128x128
-    svg_img = svg_img.scaled(128, 128)
+    # Reduce image size to 1/14th
+    svg_img = svg_img.scaled(svg_img.size() / 14)
 
     return QIcon(QPixmap(svg_img))

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -11,7 +11,7 @@ def get_colored_icon(icon_name):
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
     svg_img = QImage.fromData(svg_str)
 
-    # Reduce image size to 1/7th, from 1792 to 64
-    svg_img = svg_img.scaled(svg_img.size() / 28)
+    # Reduce image size to 128x128
+    svg_img = svg_img.scaled(128, 128)
 
     return QIcon(QPixmap(svg_img))


### PR DESCRIPTION
Turns out, Vorta uses over 300 MB of RAM. The reason is super dumb.

The reason is the icons are imported as 1792 by 1792 images. Each one takes 14MB of memory. No one needs that. 128x128 uses no memory at all.

Now its about 163 MB RAM. Much better.

Before:
```
Line #    Mem usage    Increment   Line Contents
================================================
    83    144.2 MiB    144.2 MiB       @profile
    84                                 def set_icons(self):
    85    158.7 MiB     14.5 MiB           self.extractButton.setIcon(get_colored_icon('cloud-download'))
    86    172.6 MiB     13.9 MiB           self.mountButton.setIcon(get_colored_icon('folder-open'))
    87    184.7 MiB     12.1 MiB           self.checkButton.setIcon(get_colored_icon('check-circle'))
    88    197.1 MiB     12.4 MiB           self.deleteButton.setIcon(get_colored_icon('trash'))
    89    197.9 MiB      0.8 MiB           self.diffButton.setIcon(get_colored_icon('stream-solid'))
    90    210.0 MiB     12.1 MiB           self.pruneButton.setIcon(get_colored_icon('cut'))
    91    222.4 MiB     12.4 MiB           self.listButton.setIcon(get_colored_icon('refresh'))
    92    234.5 MiB     12.1 MiB           self.toolBox.setItemIcon(0, get_colored_icon('tasks'))
    93    246.9 MiB     12.4 MiB           self.toolBox.setItemIcon(1, get_colored_icon('cut'))
```

After:
```
Line #    Mem usage    Increment   Line Contents
================================================
    83    119.9 MiB    119.9 MiB       @profile
    84                                 def set_icons(self):
    85    119.9 MiB      0.0 MiB           self.extractButton.setIcon(get_colored_icon('cloud-download'))
    86    133.9 MiB     13.9 MiB           self.mountButton.setIcon(get_colored_icon('folder-open'))
    87    133.9 MiB      0.0 MiB           self.checkButton.setIcon(get_colored_icon('check-circle'))
    88    133.9 MiB      0.0 MiB           self.deleteButton.setIcon(get_colored_icon('trash'))
    89    133.9 MiB      0.0 MiB           self.diffButton.setIcon(get_colored_icon('stream-solid'))
    90    133.9 MiB      0.0 MiB           self.pruneButton.setIcon(get_colored_icon('cut'))
    91    133.9 MiB      0.0 MiB           self.listButton.setIcon(get_colored_icon('refresh'))
    92    133.9 MiB      0.0 MiB           self.toolBox.setItemIcon(0, get_colored_icon('tasks'))
    93    133.9 MiB      0.0 MiB           self.toolBox.setItemIcon(1, get_colored_icon('cut'))
```