### PR TITLE
Sort tree dialogs alphabetically

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -7,7 +7,7 @@ import platform
 import re
 import sys
 import unicodedata
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from datetime import datetime as dt
 from functools import reduce
 
@@ -195,18 +195,6 @@ def get_asset(path):
         # we are running in a normal Python environment
         bundle_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'assets')
     return os.path.join(bundle_dir, path)
-
-
-def sort_dict(unordered_dict):
-    ''' Recursively sort a dictionary of dictionaries by key, ignoring alpha case '''
-    sorted_dict = OrderedDict()
-    for key, value in sorted(unordered_dict.items(), key=lambda x: x[0].upper()):
-        # In the future we want to move all the dicts to the start of the dictionary, and all the strings to the bottom
-        if isinstance(value, dict):
-            sorted_dict[key] = sort_dict(value)
-        else:
-            sorted_dict[key] = value
-    return sorted_dict
 
 
 def get_sorted_wifis(profile):

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -198,7 +198,7 @@ def get_asset(path):
 
 
 def sort_dict(unordered_dict):
-    ''' Recursively sort a dictionary of dictionaries, ignoring alpha case '''
+    ''' Recursively sort a dictionary of dictionaries by key, ignoring alpha case '''
     sorted_dict = OrderedDict()
     for key, value in sorted(unordered_dict.items(), key=lambda x: x[0].upper()):
         if isinstance(value, dict):

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -7,7 +7,7 @@ import platform
 import re
 import sys
 import unicodedata
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from datetime import datetime as dt
 from functools import reduce
 
@@ -195,6 +195,17 @@ def get_asset(path):
         # we are running in a normal Python environment
         bundle_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'assets')
     return os.path.join(bundle_dir, path)
+
+
+def sort_dict(unordered_dict):
+    ''' Recursively sort a dictionary of dictionaries, ignoring alpha case '''
+    sorted_dict = OrderedDict()
+    for key, value in sorted(unordered_dict.items(), key=lambda x: x[0].upper()):
+        if isinstance(value, dict):
+            sorted_dict[key] = sort_dict(value)
+        else:
+            sorted_dict[key] = value
+    return sorted_dict
 
 
 def get_sorted_wifis(profile):

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -201,6 +201,7 @@ def sort_dict(unordered_dict):
     ''' Recursively sort a dictionary of dictionaries by key, ignoring alpha case '''
     sorted_dict = OrderedDict()
     for key, value in sorted(unordered_dict.items(), key=lambda x: x[0].upper()):
+        # In the future we want to move all the dicts to the start of the dictionary, and all the strings to the bottom
         if isinstance(value, dict):
             sorted_dict[key] = sort_dict(value)
         else:

--- a/src/vorta/views/partials/tree_view.py
+++ b/src/vorta/views/partials/tree_view.py
@@ -3,7 +3,7 @@ from PyQt5.QtCore import QAbstractItemModel, QModelIndex, Qt
 import os
 import abc
 
-from vorta.utils import get_dict_from_list, pretty_bytes, sort_dict
+from vorta.utils import get_dict_from_list, pretty_bytes
 
 
 class FolderItem:
@@ -188,7 +188,7 @@ class TreeModel(QAbstractItemModel):
         parent=None,
     ):
         files_with_attributes.sort(key=lambda x: x[2].upper())  # Sorts tuples by name ignoring case
-        nested_file_list = sort_dict(nested_file_list)  # Recursively sorts folders
+        files_with_attributes.sort(key=lambda x: x[0] != 0)  # Pushes folders (size zero) to start of list
 
         super(TreeModel, self).__init__(parent)
 

--- a/src/vorta/views/partials/tree_view.py
+++ b/src/vorta/views/partials/tree_view.py
@@ -1,9 +1,8 @@
 from PyQt5.QtCore import QAbstractItemModel, QModelIndex, Qt
-
 import os
 import abc
 
-from vorta.utils import get_dict_from_list, pretty_bytes
+from vorta.utils import get_dict_from_list, pretty_bytes, sort_dict
 
 
 class FolderItem:
@@ -187,6 +186,9 @@ class TreeModel(QAbstractItemModel):
         selected_files_folders=None,
         parent=None,
     ):
+        files_with_attributes.sort(key=lambda x: x[2].upper())  # Sorts tuples by name ignoring case
+        nested_file_list = sort_dict(nested_file_list)  # Recursively sorts folders
+
         super(TreeModel, self).__init__(parent)
 
         self.rootItem = FolderItem(

--- a/src/vorta/views/partials/tree_view.py
+++ b/src/vorta/views/partials/tree_view.py
@@ -1,4 +1,5 @@
 from PyQt5.QtCore import QAbstractItemModel, QModelIndex, Qt
+
 import os
 import abc
 


### PR DESCRIPTION
Fixes #646, fixes #664.

Sorts both diff and restore due to inheritance. Puts folders first then files, but doesn't allow changing of sorting order.