### PR TITLE
Fix file selector dialog

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -111,12 +111,11 @@ def get_dict_from_list(dataDict, mapList):
 
 
 def choose_file_dialog(parent, title, want_folder=True):
-    options = QFileDialog.Options()
-    if want_folder:
-        options |= QFileDialog.ShowDirsOnly
-    dialog = QFileDialog(parent, title, os.path.expanduser('~'), options=options)
+    dialog = QFileDialog(parent, title, os.path.expanduser('~'))
     dialog.setFileMode(QFileDialog.Directory if want_folder else QFileDialog.ExistingFiles)
     dialog.setParent(parent, QtCore.Qt.Sheet)
+    if want_folder:
+        dialog.setOption(QFileDialog.ShowDirsOnly)
     return dialog
 
 


### PR DESCRIPTION
Used setOption. Fixes #693.

I have no idea why this fixes it but it fixes it. The two dialogs look different but it doesn't matter at this point.
![File](https://user-images.githubusercontent.com/67625312/104855718-f4014600-58d3-11eb-97bd-2cdef150e72a.png)
![Folder](https://user-images.githubusercontent.com/67625312/104855720-f4014600-58d3-11eb-82b6-74f94d8b4b81.png)

