### PR TITLE
use --json-lines mode for list archive results for better parsing of unusual filenames

### DIFF
--- a/src/vorta/borg/list_archive.py
+++ b/src/vorta/borg/list_archive.py
@@ -13,17 +13,16 @@ class BorgListArchiveThread(BorgThread):
         self.result.emit(result)
 
     @classmethod
-    def prepare(cls, profile):
+    def prepare(cls, profile, archive_name):
         ret = super().prepare(profile)
         if not ret['ok']:
             return ret
-        else:
-            ret['ok'] = False  # Set back to false, so we can do our own checks here.
 
-        cmd = ['borg', 'list', '--info', '--log-json', '--format', "{size:8d}{TAB}{mtime}{TAB}{path}{NL}"]
-        cmd.append(f'{profile.repo.url}')
-
+        ret['archive_name'] = archive_name
+        ret['cmd'] = [
+            'borg', 'list', '--info', '--log-json', '--json-lines',
+            '--format', "{size:8d}{TAB}{mtime}{TAB}{path}{NL}",
+            f'{profile.repo.url}::{archive_name}']
         ret['ok'] = True
-        ret['cmd'] = cmd
 
         return ret

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -376,13 +376,11 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             archive_cell = self.archiveTable.item(row_selected[0].row(), 4)
             if archive_cell:
                 archive_name = archive_cell.text()
-                params = BorgListArchiveThread.prepare(profile)
+                params = BorgListArchiveThread.prepare(profile, archive_name)
 
                 if not params['ok']:
                     self._set_status(params['message'])
                     return
-                params['cmd'][-1] += f'::{archive_name}'
-                params['archive_name'] = archive_name
                 self._set_status('')
                 self._toggle_all_buttons(False)
 

