### PR TITLE
Show backup size with excludes applied

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ setup_requires =
   setuptools_git
 install_requires =
   appdirs
+  globmatch
   paramiko
   pyqt5
   peewee

--- a/src/vorta/assets/UI/sourcetab.ui
+++ b/src/vorta/assets/UI/sourcetab.ui
@@ -81,6 +81,11 @@
        </column>
        <column>
         <property name="text">
+         <string>Size (filtered)</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
          <string>File Count</string>
         </property>
        </column>


### PR DESCRIPTION
since I want this feature and I believe it has been requested elsewhere already, I had a first stab at it, as a proof-of-concept.

![vorta](https://user-images.githubusercontent.com/724844/115997823-ddf6d600-a5e4-11eb-90a0-5f76877f5c27.png)

I'm currently not sure if the `globmatch` package handles patterns the same way `borg` does.