### PR TITLE
Set all icons to same height

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "type:bug"
+  - "type:docs"
+  - "type:enhancement"
+  - "type:feature"
+  - "type:refactor"
+  - "type:task"
+# Label to use when marking an issue as stale
+staleLabel: "status:stale"
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -10,4 +10,8 @@ def get_colored_icon(icon_name):
     if uses_dark_mode():
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
     svg_img = QImage.fromData(svg_str)
+
+    # Reduce image size to 1/7th, from 1792 to 64
+    svg_img = svg_img.scaled(svg_img.size() / 28)
+
     return QIcon(QPixmap(svg_img))

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -11,7 +11,7 @@ def get_colored_icon(icon_name):
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
     svg_img = QImage.fromData(svg_str)
 
-    # Reduce image size to 128x128
-    svg_img = svg_img.scaled(128, 128)
+    # Reduce image size to 1/14th
+    svg_img = svg_img.scaled(svg_img.size() / 14)
 
     return QIcon(QPixmap(svg_img))

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -9,9 +9,7 @@ def get_colored_icon(icon_name):
     svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
     if uses_dark_mode():
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
-    svg_img = QImage.fromData(svg_str)
-
     # Reduce image size to 128 height
-    svg_img = svg_img.scaledToHeight(128)
+    svg_img = QImage.fromData(svg_str).scaledToHeight(128)
 
     return QIcon(QPixmap(svg_img))

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -11,7 +11,7 @@ def get_colored_icon(icon_name):
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
     svg_img = QImage.fromData(svg_str)
 
-    # Reduce image size to 1/14th
-    svg_img = svg_img.scaled(svg_img.size() / 14)
+    # Reduce image size to 128 height
+    svg_img = svg_img.scaledToHeight(128)
 
     return QIcon(QPixmap(svg_img))

--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -11,7 +11,7 @@ def get_colored_icon(icon_name):
         svg_str = svg_str.replace(b'#00000', b'#ffffff')
     svg_img = QImage.fromData(svg_str)
 
-    # Reduce image size to 1/7th, from 1792 to 64
-    svg_img = svg_img.scaled(svg_img.size() / 28)
+    # Reduce image size to 128x128
+    svg_img = svg_img.scaled(128, 128)
 
     return QIcon(QPixmap(svg_img))


### PR DESCRIPTION
Some icons are imported as lower resolution, so dividing by a constant will result in slight blurriness.

The only icon that is affected by this the diff icon, but other icons in the future might have this behaviour.

Still has the memory saving property.