### PR TITLE
Refuse to add inaccessible folders, warn on inaccessible files during backup

### DIFF
--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -33,7 +33,7 @@ class BorgCreateThread(BorgThread):
                 repo.save()
 
             if result['returncode'] == 1:
-                self.app.backup_progress_event.emit(self.tr('Backup finished. Some files were not accessible.'))
+                self.app.backup_progress_event.emit(self.tr('Backup finished with warnings. See logs for details.'))
             else:
                 self.app.backup_progress_event.emit(self.tr('Backup finished.'))
 

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -32,7 +32,10 @@ class BorgCreateThread(BorgThread):
                 repo.total_unique_chunks = stats['total_unique_chunks']
                 repo.save()
 
-            self.app.backup_progress_event.emit(self.tr('Backup finished.'))
+            if result['returncode'] == 1:
+                self.app.backup_progress_event.emit(self.tr('Backup finished. Some files were not accessible.'))
+            else:
+                self.app.backup_progress_event.emit(self.tr('Backup finished.'))
 
     def progress_event(self, fmt):
         self.app.backup_progress_event.emit(fmt)

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -159,7 +159,7 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
             for dir in dirs:
                 if not os.access(dir, os.R_OK):
                     msg = QMessageBox()
-                    msg.setText(self.tr("You don't have read access to this folder: ") + dir)
+                    msg.setText(self.tr(f"You don't have read access to {dir}."))
                     msg.exec()
                     return
 

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -157,6 +157,12 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
         def receive():
             dirs = dialog.selectedFiles()
             for dir in dirs:
+                if not os.access(dir, os.R_OK):
+                    msg = QMessageBox()
+                    msg.setText(self.tr("You don't have read access to this folder: ") + dir)
+                    msg.exec()
+                    return
+
                 new_source, created = SourceFileModel.get_or_create(dir=dir, profile=self.profile())
                 if created:
                     self.add_source_to_table(new_source)


### PR DESCRIPTION
We now refuse to add unreadable folders and .

<img src="https://user-images.githubusercontent.com/3916435/115100470-764ee400-9f6f-11eb-98ac-d0ef32c36415.jpg" width=400 />

warn about access errors during backup

<img src="https://user-images.githubusercontent.com/3916435/115100472-78b13e00-9f6f-11eb-821b-fcfd53a66afc.jpg" width=400 />


Fixes #916 