### PR TITLE
Refactor scheduler to use QTimer directly

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -58,7 +58,7 @@ class VortaApp(QtSingleApplication):
         init_translations(self)
 
         self.setQuitOnLastWindowClosed(False)
-        self.scheduler = VortaScheduler(self)
+        self.scheduler = VortaScheduler()
         self.setApplicationName("Vorta")
 
         # Prepare tray and main window
@@ -103,7 +103,7 @@ class VortaApp(QtSingleApplication):
 
     def quit_app_action(self):
         self.backup_cancelled_event.emit()
-        self.scheduler.shutdown()
+        # self.scheduler.exit()
         del self.main_window
         self.tray.deleteLater()
         del self.tray

--- a/src/vorta/assets/UI/scheduletab.ui
+++ b/src/vorta/assets/UI/scheduletab.ui
@@ -26,7 +26,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="schedule">
       <property name="geometry">
@@ -54,284 +54,278 @@
         <number>0</number>
        </property>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetFixedSize</enum>
-         </property>
-         <property name="bottomMargin">
-          <number>7</number>
-         </property>
-         <item>
-          <widget class="QRadioButton" name="scheduleOffRadio">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Backup manually</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QRadioButton" name="scheduleIntervalRadio">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Backup every </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="scheduleIntervalHours">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>740</number>
-           </property>
-          </widget>
-         </item>
-         <item alignment="Qt::AlignLeft">
-          <widget class="QLabel" name="label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>hours at</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="scheduleIntervalMinutes">
-           <property name="maximum">
-            <number>59</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_2">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>minutes past the hour</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <item>
-          <widget class="QRadioButton" name="scheduleFixedRadio">
-           <property name="text">
-            <string>Backup daily at</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QTimeEdit" name="scheduleFixedTime"/>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="validationCheckBox">
-           <property name="text">
-            <string>Validate repository data every</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-           <property name="tristate">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="validationSpinBox">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>52</number>
-           </property>
-           <property name="value">
-            <number>3</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>weeks</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="pruneCheckBox">
-           <property name="text">
-            <string>Prune old Archives after each backup</string>
-           </property>
-           <property name="tristate">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="Line" name="line_2">
+        <widget class="Line" name="line">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <layout class="QGridLayout" name="gridLayout_6">
          <property name="topMargin">
           <number>0</number>
          </property>
-         <property name="rightMargin">
-          <number>0</number>
+         <property name="bottomMargin">
+          <number>10</number>
          </property>
-         <item>
-          <widget class="QPushButton" name="scheduleApplyButton">
-           <property name="text">
-            <string>Apply</string>
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetFixedSize</enum>
            </property>
-          </widget>
+           <property name="bottomMargin">
+            <number>7</number>
+           </property>
+           <item>
+            <widget class="QRadioButton" name="scheduleOffRadio">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Backup manually</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
-         <item>
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>10</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+         <item row="2" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QRadioButton" name="scheduleFixedRadio">
+             <property name="text">
+              <string>Backup daily at</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTimeEdit" name="scheduleFixedTime"/>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
-         <item>
-          <widget class="QLabel" name="label_3">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <property name="topMargin">
+            <number>0</number>
            </property>
-           <property name="text">
-            <string>Next Backup:</string>
-           </property>
-          </widget>
+           <item>
+            <widget class="QCheckBox" name="missedBackupsCheckBox">
+             <property name="text">
+              <string>Run missed backups right after startup or wakeup. </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_5">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
-         <item>
-          <widget class="QLabel" name="nextBackupDateTimeLabel">
-           <property name="text">
-            <string>Off</string>
+         <item row="0" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <property name="topMargin">
+            <number>0</number>
            </property>
-          </widget>
+           <item>
+            <widget class="QCheckBox" name="validationCheckBox">
+             <property name="text">
+              <string>Validate repository data every</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <property name="tristate">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="validationSpinBox">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>52</number>
+             </property>
+             <property name="value">
+              <number>3</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>weeks</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
-         <item>
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+         <item row="1" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <property name="topMargin">
+            <number>0</number>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
+           <item>
+            <widget class="QCheckBox" name="pruneCheckBox">
+             <property name="text">
+              <string>Prune old Archives after each backup</string>
+             </property>
+             <property name="tristate">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QRadioButton" name="scheduleIntervalRadio">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Backup every </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="scheduleIntervalHours">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>740</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="scheduleIntervalUnit"/>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <property name="topMargin">
+            <number>0</number>
            </property>
-          </spacer>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Next Backup:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="nextBackupDateTimeLabel">
+             <property name="text">
+              <string>Off</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/src/vorta/borg/borg_thread.py
+++ b/src/vorta/borg/borg_thread.py
@@ -188,9 +188,9 @@ class BorgThread(QtCore.QThread, BackupProfileMixin):
     def run(self):
         self.started_event()
         mutex.acquire()
