### PR TITLE
Fix label colour not changing on dark mode change

### DIFF
--- a/src/vorta/assets/UI/repotab.ui
+++ b/src/vorta/assets/UI/repotab.ui
@@ -51,14 +51,11 @@
          <height>0</height>
         </size>
        </property>
-       <property name="styleSheet">
-        <string notr="true">margin-top: 4;</string>
-       </property>
        <property name="text">
         <string>Repository:</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -74,7 +71,7 @@
         <number>0</number>
        </property>
        <property name="horizontalSpacing">
-        <number>-1</number>
+        <number>6</number>
        </property>
        <property name="verticalSpacing">
         <number>1</number>
@@ -152,7 +149,7 @@
           <bool>false</bool>
          </property>
         </widget>
-       </item>      
+       </item>
       </layout>
      </item>
      <item row="1" column="0">
@@ -163,14 +160,11 @@
          <height>0</height>
         </size>
        </property>
-       <property name="styleSheet">
-        <string notr="true">margin-top: 4;</string>
-       </property>
        <property name="text">
         <string>SSH Key:</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -248,14 +242,11 @@
          <height>0</height>
         </size>
        </property>
-       <property name="styleSheet">
-        <string notr="true">margin-top: 4;</string>
-       </property>
        <property name="text">
         <string>Compression:</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>


### PR DESCRIPTION
This makes the labels slightly off center, but its clear enough which labels go where and most Qt themes seem to automatically align the text anyways. Fixes #756 