### PR TITLE
Import/export settings (or bootstrap with default config)

### DIFF
--- a/src/vorta/assets/UI/backupwindow.ui
+++ b/src/vorta/assets/UI/backupwindow.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>483</width>
+    <height>245</height>
+   </rect>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Location:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="locationLabel">
+       <property name="text">
+        <string>None</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="fileButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QCheckBox" name="overrideExisting">
+     <property name="text">
+      <string>Overwrite existing settings</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QCheckBox" name="storePassword">
+     <property name="text">
+      <string>Include password in export (Will be stored in plain text, anyone can read it)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="errors">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>10</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Open|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/vorta/views/backup_window.py
+++ b/src/vorta/views/backup_window.py
@@ -1,0 +1,258 @@
+from PyQt5 import uic
+from PyQt5 import QtCore
+from PyQt5.QtWidgets import QFileDialog, QDialogButtonBox
+from playhouse.shortcuts import model_to_dict, dict_to_model
+from vorta.models import db, BackupProfileModel, BackupProfileMixin, EventLogModel, SchemaVersion, \
+    SourceFileModel, SettingsModel, ArchiveModel, WifiSettingModel, RepoModel, SCHEMA_VERSION
+from vorta.utils import get_asset
+from vorta.keyring.db import VortaDBKeyring
+from vorta.keyring.abc import VortaKeyring
+from .utils import get_colored_icon
+from pathlib import Path
+import json
+import datetime
+
+uifile = get_asset('UI/backupwindow.ui')
+BackupWindowUI, BackupWindowBase = uic.loadUiType(uifile)
+
+
+class BackupWindow(BackupWindowBase, BackupWindowUI, BackupProfileMixin):
+    def __init__(self, parent):
+        super().__init__()
+        self.setupUi(self)
+        self.parent = parent
+        self.setWindowTitle(self.tr("Backup Profile"))
+        self.fileButton.setIcon(get_colored_icon('folder-open'))
+        self.fileButton.clicked.connect(self.get_file)
+        self.buttonBox.accepted.connect(self.run)
+        self.buttonBox.rejected.connect(self.reject)
+        self.set_button_box()
+
+        self.overrideExisting.hide()
+
+        profile = self.parent.current_profile
+        if profile.repo is None or VortaDBKeyring().get_password('vorta-repo', profile.repo.url) is None:
+            self.storePassword.hide()
+
+    def set_button_box(self):
+        self.buttonBox.button(QDialogButtonBox.Save).setText(self.tr("Save"))
+        self.buttonBox.button(QDialogButtonBox.Cancel).setText(self.tr("Cancel"))
+        self.buttonBox.button(QDialogButtonBox.Save).setEnabled(False)
+        self.buttonBox.button(QDialogButtonBox.Open).hide()
+
+    def profile_to_json(self, profile):
+        ''' Convert profile to json string '''
+        # Profile to dict
+        profile_dict = model_to_dict(profile, exclude=[RepoModel.id])  # Have to retain profile ID
+
+        keyring = VortaKeyring.get_keyring()
+        if self.storePassword.isChecked():
+            profile_dict['password'] = keyring.get_password('vorta-repo', profile.repo.url)
+
+        # For all below, exclude ids to prevent collisions. DB will automatically reassign ids
+        # Add SourceFileModel
+        profile_dict['SourceFileModel'] = [
+            model_to_dict(
+                source,
+                recurse=False, exclude=[SourceFileModel.id]) for source in SourceFileModel.select().where(
+                SourceFileModel.profile == profile)]
+        # Add ArchiveModel
+        profile_dict['ArchiveModel'] = [
+            model_to_dict(
+                archive,
+                recurse=False, exclude=[ArchiveModel.id]) for archive in ArchiveModel.select().where(
+                ArchiveModel.repo == profile.repo.id)]
+        # Add WifiSettingModel
+        profile_dict['WifiSettingModel'] = [
+            model_to_dict(
+                wifi, recurse=False) for wifi in WifiSettingModel.select().where(
+                WifiSettingModel.profile == profile.id)]
+        # Add EventLogModel
+        profile_dict['EventLogModel'] = [
+            model_to_dict(s) for s in EventLogModel.select().order_by(
+                EventLogModel.start_time.desc())]
+        # Add SchemaVersion
+        profile_dict['SchemaVersion'] = model_to_dict(SchemaVersion.get(id=1))
+        # Add SettingsModel
+        profile_dict['SettingsModel'] = [
+            model_to_dict(s, exclude=[SettingsModel.id]) for s in SettingsModel]
+
+        # Convert dict of profile to json string
+        return json.dumps(profile_dict, default=self.converter, indent=4)
+
+    def get_file(self):
+        ''' Get targetted save file with custom extension '''
+        fileName = QFileDialog.getSaveFileName(
+            self,
+            self.tr("Save profile"),
+            str(Path.home()),
+            self.tr("Vorta backup profile (*.vortabackup);;All files (*)"))[0]
+        if fileName:
+            self.locationLabel.setText(fileName)
+        self.buttonBox.button(QDialogButtonBox.Save).setEnabled(bool(fileName))
+
+    def run(self):
+        ''' Attempt to write backup to file '''
+        profile = self.parent.current_profile
+        json = self.profile_to_json(profile)
+        try:
+            with open(self.locationLabel.text(), 'w') as file:
+                file.write(json)
+        except (PermissionError, OSError):
+            self.errors.setText(self.tr("Backup file unwritable."))
+        else:
+            self.errors.setText(self.tr("Backup written to {}").format(self.locationLabel.text()))
+            self.locationLabel.setText("")
+            self.buttonBox.button(QDialogButtonBox.Save).setEnabled(False)
+
+    def converter(self, obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.__str__()
+
+
+class RestoreWindow(BackupWindow):
+    profile_restored = QtCore.pyqtSignal(BackupProfileModel, dict)
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Restore Profile"))
+        self.overrideExisting.show()
+        self.storePassword.hide()
+
+    def set_button_box(self):
+        self.buttonBox.button(QDialogButtonBox.Open).setText(self.tr("Open"))
+        self.buttonBox.button(QDialogButtonBox.Cancel).setText(self.tr("Cancel"))
+        self.buttonBox.button(QDialogButtonBox.Open).setEnabled(False)
+        self.buttonBox.button(QDialogButtonBox.Save).hide()
+
+    def json_to_profile(self, jsonData):
+        ''' Convert json string to profile and save '''
+        # Json string to dict
+        profile_dict = json.loads(jsonData)
+        profile_schema = profile_dict['SchemaVersion']['version']
+        returns = {}
+
+        keyring = VortaKeyring.get_keyring()
+
+        if SCHEMA_VERSION < profile_schema:
+            raise VersionException()
+        elif SCHEMA_VERSION > profile_schema:
+            # Add model upgrading code here, only needed if not adding columns
+            if profile_schema < 16:
+                for sourcedir in profile_dict['SourceFileModel']:
+                    sourcedir['dir_files_count'] = -1
+                    sourcedir['dir_size'] = -1
+                    sourcedir['path_isdir'] = False
+
+        # Guarantee uniqueness of ids
+        while BackupProfileModel.get_or_none(BackupProfileModel.id == profile_dict['id']) is not None:
+            profile_dict['id'] += 1
+
+        # Add suffix incase names are the same
+        if BackupProfileModel.get_or_none(BackupProfileModel.name == profile_dict['name']) is not None:
+            suffix = 1
+            while BackupProfileModel.get_or_none(
+                    BackupProfileModel.name == f"{profile_dict['name']}-{suffix}") is not None:
+                suffix += 1
+            profile_dict['name'] = f"{profile_dict['name']}-{suffix}"
+
+        # Load existing repo or restore it
+        repo = RepoModel.get_or_none(RepoModel.url == profile_dict['repo']['url'])
+        if repo is None:
+            # Load repo from backup
+            repo = dict_to_model(RepoModel, profile_dict['repo'])
+            repo.save(force_insert=True)
+            returns['repo'] = True
+        else:
+            # Use pre-exisitng repo
+            profile_dict['repo'] = model_to_dict(repo)
+
+        if profile_dict.get('password'):
+            keyring.set_password('vorta-repo', profile_dict['repo']['url'], profile_dict['password'])
+            del profile_dict['password']
+
+        # Delete and recreate the tables to clear them
+        if self.overrideExisting.isChecked():
+            db.drop_tables([SettingsModel, EventLogModel, WifiSettingModel])
+            db.create_tables([SettingsModel, EventLogModel, WifiSettingModel])
+            SettingsModel.insert_many(profile_dict['SettingsModel']).execute()
+            EventLogModel.insert_many(profile_dict['EventLogModel']).execute()
+            WifiSettingModel.insert_many(profile_dict['WifiSettingModel']).execute()
+            returns['overrideExisting'] = True
+
+        # Set the profile ids to be match new profile
+        for source in profile_dict['SourceFileModel']:
+            source['profile'] = profile_dict['id']
+        SourceFileModel.insert_many(profile_dict['SourceFileModel']).execute()
+
+        # Restore only if repo added to prevent overwriting
+        if returns.get('repo'):
+            # Set the profile ids to be match new profile
+            for archive in profile_dict['ArchiveModel']:
+                archive['repo'] = repo.id
+            profile_dict['repo'] = repo.id
+            ArchiveModel.insert_many(profile_dict['ArchiveModel']).execute()
+
+        # Delete added dictionaries to make it match BackupProfileModel
+        del profile_dict['SettingsModel']
+        del profile_dict['SourceFileModel']
+        del profile_dict['ArchiveModel']
+        del profile_dict['EventLogModel']
+        del profile_dict['WifiSettingModel']
+        del profile_dict['SchemaVersion']
+
+        # dict to profile
+        new_profile = dict_to_model(BackupProfileModel, profile_dict)
+        new_profile.save(force_insert=True)
+
+        return new_profile, returns
+
+    def run(self):
+        ''' Attempt to read backup file and restore profile '''
+        def get_schema_version(jsonData):
+            return json.loads(jsonData)['SchemaVersion']['version']
+
+        with open(self.locationLabel.text(), 'r') as file:
+            try:
+                jsonStr = file.read()
+                new_profile, returns = self.json_to_profile(jsonStr)
+            except (json.decoder.JSONDecodeError, KeyError):
+                self.errors.setText(self.tr("Invalid backup file"))
+            except AttributeError as e:
+                # Runs when model upgrading code in json_to_profile incomplete
+                schema_message = "Current schema: {0}\n Backup schema: {1}".format(
+                    SCHEMA_VERSION, get_schema_version(jsonStr))
+                self.errors.setText(
+                    self.tr("Schema upgrade failure, file a bug report with the link in the Misc tab "
+                            "with the following error: \n {0} \n {1}").format(str(e), schema_message))
+            except VersionException:
+                self.errors.setText(self.tr("Newer backup files cannot be used on older versions."))
+            except PermissionError:
+                self.errors.setText(self.tr("Cannot read backup file due to permission error."))
+            except FileNotFoundError:
+                self.errors.setText(self.tr("Backup file not found."))
+            else:
+                repo_url = new_profile.repo.url
+                keyring = VortaKeyring.get_keyring()
+                if keyring.get_password('vorta-repo', repo_url):
+                    self.errors.setText(self.tr(f"Profile {new_profile.name} restored sucessfully."))
+                else:
+                    self.errors.setText(
+                        self.tr(f"Profile {new_profile.name} restored, but the password for {repo_url} cannot be found, consider unlinking and readding the repository."))  # noqa
+                self.profile_restored.emit(new_profile, returns)
+
+    def get_file(self):
+        ''' Attempt to read backup from file '''
+        fileName = QFileDialog.getOpenFileName(
+            self,
+            self.tr("Load profile"),
+            str(Path.home()),
+            self.tr("Vorta backup profile (*.vortabackup);;All files (*)"))[0]
+        if fileName:
+            self.locationLabel.setText(fileName)
+        self.buttonBox.button(QDialogButtonBox.Open).setEnabled(bool(fileName))
+
+
+class VersionException(Exception):
+    ''' For when current_version < backup_version. Should only occur if downgrading '''
+    pass

--- a/tests/test_backuprestore.py
+++ b/tests/test_backuprestore.py
@@ -1,0 +1,112 @@
+import os
+from PyQt5 import QtCore
+from PyQt5.QtWidgets import QFileDialog, QDialogButtonBox
+from vorta.views.backup_window import RestoreWindow
+from vorta.models import BackupProfileModel, SourceFileModel
+
+
+def test_restore_success(qapp, qtbot, rootdir, monkeypatch):
+    # Do not change this file, as it also tests restoring from older schema versions
+    GOOD_FILE = os.path.join(rootdir, "testcase.vortabackup")
+
+    def getOpenFileName(*args, **kwargs):
+        return [GOOD_FILE]
+
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileName", getOpenFileName
+    )
+    '''
+    # Using this breaks the next test
+    main = qapp.main_window
+    main.restoreAction.trigger()
+    qtbot.waitUntil(lambda: hasattr(main, 'window'), timeout=10000)
+    restore_dialog = main.window
+    '''
+    restore_dialog = RestoreWindow(parent=qapp.main_window)
+
+    qtbot.mouseClick(restore_dialog.fileButton, QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: restore_dialog.locationLabel.text() == GOOD_FILE, timeout=5000)
+
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Open), QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: "sucessfully" in restore_dialog.errors.text(), timeout=5000)
+
+    restored_profile = BackupProfileModel.get_or_none(name="Test Profile Restoration")
+    assert restored_profile is not None
+    restored_repo = restored_profile.repo
+    assert restored_repo is not None
+    assert len(SourceFileModel.select().where(SourceFileModel.profile == restored_profile)) == 3
+    # assert main.profileSelector.currentText() == "Test Profile Restoration" # See above comment
+
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Cancel), QtCore.Qt.LeftButton)
+
+
+def test_restore_fail(qapp, qtbot, rootdir, monkeypatch):
+    BAD_FILE = os.path.join(rootdir, "invalid.vortabackup")
+
+    def getOpenFileName(*args, **kwargs):
+        return [BAD_FILE]
+
+    monkeypatch.setattr(
+        QFileDialog, "getOpenFileName", getOpenFileName
+    )
+    main = qapp.main_window
+    main.restoreAction.trigger()
+    qtbot.waitUntil(lambda: hasattr(main, 'window'), timeout=10000)
+    restore_dialog = main.window
+
+    qtbot.mouseClick(restore_dialog.fileButton, QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: restore_dialog.locationLabel.text() == BAD_FILE, timeout=5000)
+
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Open), QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: restore_dialog.errors.text() == "Invalid backup file", timeout=5000)
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Cancel), QtCore.Qt.LeftButton)
+
+
+def test_backup_success(qapp, qtbot, tmpdir, monkeypatch):
+    FILE_PATH = os.path.join(tmpdir, "testresult.vortabackup")
+
+    def getSaveFileName(*args, **kwargs):
+        return [FILE_PATH]
+
+    monkeypatch.setattr(
+        QFileDialog, "getSaveFileName", getSaveFileName
+    )
+
+    main = qapp.main_window
+    main.backupAction.trigger()
+    qtbot.waitUntil(lambda: hasattr(main, 'window'), timeout=10000)
+    restore_dialog = main.window
+
+    qtbot.mouseClick(restore_dialog.fileButton, QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: restore_dialog.locationLabel.text() == FILE_PATH, timeout=5000)
+
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Save), QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: "written to" in restore_dialog.errors.text(), timeout=5000)
+
+    assert os.path.isfile(FILE_PATH)
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Cancel), QtCore.Qt.LeftButton)
+
+
+def test_backup_fail(qapp, qtbot, tmpdir, monkeypatch):
+    FILE_PATH = os.path.join(os.path.abspath(os.sep), "testresult.vortabackup")
+
+    def getSaveFileName(*args, **kwargs):
+        return [FILE_PATH]
+
+    monkeypatch.setattr(
+        QFileDialog, "getSaveFileName", getSaveFileName
+    )
+
+    main = qapp.main_window
+    main.backupAction.trigger()
+    qtbot.waitUntil(lambda: hasattr(main, 'window'), timeout=10000)
+    restore_dialog = main.window
+
+    qtbot.mouseClick(restore_dialog.fileButton, QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: restore_dialog.locationLabel.text() == FILE_PATH, timeout=5000)
+
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Save), QtCore.Qt.LeftButton)
+    qtbot.waitUntil(lambda: "unwritable" in restore_dialog.errors.text(), timeout=5000)
+
+    assert not os.path.isfile(FILE_PATH)
+    qtbot.mouseClick(restore_dialog.buttonBox.button(QDialogButtonBox.Cancel), QtCore.Qt.LeftButton)