-        log_entry = EventLogModel(category='borg-run',
+        log_entry = EventLogModel(category=self.params.get('initiator', 'user'),
                                   subcommand=self.cmd[1],
-                                  profile=self.params.get('profile_name', None)
+                                  profile=self.params.get('profile_id', None)
                                   )
         log_entry.save()
         logger.info('Running command %s', ' '.join(self.cmd))

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -101,6 +101,7 @@ class BorgCreateThread(BorgThread):
             return ret
 
         ret['profile'] = profile
+        ret['profile_id'] = profile.id
         ret['repo'] = profile.repo
 
         # Run user-supplied pre-backup command

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -16,7 +16,7 @@ from playhouse.migrate import SqliteMigrator, migrate
 from vorta.i18n import trans_late
 from vorta.utils import slugify
 
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 
 db = pw.Proxy()
 
@@ -76,9 +76,10 @@ class BackupProfileModel(pw.Model):
     exclude_if_present = pw.TextField(null=True)
     schedule_mode = pw.CharField(default='off')
     schedule_interval_hours = pw.IntegerField(default=3)
-    schedule_interval_minutes = pw.IntegerField(default=42)
+    schedule_interval_unit = pw.CharField(default='hours')
     schedule_fixed_hour = pw.IntegerField(default=3)
     schedule_fixed_minute = pw.IntegerField(default=42)
+    schedule_make_up_missed = pw.BooleanField(default=False)
     validation_on = pw.BooleanField(default=True)
     validation_weeks = pw.IntegerField(default=3)
     prune_on = pw.BooleanField(default=False)
@@ -416,6 +417,15 @@ def init_db(con=None):
             current_schema, 17,
             migrator.add_column(RepoModel._meta.table_name,
                                 'create_backup_cmd', pw.CharField(default=''))
+        )
+
+    if current_schema.version < 18:
+        _apply_schema_update(
+            current_schema, 18,
+            migrator.add_column(BackupProfileModel._meta.table_name,
+                                'schedule_interval_unit', pw.CharField(default='hours')),
+            migrator.add_column(BackupProfileModel._meta.table_name,
+                                'schedule_make_up_missed', pw.BooleanField(default=False))
         )
 
     # Create missing settings and update labels. Leave setting values untouched.

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -54,7 +54,6 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.repoTab.repo_changed.connect(self.archiveTab.populate_from_profile)
         self.repoTab.repo_changed.connect(self.scheduleTab.populate_from_profile)
         self.repoTab.repo_added.connect(self.archiveTab.list_action)
-        self.tabWidget.currentChanged.connect(self.scheduleTab._draw_next_scheduled_backup)
 
         self.createStartBtn.clicked.connect(self.app.create_backup_action)
         self.cancelButton.clicked.connect(self.app.backup_cancelled_event.emit)

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -39,12 +39,16 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.logTableWidget.setSelectionBehavior(QTableView.SelectRows)
         self.logTableWidget.setEditTriggers(QTableView.NoEditTriggers)
 
+        self.scheduleIntervalUnit.addItem(self.tr('Minutes'), 'minutes')
+        self.scheduleIntervalUnit.addItem(self.tr('Hours'), 'hours')
+        self.scheduleIntervalUnit.addItem(self.tr('Days'), 'days')
+        self.scheduleIntervalUnit.addItem(self.tr('Weeks'), 'weeks')
+
         # Populate with data
         self.populate_from_profile()
         self.set_icons()
 
         # Connect events
-        self.scheduleApplyButton.clicked.connect(self.on_scheduler_apply)
         self.app.backup_finished_event.connect(self.populate_logs)
         self.dontRunOnMeteredNetworksCheckBox.stateChanged.connect(
             lambda new_val, attr='dont_run_on_metered_networks': self.save_profile_attr(attr, new_val))
@@ -67,17 +71,22 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.schedulerRadioMapping[profile.schedule_mode].setChecked(True)
 
         self.scheduleIntervalHours.setValue(profile.schedule_interval_hours)
-        self.scheduleIntervalMinutes.setValue(profile.schedule_interval_minutes)
+        self.scheduleIntervalUnit.setCurrentIndex(
+            self.scheduleIntervalUnit.findData(profile.schedule_interval_unit))
+
         self.scheduleFixedTime.setTime(
             QtCore.QTime(profile.schedule_fixed_hour, profile.schedule_fixed_minute))
 
         # Set checking options
         self.validationCheckBox.setCheckState(profile.validation_on)
         self.validationSpinBox.setValue(profile.validation_weeks)
+        self.validationCheckBox.setTristate(False)
 
         self.pruneCheckBox.setCheckState(profile.prune_on)
-        self.validationCheckBox.setTristate(False)
         self.pruneCheckBox.setTristate(False)
+
+        self.missedBackupsCheckBox.setCheckState(profile.schedule_make_up_missed)
+        self.missedBackupsCheckBox.setTristate(False)
 
         self.dontRunOnMeteredNetworksCheckBox.setChecked(profile.dont_run_on_metered_networks)
 
@@ -89,7 +98,6 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         else:
             self.createCmdLineEdit.setEnabled(False)
 
-        self._draw_next_scheduled_backup()
         self.populate_wifi()
         self.populate_logs()
 


### PR DESCRIPTION
- Remove APScheduler dependency and use QTimer directly
- Option to catch up with missed backups when machine was off or hibernated
- Remove *Apply* button on *Schedule* tab

Fixes #862, fixes #263