### PR TITLE
Re-enable SSH host key checking for all operations except when adding repo

### DIFF
--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -70,7 +70,6 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
         if env.get('BORG_PASSCOMMAND', False):
             env.pop('BORG_PASSPHRASE', None)  # Unset passphrase
 
-        env['BORG_RSH'] = 'ssh -oStrictHostKeyChecking=no'
         ssh_key = params.get('ssh_key')
         if ssh_key is not None:
             ssh_key_path = os.path.expanduser(f'~/.ssh/{ssh_key}')

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -61,6 +61,10 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
         env = os.environ.copy()
         env['BORG_HOSTNAME_IS_UNIQUE'] = '1'
         env['BORG_RELOCATED_REPO_ACCESS_IS_OK'] = '1'
+
+        if 'additional_env' in params:
+            env = {**env, **params['additional_env']}
+
         password = params.get('password')
         if password is not None:
             env['BORG_PASSPHRASE'] = password

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -61,7 +61,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
         env = os.environ.copy()
         env['BORG_HOSTNAME_IS_UNIQUE'] = '1'
         env['BORG_RELOCATED_REPO_ACCESS_IS_OK'] = '1'
-        env['BORG_RSH'] = ''
+        env['BORG_RSH'] = 'ssh'
 
         if 'additional_env' in params:
             env = {**env, **params['additional_env']}

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -61,6 +61,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
         env = os.environ.copy()
         env['BORG_HOSTNAME_IS_UNIQUE'] = '1'
         env['BORG_RELOCATED_REPO_ACCESS_IS_OK'] = '1'
+        env['BORG_RSH'] = ''
 
         if 'additional_env' in params:
             env = {**env, **params['additional_env']}

--- a/src/vorta/borg/info.py
+++ b/src/vorta/borg/info.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 from .borg_thread import BorgThread
 from vorta.models import RepoModel
 from vorta.keyring.abc import get_keyring
-import os
 
 FakeRepo = namedtuple('Repo', ['url', 'id', 'extra_borg_arguments'])
 FakeProfile = namedtuple('FakeProfile', ['repo', 'name', 'ssh_key'])

--- a/src/vorta/borg/info.py
+++ b/src/vorta/borg/info.py
@@ -35,7 +35,10 @@ class BorgInfoThread(BorgThread):
         cmd = ["borg", "info", "--info", "--json", "--log-json"]
         cmd.append(profile.repo.url)
 
-        os.environ['BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK'] = "yes"
+        ret['additional_env'] = {
+            'BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK': "yes",
+            'BORG_RSH': 'ssh -oStrictHostKeyChecking=no'
+        }
 
         if params['password'] == '':
             ret['password'] = '999999'  # Dummy password if the user didn't supply one. To avoid prompt.

--- a/src/vorta/borg/init.py
+++ b/src/vorta/borg/init.py
@@ -27,6 +27,10 @@ class BorgInitThread(BorgThread):
         cmd.append(f"--encryption={params['encryption']}")
         cmd.append(params['repo_url'])
 
+        ret['additional_env'] = {
+            'BORG_RSH': 'ssh -oStrictHostKeyChecking=no'
+        }
+
         ret['encryption'] = params['encryption']
         ret['password'] = params['password']
         ret['ok'] = True


### PR DESCRIPTION
This limits accepting unknown SSH host keys to the inital repo setup. I.e. `borg info` and `borg init`. All other operations would fail if the original host key changed.

This is a trade-off between usability and security. Eventually we'd like to ask for the host key fingerprint when adding a new repo and verify it when adding.

See also: #714 