--- a/tests/testcase.vortabackup
+++ b/tests/testcase.vortabackup
@@ -1,0 +1,319 @@
+{
+    "id": 1,
+    "name": "Test Profile Restoration",
+    "added_at": "2020-09-10 01:09:03.402268",
+    "repo": {
+        "url": "/tmp/asdf",
+        "added_at": "2020-09-10 21:48:21.427080",
+        "encryption": "repokey-blake2",
+        "unique_size": null,
+        "unique_csize": null,
+        "total_size": null,
+        "total_unique_chunks": null,
+        "extra_borg_arguments": ""
+    },
+    "ssh_key": null,
+    "compression": "zstd,8",
+    "exclude_patterns": null,
+    "exclude_if_present": ".nobackup",
+    "schedule_mode": "off",
+    "schedule_interval_hours": 1,
+    "schedule_interval_minutes": 26,
+    "schedule_fixed_hour": 16,
+    "schedule_fixed_minute": 0,
+    "validation_on": true,
+    "validation_weeks": 3,
+    "prune_on": true,
+    "prune_hour": 2,
+    "prune_day": 7,
+    "prune_week": 4,
+    "prune_month": 6,
+    "prune_year": 2,
+    "prune_keep_within": "10H",
+    "new_archive_name": "{hostname}-{profile_slug}-{now:%Y-%m-%dT%H:%M:%S}",
+    "prune_prefix": "{hostname}-{profile_slug}-",
+    "pre_backup_cmd": "",
+    "password": "Tr0ub4dor&3",
+    "post_backup_cmd": "",
+    "dont_run_on_metered_networks": true,
+    "SourceFileModel": [
+        {
+            "dir": "/this/is/a/test/file",
+            "profile": 1,
+            "added_at": "2020-07-03 03:39:35.226932"
+        },
+        {
+            "dir": "/this/is/another/test/file",
+            "profile": 1,
+            "added_at": "2020-07-03 04:37:02.367233"
+        },
+        {
+            "dir": "/why/are/you/reading/this",
+            "profile": 1,
+            "added_at": "2020-07-03 04:37:05.106150"
+        }
+    ],
+    "ArchiveModel": [],
+    "WifiSettingModel": [],
+    "EventLogModel": [
+        {
+            "id": 20,
+            "start_time": "2020-09-10 21:47:45.882513",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 19,
+            "start_time": "2020-09-10 21:47:18.649705",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 18,
+            "start_time": "2020-09-10 21:46:17.805760",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 17,
+            "start_time": "2020-09-10 21:07:51.201491",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 16,
+            "start_time": "2020-09-10 21:07:39.605904",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 15,
+            "start_time": "2020-09-10 17:01:02.869225",
+            "category": "borg-run",
+            "subcommand": "check",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": "Test Profile",
+            "repo_url": "/tmp/asdf"
+        },
+        {
+            "id": 14,
+            "start_time": "2020-09-10 17:00:00.042385",
+            "category": "borg-run",
+            "subcommand": "create",
+            "message": null,
+            "returncode": 1,
+            "params": null,
+            "profile": "Test Profile",
+            "repo_url": "/tmp/asdf"
+        },
+        {
+            "id": 13,
+            "start_time": "2020-09-10 14:39:44.207662",
+            "category": "borg-run",
+            "subcommand": "create",
+            "message": null,
+            "returncode": 1,
+            "params": null,
+            "profile": "Test Profile",
+            "repo_url": "/tmp/asdf"
+        },
+        {
+            "id": 12,
+            "start_time": "2020-09-10 14:39:42.227646",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 11,
+            "start_time": "2020-09-10 14:39:27.960603",
+            "category": "borg-run",
+            "subcommand": "create",
+            "message": null,
+            "returncode": 2,
+            "params": null,
+            "profile": "Test Profile",
+            "repo_url": "/tmp/asdf"
+        },
+        {
+            "id": 10,
+            "start_time": "2020-09-10 01:29:34.257565",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 9,
+            "start_time": "2020-09-10 01:21:03.401751",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 8,
+            "start_time": "2020-09-10 01:17:57.422174",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 7,
+            "start_time": "2020-09-10 01:17:46.624724",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 6,
+            "start_time": "2020-09-10 01:16:05.428776",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 5,
+            "start_time": "2020-09-10 01:10:04.425668",
+            "category": "borg-run",
+            "subcommand": "list",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": "Default",
+            "repo_url": "/tmp/asdf"
+        },
+        {
+            "id": 4,
+            "start_time": "2020-09-10 01:10:03.313018",
+            "category": "borg-run",
+            "subcommand": "info",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": "New Repo",
+            "repo_url": "/tmp/asdf"
+        },
+        {
+            "id": 3,
+            "start_time": "2020-09-10 01:09:41.246724",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 2,
+            "start_time": "2020-09-10 01:09:17.363603",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        },
+        {
+            "id": 1,
+            "start_time": "2020-09-10 01:09:04.118227",
+            "category": "borg-run",
+            "subcommand": "--version",
+            "message": null,
+            "returncode": 0,
+            "params": null,
+            "profile": null,
+            "repo_url": null
+        }
+    ],
+    "SchemaVersion": {
+        "id": 1,
+        "version": 15,
+        "changed_at": "2020-10-19 19:07:35.305493"
+    },
+    "SettingsModel": [
+        {
+            "id": 1,
+            "key": "enable_notifications",
+            "value": true,
+            "str_value": "",
+            "label": "Display notifications when background tasks fail",
+            "type": "checkbox"
+        },
+        {
+            "id": 2,
+            "key": "enable_notifications_success",
+            "value": false,
+            "str_value": "",
+            "label": "Also notify about successful background tasks",
+            "type": "checkbox"
+        },
+        {
+            "id": 3,
+            "key": "autostart",
+            "value": false,
+            "str_value": "",
+            "label": "Automatically start Vorta at login",
+            "type": "checkbox"
+        },
+        {
+            "id": 4,
+            "key": "foreground",
+            "value": true,
+            "str_value": "",
+            "label": "Open main window on startup",
+            "type": "checkbox"
+        }
+    ]
+}


