### PR TITLE
Replace Borg version with install method

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ Steps to reproduce the behavior:
 **Desktop (please complete the following information):**
 - OS:
 - Vorta version:
-- Borg version:
+- Installed from:
 
 Vorta and Borg versions can be found in Main Window > Misc Tab
 


### PR DESCRIPTION
We don't seem to have many bugs due to Borg errors, but we do have many due to packaging issues.

This helps diagnosing issues without having to ask more questions.