### PR TITLE
Avoid passing None as subprocess CWD. (Error in Py3.9)

### DIFF
--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -83,7 +83,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
 
         self.env = env
         self.cmd = cmd
-        self.cwd = params.get('cwd', None)
+        self.cwd = params.get('cwd', os.path.expanduser('~'))
         self.params = params
         self.process = None
 


### PR DESCRIPTION
This error without:

```
2021-01-19 13:46:11,839 - vorta.borg.borg_thread - INFO - Running command /Applications/Vorta.app/Contents/Resources/borg-dir/borg.exe list --info --log-json --json /Users/bibs/Downloads/testrepo
2021-01-19 13:46:11,840 - root - CRITICAL - Uncaught exception, file a report at https://github.com/borgbase/vorta/issues/new
Traceback (most recent call last):
 File "borg/borg_thread.py", line 196, in run
 File "subprocess.py", line 947, in __init__
 File "subprocess.py", line 1739, in _execute_child
 File "os.py", line 810, in fsencode
TypeError: expected str, bytes or os.PathLike object, not NoneType
```