### PR TITLE
Link ssh key to repository, allow unsetting of profile repository.

### DIFF
--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -142,7 +142,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
                 logger.warning('Found password in database, but secure storage was available. '
                                'Consider re-adding the repo to use it.')
 
-        ret['ssh_key'] = profile.ssh_key
+        ret['ssh_key'] = profile.repo.ssh_key
         ret['repo_id'] = profile.repo.id
         ret['repo_url'] = profile.repo.url
         ret['extra_borg_arguments'] = profile.repo.extra_borg_arguments

--- a/src/vorta/borg/info.py
+++ b/src/vorta/borg/info.py
@@ -3,8 +3,8 @@ from .borg_thread import BorgThread
 from vorta.models import RepoModel
 from vorta.keyring.abc import get_keyring
 
-FakeRepo = namedtuple('Repo', ['url', 'id', 'extra_borg_arguments'])
-FakeProfile = namedtuple('FakeProfile', ['repo', 'name', 'ssh_key'])
+FakeRepo = namedtuple('Repo', ['url', 'id', 'extra_borg_arguments', 'ssh_key'])
+FakeProfile = namedtuple('FakeProfile', ['repo', 'name'])
 
 
 class BorgInfoThread(BorgThread):
@@ -20,9 +20,9 @@ class BorgInfoThread(BorgThread):
 
         # Build fake profile because we don't have it in the DB yet.
         profile = FakeProfile(
-            FakeRepo(params['repo_url'], 999, params['extra_borg_arguments']),
+            FakeRepo(params['repo_url'], 999, params['extra_borg_arguments', params['ssh_key']]),
             'New Repo',
-            params['ssh_key']
+
         )
 
         ret = super().prepare(profile)

--- a/src/vorta/borg/init.py
+++ b/src/vorta/borg/init.py
@@ -14,7 +14,7 @@ class BorgInitThread(BorgThread):
 
         # Build fake profile because we don't have it in the DB yet.
         profile = FakeProfile(
-            FakeRepo(params['repo_url'], 999, params['extra_borg_arguments']), 'Init Repo', params['ssh_key']
+            FakeRepo(params['repo_url'], 999, params['extra_borg_arguments'], params['ssh_key']), 'Init Repo'
         )
 
         ret = super().prepare(profile)


### PR DESCRIPTION
It makes more sense, since ssh keys are used to access remote repositories.

However, it does delete the existing ssh key setting per profile. I don't think its feasible to migrate, since a two profiles can have different ssh keys and be linked to the same repo.