### PR TITLE
Refactor add and rename to not use exec_

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -132,10 +132,10 @@ class MainWindow(MainWindowBase, MainWindowUI):
 
     def profile_rename_action(self):
         window = EditProfileWindow(rename_existing_id=self.profileSelector.currentData())
+        self.window = window  # For tests
         window.setParent(self, QtCore.Qt.Sheet)
-        window.show()
-        if window.exec_():
-            self.profileSelector.setItemText(self.profileSelector.currentIndex(), window.profileNameField.text())
+        window.profile_changed.connect(self.add_profile_entry)
+        window.rejected.connect(lambda: self.profileSelector.setCurrentIndex(self.profileSelector.currentIndex()))
 
     def profile_delete_action(self):
         if self.profileSelector.count() > 1:
@@ -150,20 +150,21 @@ class MainWindow(MainWindowBase, MainWindowUI):
             if reply == QMessageBox.Yes:
                 if self.app.scheduler.get_job(to_delete_id):
                     self.app.scheduler.remove_job(to_delete_id)
-
                 to_delete.delete_instance(recursive=True)
                 self.profileSelector.removeItem(self.profileSelector.currentIndex())
                 self.profile_select_action(0)
 
     def profile_add_action(self):
         window = AddProfileWindow()
+        self.window = window  # For tests
         window.setParent(self, QtCore.Qt.Sheet)
-        window.show()
-        if window.exec_():
-            self.profileSelector.addItem(window.edited_profile.name, window.edited_profile.id)
-            self.profileSelector.setCurrentIndex(self.profileSelector.count() - 1)
-        else:
-            self.profileSelector.setCurrentIndex(self.profileSelector.currentIndex())
+        window.open()
+        window.profile_changed.connect(self.add_profile_entry)
+        window.rejected.connect(lambda: self.profileSelector.setCurrentIndex(self.profileSelector.currentIndex()))
+
+    def add_profile_entry(self, profile_name, profile_id):
+        self.profileSelector.addItem(profile_name, profile_id)
+        self.profileSelector.setCurrentIndex(self.profileSelector.count() - 1)
 
     def backup_started_event(self):
         self._toggle_buttons(create_enabled=False)

--- a/src/vorta/views/profile_add_edit_dialog.py
+++ b/src/vorta/views/profile_add_edit_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5 import uic
+from PyQt5 import uic, QtCore
 from PyQt5.QtWidgets import QDialogButtonBox
 from ..utils import get_asset
 from ..models import BackupProfileModel
@@ -8,6 +8,9 @@ AddProfileUI, AddProfileBase = uic.loadUiType(uifile)
 
 
 class AddProfileWindow(AddProfileBase, AddProfileUI):
+
+    profile_changed = QtCore.pyqtSignal(str, int)
+
     def __init__(self, parent=None, rename_existing_id=None):
         super().__init__(parent)
         self.setupUi(self)
@@ -36,7 +39,7 @@ class AddProfileWindow(AddProfileBase, AddProfileUI):
     def save(self):
         new_profile = BackupProfileModel(name=self.profileNameField.text())
         new_profile.save()
-        self.edited_profile = new_profile
+        self.profile_changed.emit(new_profile.name, new_profile.id)
         self.accept()
 
     def button_validation(self):
@@ -64,5 +67,5 @@ class EditProfileWindow(AddProfileWindow):
         renamed_profile = BackupProfileModel.get(id=self.existing_id)
         renamed_profile.name = self.profileNameField.text()
         renamed_profile.save()
-        self.edited_profile = renamed_profile
+        self.profile_changed.emit(renamed_profile.name, renamed_profile.id)
         self.accept()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,3 +100,19 @@ def borg_json_output():
         stderr = open(f'tests/borg_json_output/{subcommand}_stderr.json')
         return stdout, stderr
     return _read_json
+
+
+@pytest.fixture
+def rootdir():
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def delete_current_profile(qapp):
+    ''' Delete current profile for cleanup '''
+    main = qapp.main_window
+    target = BackupProfileModel.get(id=main.profileSelector.currentData())
+    if qapp.scheduler.get_job(target.id):
+        qapp.scheduler.remove_job(target.id)
+    target.delete_instance(recursive=True)
+    main.profileSelector.removeItem(main.profileSelector.currentIndex())
+    main.profile_select_action(0)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,29 +1,36 @@
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QDialogButtonBox
-
-from vorta.views.profile_add_edit_dialog import AddProfileWindow, EditProfileWindow
+from .conftest import delete_current_profile
 from vorta.models import BackupProfileModel
 
 
 def test_profile_add(qapp, qtbot):
     main = qapp.main_window
-    add_profile_window = AddProfileWindow(main)
-    qtbot.addWidget(add_profile_window)
+    qtbot.mouseClick(main.profileAddButton, QtCore.Qt.LeftButton)
 
-    # Add a new profile
+    add_profile_window = main.window
+
+    qtbot.addWidget(add_profile_window)
     qtbot.keyClicks(add_profile_window.profileNameField, 'Test Profile')
     qtbot.mouseClick(add_profile_window.buttonBox.button(QDialogButtonBox.Save), QtCore.Qt.LeftButton)
+
     assert BackupProfileModel.get_or_none(name='Test Profile') is not None
+    assert main.profileSelector.currentText() == 'Test Profile'
+
+    delete_current_profile(qapp)
 
 
 def test_profile_edit(qapp, qtbot):
     main = qapp.main_window
-    edit_profile_window = EditProfileWindow(main, rename_existing_id=main.profileSelector.currentData())
-    qtbot.addWidget(edit_profile_window)
+    qtbot.mouseClick(main.profileRenameButton, QtCore.Qt.LeftButton)
 
-    # Edit profile name
+    edit_profile_window = main.window
+
+    qtbot.addWidget(edit_profile_window)
     edit_profile_window.profileNameField.setText("")
     qtbot.keyClicks(edit_profile_window.profileNameField, 'Test Profile')
     qtbot.mouseClick(edit_profile_window.buttonBox.button(QDialogButtonBox.Save), QtCore.Qt.LeftButton)
+
     assert BackupProfileModel.get_or_none(name='Default') is None
     assert BackupProfileModel.get_or_none(name='Test Profile') is not None
+    assert main.profileSelector.currentText() == 'Test Profile'


### PR DESCRIPTION
exec_ not recommended per documentation https://doc.qt.io/qt-5/qdialog.html#exec.
Now the tests run on the actual client

rootdir is copied from #548 