### PR TITLE
CI: Integrate codecov.io

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit = tests/*
+source=vorta
+relative_files=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install Vorta
       run: |
         pip install .
+        pip install coverage
         pip install borgbackup
         pip install -r requirements.d/dev.txt
     # - name: Setup tmate session
@@ -53,12 +54,15 @@ jobs:
         export $(dbus-launch)
         (herbstluftwm) &
         sleep 3
-        pytest
+        coverage run -m pytest
     - name: Test with pytest (macOS)
       if: runner.os == 'macOS'
       run: |
-        pytest
-
+        coverage run -m pytest
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Now that we have a Debian package, it would be nice to track our code test case coverage

Example:
https://codecov.io/gh/samuel-w/vorta-1/tree/6eef88395b9b3aa5e5514957c95f7efb77af4c54