### PR TITLE
Allows to fully disable using the system keychain.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
         pip install -e .
         pip install -r requirements.d/dev.txt
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v1
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v1
 
     - name: Test with pytest (Linux)
       if: runner.os == 'Linux'
@@ -62,6 +62,7 @@ jobs:
         pytest
 
     - name: Upload coverage to Codecov
+      if: runner.os == 'Linux'
       uses: codecov/codecov-action@v1
       env:
         OS: ${{ runner.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
         pip install -e .
         pip install -r requirements.d/dev.txt
 
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v1
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v1
 
     - name: Test with pytest (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,10 +59,9 @@ jobs:
     - name: Test with pytest (macOS)
       if: runner.os == 'macOS'
       run: |
-        pytest
+        pytest --cov=vorta
 
     - name: Upload coverage to Codecov
-      if: runner.os == 'Linux'
       uses: codecov/codecov-action@v1
       env:
         OS: ${{ runner.os }}

--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -102,9 +102,11 @@ class VortaApp(QtSingleApplication):
         return False
 
     def quit_app_action(self):
-        del self.main_window
-        self.scheduler.shutdown()
         self.backup_cancelled_event.emit()
+        self.scheduler.shutdown()
+        del self.main_window
+        self.tray.deleteLater()
+        del self.tray
         cleanup_db()
 
     def create_backup_action(self, profile_id=None):

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -139,7 +139,8 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
 
         # Check if keyring is locked
         if profile.repo.encryption != 'none' and not cls.keyring.is_unlocked:
-            ret['message'] = trans_late('messages', 'Please unlock your password manager.')
+            ret['message'] = trans_late('messages',
+                                        'Please unlock your system password manager or disable it under Misc')
             return ret
 
         # Try to fall back to DB Keyring, if we use the system keychain.

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -290,6 +290,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
                 self.process.terminate()
             mutex.unlock()
             self.terminate()
+            self.wait()
 
     def process_result(self, result):
         pass

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -144,7 +144,7 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
             return ret
 
         # Try to fall back to DB Keyring, if we use the system keychain.
-        if ret['password'] is None and cls.keyring.is_primary:
+        if ret['password'] is None and cls.keyring.is_system:
             logger.debug('Password not found in primary keyring. Falling back to VortaDBKeyring.')
             ret['password'] = VortaDBKeyring().get_password('vorta-repo', profile.repo.url)
 

--- a/src/vorta/keyring/abc.py
+++ b/src/vorta/keyring/abc.py
@@ -16,8 +16,8 @@ class VortaKeyring:
         Choose available Keyring or save passwords to settings database.
 
         Will always use Keychain on macOS. Will try KWallet and then Secret
-        Storage on Linux and *BSD. If non are available or usage of system keychain
-        is disabled, fall back to saving passwords to DB.
+        Storage on Linux and *BSD. If none are available or usage of system
+        keychain is disabled, fall back to saving passwords to DB.
         """
 
         from vorta.models import SettingsModel

--- a/src/vorta/keyring/abc.py
+++ b/src/vorta/keyring/abc.py
@@ -5,6 +5,7 @@ fall back to a simple database keystore if needed.
 """
 import sys
 from pkg_resources import parse_version
+from vorta.i18n import trans_late
 
 
 class VortaKeyring:
@@ -54,6 +55,12 @@ class VortaKeyring:
             cls._keyring = VortaDBKeyring()
 
         return cls._keyring
+
+    def get_backend_warning(self):
+        if self.is_system:
+            return trans_late('utils', 'Storing password in your password manager.')
+        else:
+            return trans_late('utils', 'Saving password with Vorta settings.')
 
     def set_password(self, service, repo_url, password):
         """

--- a/src/vorta/keyring/abc.py
+++ b/src/vorta/keyring/abc.py
@@ -16,7 +16,13 @@ class VortaKeyring:
         Attempts to get secure keyring at runtime if current keyring is insecure.
         Once it finds a secure keyring, it wil always use that keyring
         """
-        if cls._keyring is None or not cls._keyring.is_primary:
+
+        # Using system keychain is disabled in settings
+        from vorta.models import SettingsModel
+        if not SettingsModel.get(key='use_system_keyring').value:
+            from .db import VortaDBKeyring
+            cls._keyring = VortaDBKeyring()
+        elif cls._keyring is None or not cls._keyring.is_primary:
             if sys.platform == 'darwin':  # Use Keychain on macOS
                 from .darwin import VortaDarwinKeyring
                 cls._keyring = VortaDarwinKeyring()

--- a/src/vorta/keyring/darwin.py
+++ b/src/vorta/keyring/darwin.py
@@ -7,6 +7,7 @@ objc modules.
 
 Adapted from https://gist.github.com/apettinen/5dc7bf1f6a07d148b2075725db6b1950
 """
+import sys
 from .abc import VortaKeyring
 
 
@@ -79,8 +80,20 @@ class VortaDarwinKeyring(VortaKeyring):
 
         return keychain_status & kSecUnlockStateStatus
 
+    @classmethod
+    def get_priority(cls):
+        if sys.platform == 'darwin':
+            return 8
+        else:
+            raise RuntimeError('Only available on macOS')
+
+    @property
+    def is_system(self):
+        return True
+
 
 def _resolve_password(password_length, password_buffer):
     from ctypes import c_char
     s = (c_char*password_length).from_address(password_buffer.__pointer__)[:]
     return s.decode()
+

--- a/src/vorta/keyring/db.py
+++ b/src/vorta/keyring/db.py
@@ -27,7 +27,7 @@ class VortaDBKeyring(VortaKeyring):
             return None
 
     @property
-    def is_primary(self):
+    def is_system(self):
         return False
 
     @property

--- a/src/vorta/keyring/db.py
+++ b/src/vorta/keyring/db.py
@@ -1,5 +1,6 @@
 import peewee
 from .abc import VortaKeyring
+from vorta.models import SettingsModel
 
 
 class VortaDBKeyring(VortaKeyring):
@@ -33,3 +34,7 @@ class VortaDBKeyring(VortaKeyring):
     @property
     def is_unlocked(self):
         return True
+
+    @classmethod
+    def get_priority(cls):
+        return 1 if SettingsModel.get(key='use_system_keyring').value else 10

--- a/src/vorta/keyring/kwallet.py
+++ b/src/vorta/keyring/kwallet.py
@@ -1,3 +1,4 @@
+import os
 from PyQt5 import QtDBus
 from PyQt5.QtCore import QVariant
 from vorta.keyring.abc import VortaKeyring
@@ -54,6 +55,14 @@ class VortaKWallet5Keyring(VortaKeyring):
             self.handle = int(output)
         except ValueError:  # For when kwallet is disabled or dbus otherwise broken
             self.handle = -2
+
+    @classmethod
+    def get_priority(cls):
+        return 6 if "KDE" in os.getenv("XDG_CURRENT_DESKTOP", "") else 4
+
+    @property
+    def is_system(self):
+        return True
 
 
 class KWalletNotAvailableException(Exception):

--- a/src/vorta/keyring/kwallet.py
+++ b/src/vorta/keyring/kwallet.py
@@ -20,6 +20,7 @@ class VortaKWallet5Keyring(VortaKeyring):
             self.object_path,
             self.interface_name,
             QtDBus.QDBusConnection.sessionBus())
+        self.handle = -1
         if not (self.iface.isValid() and self.get_result("isEnabled") is True):
             raise KWalletNotAvailableException
 

--- a/src/vorta/keyring/secretstorage.py
+++ b/src/vorta/keyring/secretstorage.py
@@ -55,7 +55,7 @@ class VortaSecretStorageKeyring(VortaKeyring):
 
     @classmethod
     def get_priority(cls):
-        return 6 if "GNOME" in os.getenv("XDG_CURRENT_DESKTOP", "") else 4
+        return 6 if "GNOME" in os.getenv("XDG_CURRENT_DESKTOP", "") else 5
 
     @property
     def is_system(self):

--- a/src/vorta/keyring/secretstorage.py
+++ b/src/vorta/keyring/secretstorage.py
@@ -1,6 +1,6 @@
 import asyncio
 import sys
-
+import os
 import secretstorage
 
 from vorta.keyring.abc import VortaKeyring
@@ -52,3 +52,11 @@ class VortaSecretStorageKeyring(VortaKeyring):
         except secretstorage.exceptions.SecretServiceNotAvailableException:
             logger.debug('SecretStorage is closed.')
             return False
+
+    @classmethod
+    def get_priority(cls):
+        return 6 if "GNOME" in os.getenv("XDG_CURRENT_DESKTOP", "") else 4
+
+    @property
+    def is_system(self):
+        return True

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -279,6 +279,7 @@ def get_misc_settings():
 def cleanup_db():
     # Clean up database
     db.execute_sql("VACUUM")
+    db.close()
 
 
 def init_db(con=None):

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -226,6 +226,11 @@ def get_misc_settings():
                                 'Get statistics of file/folder when added')
         },
         {
+            'key': 'use_system_keyring', 'value': True, 'type': 'checkbox',
+            'label': trans_late('settings',
+                                'Store repository passwords in system keychain, if available.')
+        },
+        {
             'key': 'override_mount_permissions', 'value': False, 'type': 'checkbox',
             'label': trans_late('settings',
                                 'Try to replace existing permissions when mounting an archive.')

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -22,7 +22,6 @@ from PyQt5.QtWidgets import QApplication, QFileDialog, QSystemTrayIcon
 
 from vorta.borg._compatibility import BorgCompatibility
 from vorta.i18n import trans_late
-from vorta.keyring.abc import VortaKeyring
 from vorta.log import logger
 from vorta.network_status.abc import NetworkStatusMonitor
 
@@ -337,14 +336,3 @@ def validate_passwords(first_pass, second_pass):
         return trans_late('utils', "Passwords must be greater than 8 characters long.")
 
     return ""
-
-
-def display_password_backend(encryption):
-    ''' Display password backend message based off current keyring '''
-    # flake8: noqa E501
-    if encryption != 'none':
-        keyring = VortaKeyring.get_keyring()
-        return trans_late('utils', "Storing the password in your password manager.") if keyring.is_system else trans_late(
-            'utils', 'Saving the password to disk. To store password more securely install a supported secret store such as KeepassXC')
-    else:
-        return ""

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -344,7 +344,7 @@ def display_password_backend(encryption):
     # flake8: noqa E501
     if encryption != 'none':
         keyring = VortaKeyring.get_keyring()
-        return trans_late('utils', "Storing the password in your password manager.") if keyring.is_primary else trans_late(
+        return trans_late('utils', "Storing the password in your password manager.") if keyring.is_system else trans_late(
             'utils', 'Saving the password to disk. To store password more securely install a supported secret store such as KeepassXC')
     else:
         return ""

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -7,7 +7,7 @@ from vorta.utils import get_private_keys, get_asset, choose_file_dialog, \
 from vorta.keyring.abc import VortaKeyring
 from vorta.borg.init import BorgInitThread
 from vorta.borg.info_repo import BorgInfoRepoThread
-from vorta.i18n import translate, trans_late
+from vorta.i18n import translate
 from vorta.views.utils import get_colored_icon
 from vorta.models import RepoModel
 
@@ -31,7 +31,7 @@ class AddRepoWindow(AddRepoBase, AddRepoUI):
         self.repoURL.textChanged.connect(self.set_password)
         self.passwordLineEdit.textChanged.connect(self.password_listener)
         self.confirmLineEdit.textChanged.connect(self.password_listener)
-        self.encryptionComboBox.activated.connect(self.display_password_backend)
+        self.encryptionComboBox.activated.connect(self.display_backend_warning)
 
         # Add clickable icon to toggle password visibility to end of box
         self.showHideAction = QAction(self.tr("Show my passwords"), self)
@@ -45,7 +45,7 @@ class AddRepoWindow(AddRepoBase, AddRepoUI):
         self.init_encryption()
         self.init_ssh_key()
         self.set_icons()
-        self.display_password_backend()
+        self.display_backend_warning()
 
     def set_icons(self):
         self.chooseLocalFolderButton.setIcon(get_colored_icon('folder-open'))
@@ -64,17 +64,10 @@ class AddRepoWindow(AddRepoBase, AddRepoUI):
             out['encryption'] = self.encryptionComboBox.currentData()
         return out
 
-    def display_password_backend(self):
+    def display_backend_warning(self):
         '''Display password backend message based off current keyring'''
-        backend_msg = ''
         if self.encryptionComboBox.currentData() != 'none':
-            keyring = VortaKeyring.get_keyring()
-            if keyring.is_system:
-                backend_msg = trans_late('utils', 'Storing password in your password manager.')
-            else:
-                backend_msg = trans_late('utils', 'Saving password with Vorta settings.')
-
-        self.passwordLabel.setText(backend_msg)
+            self.passwordLabel.setText(VortaKeyring.get_keyring().get_backend_warning())
 
     def choose_local_backup_folder(self):
         def receive():

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -3,11 +3,11 @@ from PyQt5 import uic, QtCore
 from PyQt5.QtWidgets import QLineEdit, QAction
 
 from vorta.utils import get_private_keys, get_asset, choose_file_dialog, \
-    borg_compat, validate_passwords, display_password_backend
+    borg_compat, validate_passwords
 from vorta.keyring.abc import VortaKeyring
 from vorta.borg.init import BorgInitThread
 from vorta.borg.info_repo import BorgInfoRepoThread
-from vorta.i18n import translate
+from vorta.i18n import translate, trans_late
 from vorta.views.utils import get_colored_icon
 from vorta.models import RepoModel
 
@@ -65,7 +65,16 @@ class AddRepoWindow(AddRepoBase, AddRepoUI):
         return out
 
     def display_password_backend(self):
-        self.passwordLabel.setText(translate('utils', display_password_backend(self.encryptionComboBox.currentData())))
+        '''Display password backend message based off current keyring'''
+        backend_msg = ''
+        if self.encryptionComboBox.currentData() != 'none':
+            keyring = VortaKeyring.get_keyring()
+            if keyring.is_system:
+                backend_msg = trans_late('utils', 'Storing password in your password manager.')
+            else:
+                backend_msg = trans_late('utils', 'Saving password with Vorta settings.')
+
+        self.passwordLabel.setText(backend_msg)
 
     def choose_local_backup_folder(self):
         def receive():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-import pytest
-import peewee
-import sys
 import os
+import peewee
+import pytest
+import sys
 from datetime import datetime as dt
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
This PR tries to avoid common issues with system keychains that were reported:

- Add option to avoid using system keychain.
- Prioritize keychains first. Then try to start them.
- Maintenance: Possible fixes for hung tests and segfault on exit on some setups.


To test:

`$ pip install --force-reinstall git+https://github.com/m3nu/vorta.git@issue/make-keyring-optional`

In *Misc* tab disable the setting "Store repository passwords in system keychain...". After that all repo passwords will be stored with Vorta only, independent of the system keychain.

![Screen Shot 2021-02-27 at 10 58 39](https://user-images.githubusercontent.com/3916435/109373610-d8ce2100-78ea-11eb-80a4-b89e6c5da056.jpg)