### PR DESCRIPTION
Here a work-in-progress of the import/export feature. I cherry-picked the main files since other files have diverged since this was added. Left to do:

- Not necessary to export archive details, since they can be fetched from the repo.
- Discuss file name/extension to use. Currently `.vortabackup`. Maybe just `vorta-profile.json` is clearer (see example test file)
- You wanted to bootstrap from a default location. This could be triggered by looking for a specific file, if there are no repos (in `srv/vorta/models.py`) or with a command line argument. The former might be better.
- Most logic is in `backup_window.py` This needs to be linked to some button in the main window. Maybe next to the profile changer. Roughly like this:
```
def __init__():
    ...
    self.backupAction = menu.addAction("Backup profile", self.profile_backup_action)
    self.restoreAction = menu.addAction("Restore profile backup", self.profile_restore_action)
    ...

def profile_backup_action(self):
    window = BackupWindow(parent=self)
    self.window = window
    window.setParent(self, QtCore.Qt.Sheet)
    window.show()

def profile_restore_action(self):
    def profile_restored_event(new_profile, returns):
        if returns.get('repo'):
            self.repoTab.set_repos()
        if returns.get('overrideExisting'):
            self.scheduleTab.init_logs()
            self.scheduleTab.init_wifi()
            self.miscTab.populate_from_profile()
        self.add_profile_entry(new_profile.name, new_profile.id)
    window = RestoreWindow(parent=self)
    self.window = window
    window.setParent(self, QtCore.Qt.Sheet)
    window.profile_restored.connect(profile_restored_event)
    window.show()
```