### PR TITLE
fix issue #940 - KeyError in get_dict_from_list

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -1,13 +1,11 @@
 import argparse
 import errno
 import getpass
-import operator
 import os
 import platform
 import re
 import sys
 import unicodedata
-from collections import defaultdict
 from datetime import datetime as dt
 from functools import reduce
 
@@ -105,11 +103,11 @@ def nested_dict():
     - https://stackoverflow.com/a/16724937/3983708
     - https://stackoverflow.com/a/14692747/3983708
     """
-    return defaultdict(nested_dict)
+    return dict()
 
 
 def get_dict_from_list(dataDict, mapList):
-    return reduce(operator.getitem, mapList, dataDict)
+    return reduce(lambda d, k: d.setdefault(k, {}), mapList, dataDict)
 
 
 def choose_file_dialog(parent, title, want_folder=True):

--- a/tests/borg_json_output/diff_archives_dict_issue_stdout.json
+++ b/tests/borg_json_output/diff_archives_dict_issue_stdout.json
@@ -1,0 +1,7 @@
+added directory     Users/manu/Downloads
+added         122 B Users/manu/Downloads/.transifexrc
+added       9.22 kB Users/manu/Downloads/12042021 ORDER COD NUMBER.doc
+removed directory   Users/manu/Downloads/test-diff/bar
+removed         0 B Users/manu/Downloads/test-diff/bar/2.txt
+removed directory   Users/manu/Downloads/test-diff/foo
+removed         0 B Users/manu/Downloads/test-diff/foo/1.txt

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -4,7 +4,9 @@ import vorta.views.archive_tab
 import vorta.utils
 
 
-def test_archive_diff(qapp, qtbot, mocker, borg_json_output):
+@pytest.mark.parametrize('json_mock_file,folder_root', [
+    ('diff_archives', 'test'), ('diff_archives_dict_issue', 'Users')])
+def test_archive_diff(qapp, qtbot, mocker, borg_json_output, json_mock_file, folder_root):
     main = qapp.main_window
     tab = main.archiveTab
     main.tabWidget.setCurrentIndex(3)
@@ -12,7 +14,7 @@ def test_archive_diff(qapp, qtbot, mocker, borg_json_output):
     tab.populate_from_profile()
     qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2)
 
-    stdout, stderr = borg_json_output('diff_archives')
+    stdout, stderr = borg_json_output(json_mock_file)
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
     mocker.patch.object(vorta.borg.borg_thread, 'Popen', return_value=popen_result)
 
@@ -24,7 +26,7 @@ def test_archive_diff(qapp, qtbot, mocker, borg_json_output):
     tab._window.diff_action()
     qtbot.waitUntil(lambda: hasattr(tab, '_resultwindow'), **pytest._wait_defaults)
 
-    assert tab._resultwindow.treeView.model().rootItem.childItems[0].data(0) == 'test'
+    assert tab._resultwindow.treeView.model().rootItem.childItems[0].data(0) == folder_root
     tab._resultwindow.treeView.model().rootItem.childItems[0].load_children()
 
     assert tab._resultwindow.archiveNameLabel_1.text() == 'test-archive'


### PR DESCRIPTION
- cause of error : defaultdict added more defaultdict while attempting to traverse the tree, but once a 'potential leaf' node was added, it was added as a dict, not a defaultdict.

example: (annotated output from 'borg diff --info --log-json repo::archive1 archive2')
added directory     home/rblenis/tmp/borgtest                              <-- 'home','rblenis','tmp' added as defaultdict, 'borgtest' added as dict
added       6.93 kB home/rblenis/tmp/borgtest/CircleFit.cpp       <-- 'CircleFit.cpp' added as dict
added       1.61 kB home/rblenis/tmp/borgtest/CircleFit.h           <-- 'CircleFit.h' added as dict
added directory     home/rblenis/tmp/borgtest/folder2                <-- 'folder2' added as dict
added       6.93 kB home/rblenis/tmp/borgtest/folder2/CircleFit.cpp   <-- 'CircleFit.cpp' added as dict
added       1.61 kB home/rblenis/tmp/borgtest/folder2/CircleFit.h       <-- 'CirclFit.h' added as dict
removed directory   home/rblenis/tmp/borgtest/foo/bar1                     <-- 'borgtest' is dict, so trying to traverse to non existent foo/bar1 throws KeyError.

- two possible solutions:
    - 1 - change everywhere that adds a 'potential' leaf node to add a defaultdict (ie nested_dict()) - this occurs in several places, but not many.
    - 2 - change get_dict_from_list to add a default dict (not defaultdict) when traversing the tree, for the case where a multi-level node is added on top of an existing node. This requires only changing a single location, and means that the dictionaries returned by accessing the tree will behave like normal dict (ie, won't by default add missing keys).