--- a/tests/borg_json_output/list_archive_stdout.json
+++ b/tests/borg_json_output/list_archive_stdout.json
@@ -1,69 +1,69 @@
-       0	Thu, 2018-11-29 10:35:09	Users/manu/Desktop
-       0	Wed, 2013-09-04 00:54:20	Users/manu/Desktop/.ipynb_checkpoints
-  247348	Wed, 2013-09-04 01:00:31	Users/Untitled7-checkpoint.ipynb
-     888	Wed, 2018-03-21 23:18:32	Users/manu/Desktop/Receipts
-     800	Wed, 2018-03-21 23:18:58	Users/manu/Desktop/Documents
-     840	Tue, 2018-03-27 00:42:58	Users/manu/Desktop/travel
-     199	Fri, 2017-02-24 12:13:39	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.au/settings.sol
-       0	Fri, 2017-02-24 12:13:41	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my
-     199	Fri, 2017-02-24 12:13:41	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my/settings.sol
-       0	Fri, 2017-02-24 12:13:39	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com
-     196	Fri, 2017-02-24 12:13:39	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com/settings.sol
-       0	Fri, 2017-02-24 12:13:41	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de
-     195	Fri, 2017-02-24 12:13:41	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de/settings.sol
-       0	Fri, 2017-02-24 12:13:41	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com
-     194	Fri, 2017-02-24 12:13:41	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com/settings.sol
-       0	Fri, 2017-02-24 12:13:42	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com
-     190	Fri, 2017-02-24 12:13:42	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com/settings.sol
-       0	Fri, 2017-02-24 12:13:39	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net
-     191	Fri, 2017-02-24 12:13:39	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net/settings.sol
-       0	Fri, 2017-02-24 12:13:44	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com
-     194	Fri, 2017-02-24 12:13:44	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com/settings.sol
-       0	Fri, 2017-02-24 12:13:38	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net
-     199	Fri, 2017-02-24 12:13:38	Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net/settings.sol
-  188016	Fri, 2014-09-19 05:52:28	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/NuFS.framework/Versions/A/NuFS
-       0	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext
-       0	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents
-       0	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS
-  229692	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS/transmitdiskfs
-    1908	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/Info.plist
-  339916	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/libfuse.dylib
-   47376	Fri, 2014-09-19 05:52:28	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/load_nufs
-   74416	Fri, 2014-09-19 05:52:28	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/mount_nufs
-   65853	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/License.pdf
-    2682	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Info.plist
-     551	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/version.plist
-  129893	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/disk-transmit.icns
-    1178	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/sparkle_dsa_pub.pem
-       0	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature
-    8378	Fri, 2014-09-19 05:52:30	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature/CodeResources
-    1768	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Info.plist
-       8	Fri, 2014-09-19 05:51:56	Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/PkgInfo
-  239529	Thu, 2018-11-29 08:51:51	Users/manu/Library/Application Support/Transmit/Connections.transmitstore
-       0	Tue, 2018-11-13 09:02:33	Users/manu/Library/Application Support/coconutBattery
-   30939	Mon, 2017-09-11 22:52:42	Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive.backup_3.6.3
-   31097	Sat, 2017-04-08 18:45:35	Users/manu/Library/Application Support/coconutBattery/coconutBatteryData.ccbarchive
-   98162	Tue, 2018-11-13 09:02:33	Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive
-   84803	Tue, 2013-12-10 13:41:58	Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-11-02.PDF
-   84228	Tue, 2013-12-10 13:42:02	Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-12-02.PDF
-   85337	Tue, 2014-01-07 21:28:09	Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-01-02.PDF
-   84228	Mon, 2014-04-07 22:48:28	Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-02-02.PDF
-   85095	Mon, 2014-04-07 22:52:59	Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-03-02.PDF
-   83329	Mon, 2014-04-07 22:53:03	Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-04-02.PDF
-       0	Tue, 2016-03-15 19:29:23	Users/manu/Documents/financial/_archive/Direktanlage
-  117360	Tue, 2013-08-27 14:53:25	Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300001.PDF
-  156800	Wed, 2013-10-16 20:21:38	Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300002.PDF
-   80720	Sat, 2014-01-04 21:05:34	Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300003.PDF
- 1292665	Mon, 2012-07-23 05:26:43	Users/manu/Documents/cooking/IMG_20120505_160225.jpg
- 1330876	Mon, 2012-07-23 05:26:40	Users/manu/Documents/cooking/IMG_20120505_160425.jpg
- 1219294	Mon, 2012-07-23 05:26:43	Users/manu/Documents/cooking/IMG_20120505_160842.jpg
- 1205672	Mon, 2012-07-23 05:26:44	Users/manu/Documents/cooking/IMG_20120505_161225.jpg
- 1254561	Mon, 2012-07-23 05:26:42	Users/manu/Documents/cooking/IMG_20120505_161247.jpg
- 1141842	Mon, 2012-07-23 05:26:44	Users/manu/Documents/cooking/IMG_20120505_161525.jpg
- 1143566	Mon, 2012-07-23 05:26:37	Users/manu/Documents/cooking/IMG_20120505_162547.jpg
- 1015435	Sat, 2012-02-25 21:55:12	Users/manu/Documents/cooking/Jamie Oliver Tuna in Tomatoe Sauce.pdf
-   33762	Fri, 2012-11-02 23:19:19	Users/manu/Documents/cooking/Mediterranean Beef Stew with Rosemary.pdf
- 1225647	Mon, 2012-07-23 05:26:50	Users/manu/Documents/cooking/Schweinekotelett und Ratatouille.jpg
- 1038737	Wed, 2012-12-12 21:38:43	Users/manu/Documents/cooking/Shrimp, Avocado and Red Pepper Salad.pdf
-   65393	Tue, 2012-11-13 22:04:04	Users/manu/Documents/cooking/Tiramisu Semifreddo.pdf
- 1266835	Mon, 2012-07-23 05:26:50	Users/manu/Documents/cooking/Tomaten-Paprika Suppe.jpg
+{"size": 0, "mtime": "2018-11-29T10:35:09", "path": "Users/manu/Desktop"}
+{"size": 0, "mtime": "2013-09-04T00:54:20", "path": "Users/manu/Desktop/.ipynb_checkpoints"}
+{"size": 247348, "mtime": "2013-09-04T01:00:31", "path": "Users/Untitled7-checkpoint.ipynb"}
+{"size": 888, "mtime": "2018-03-21T23:18:32", "path": "Users/manu/Desktop/Receipts"}
+{"size": 800, "mtime": "2018-03-21T23:18:58", "path": "Users/manu/Desktop/Documents"}
+{"size": 840, "mtime": "2018-03-27T00:42:58", "path": "Users/manu/Desktop/travel"}
+{"size": 199, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.au/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my"}
+{"size": 199, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com"}
+{"size": 196, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de"}
+{"size": 195, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com"}
+{"size": 194, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:42", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com"}
+{"size": 190, "mtime": "2017-02-24T12:13:42", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net"}
+{"size": 191, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:44", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com"}
+{"size": 194, "mtime": "2017-02-24T12:13:44", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com/settings.sol"}
+{"size": 0, "mtime": "2017-02-24T12:13:38", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net"}
+{"size": 199, "mtime": "2017-02-24T12:13:38", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net/settings.sol"}
+{"size": 188016, "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/NuFS.framework/Versions/A/NuFS"}
+{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext"}
+{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents"}
+{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS"}
+{"size": 229692, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS/transmitdiskfs"}
+{"size": 1908, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/Info.plist"}
+{"size": 339916, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/libfuse.dylib"}
+{"size": 47376, "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/load_nufs"}
+{"size": 74416, "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/mount_nufs"}
+{"size": 65853, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/License.pdf"}
+{"size": 2682, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Info.plist"}
+{"size": 551, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/version.plist"}
+{"size": 129893, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/disk-transmit.icns"}
+{"size": 1178, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/sparkle_dsa_pub.pem"}
+{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature"}
+{"size": 8378, "mtime": "2014-09-19T05:52:30", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature/CodeResources"}
+{"size": 1768, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Info.plist"}
+{"size": 8, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/PkgInfo"}
+{"size": 239529, "mtime": "2018-11-29T08:51:51", "path": "Users/manu/Library/Application Support/Transmit/Connections.transmitstore"}
+{"size": 0, "mtime": "2018-11-13T09:02:33", "path": "Users/manu/Library/Application Support/coconutBattery"}
+{"size": 30939, "mtime": "2017-09-11T22:52:42", "path": "Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive.backup_3.6.3"}
+{"size": 31097, "mtime": "2017-04-08T18:45:35", "path": "Users/manu/Library/Application Support/coconutBattery/coconutBatteryData.ccbarchive"}
+{"size": 98162, "mtime": "2018-11-13T09:02:33", "path": "Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive"}
+{"size": 84803, "mtime": "2013-12-10T13:41:58", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-11-02.PDF"}
+{"size": 84228, "mtime": "2013-12-10T13:42:02", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-12-02.PDF"}
+{"size": 85337, "mtime": "2014-01-07T21:28:09", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-01-02.PDF"}
+{"size": 84228, "mtime": "2014-04-07T22:48:28", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-02-02.PDF"}
+{"size": 85095, "mtime": "2014-04-07T22:52:59", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-03-02.PDF"}
+{"size": 83329, "mtime": "2014-04-07T22:53:03", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-04-02.PDF"}
+{"size": 0, "mtime": "2016-03-15T19:29:23", "path": "Users/manu/Documents/financial/_archive/Direktanlage"}
+{"size": 117360, "mtime": "2013-08-27T14:53:25", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300001.PDF"}
+{"size": 156800, "mtime": "2013-10-16T20:21:38", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300002.PDF"}
+{"size": 80720, "mtime": "2014-01-04T21:05:34", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300003.PDF"}
+{"size": 1292665, "mtime": "2012-07-23T05:26:43", "path": "Users/manu/Documents/cooking/IMG_20120505_160225.jpg"}
+{"size": 1330876, "mtime": "2012-07-23T05:26:40", "path": "Users/manu/Documents/cooking/IMG_20120505_160425.jpg"}
+{"size": 1219294, "mtime": "2012-07-23T05:26:43", "path": "Users/manu/Documents/cooking/IMG_20120505_160842.jpg"}
+{"size": 1205672, "mtime": "2012-07-23T05:26:44", "path": "Users/manu/Documents/cooking/IMG_20120505_161225.jpg"}
+{"size": 1254561, "mtime": "2012-07-23T05:26:42", "path": "Users/manu/Documents/cooking/IMG_20120505_161247.jpg"}
+{"size": 1141842, "mtime": "2012-07-23T05:26:44", "path": "Users/manu/Documents/cooking/IMG_20120505_161525.jpg"}
+{"size": 1143566, "mtime": "2012-07-23T05:26:37", "path": "Users/manu/Documents/cooking/IMG_20120505_162547.jpg"}
+{"size": 1015435, "mtime": "2012-02-25T21:55:12", "path": "Users/manu/Documents/cooking/Jamie Oliver Tuna in Tomatoe Sauce.pdf"}
+{"size": 33762, "mtime": "2012-11-02T23:19:19", "path": "Users/manu/Documents/cooking/Mediterranean Beef Stew with Rosemary.pdf"}
+{"size": 1225647, "mtime": "2012-07-23T05:26:50", "path": "Users/manu/Documents/cooking/Schweinekotelett und Ratatouille.jpg"}
+{"size": 1038737, "mtime": "2012-12-12T21:38:43", "path": "Users/manu/Documents/cooking/Shrimp, Avocado and Red Pepper Salad.pdf"}
+{"size": 65393, "mtime": "2012-11-13T22:04:04", "path": "Users/manu/Documents/cooking/Tiramisu Semifreddo.pdf"}
+{"size": 1266835, "mtime": "2012-07-23T05:26:50", "path": "Users/manu/Documents/cooking/Tomaten-Paprika Suppe.jpg"}


### PR DESCRIPTION
This change relies on using borg >= 1.1.0. Do we need to support older versions? If so, I can add checks for borg version and fallback to old text parsing. This fixes one of the 2 cases in issue #883.