### PR TITLE
Set application name

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -45,6 +45,7 @@ class VortaApp(QtSingleApplication):
 
         self.setQuitOnLastWindowClosed(False)
         self.scheduler = VortaScheduler(self)
+        self.setApplicationName("Vorta")
 
         # Prepare system tray icon
         self.tray = TrayMenu(self)


### PR DESCRIPTION
Used to be "vorta". Now its "Vorta" in the tray. 
I had an idea to basically mirror the tray status text, but it would have to hook into too many things and would be a pain to maintain.
![tray](https://user-images.githubusercontent.com/67625312/93837455-bfde8700-fc4b-11ea-877b-26e77d12119c.png)

