### PR TITLE
Fix for #915 . Folder ares sorted with type.

### DIFF
--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -31,6 +31,8 @@ class DiffResult(DiffResultBase, DiffResultUI):
 
         files_with_attributes, nested_file_list = parse_diff_json_lines(lines) \
             if json_lines else parse_diff_lines(lines)
+        # add type attributes : directory, files
+        files_with_attributes = [attrs + (type_f, ) for attrs, type_f in zip(files_with_attributes, fs_data[1])]
         model = DiffTree(files_with_attributes, nested_file_list)
 
         view = self.treeView
@@ -165,7 +167,7 @@ def parse_diff_lines(diff_lines):
 
     files_with_attributes = [parse_line(line) for line in diff_lines if line]
 
-    return (files_with_attributes, nested_file_list)
+    return files_with_attributes, nested_file_list
 
 
 def calc_size(significand, unit):

--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -35,7 +35,7 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
             d = get_dict_from_list(nested_file_list, dirpath.split("/"))
             if name not in d:
                 d[name] = {}
-            return size, modified, name, dirpath
+            return size, modified, name, dirpath, data["type"]
 
         # handle case of a single line of result, which will already be a dict
         lines = [fs_data] if isinstance(fs_data, dict) else \

--- a/src/vorta/views/partials/tree_view.py
+++ b/src/vorta/views/partials/tree_view.py
@@ -188,7 +188,7 @@ class TreeModel(QAbstractItemModel):
         parent=None,
     ):
         files_with_attributes.sort(key=lambda x: x[2].upper())  # Sorts tuples by name ignoring case
-        files_with_attributes.sort(key=lambda x: x[0] != 0)  # Pushes folders (size zero) to start of list
+        files_with_attributes.sort(key=lambda x: x[4] != 'd')  # Pushes folders (type 'd') to start of list
 
         super(TreeModel, self).__init__(parent)
 

--- a/tests/borg_json_output/list_archive_stdout.json
+++ b/tests/borg_json_output/list_archive_stdout.json
@@ -1,69 +1,69 @@
-{"size": 0, "mtime": "2018-11-29T10:35:09", "path": "Users/manu/Desktop"}
-{"size": 0, "mtime": "2013-09-04T00:54:20", "path": "Users/manu/Desktop/.ipynb_checkpoints"}
-{"size": 247348, "mtime": "2013-09-04T01:00:31", "path": "Users/Untitled7-checkpoint.ipynb"}
-{"size": 888, "mtime": "2018-03-21T23:18:32", "path": "Users/manu/Desktop/Receipts"}
-{"size": 800, "mtime": "2018-03-21T23:18:58", "path": "Users/manu/Desktop/Documents"}
-{"size": 840, "mtime": "2018-03-27T00:42:58", "path": "Users/manu/Desktop/travel"}
-{"size": 199, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.au/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my"}
-{"size": 199, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com"}
-{"size": 196, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de"}
-{"size": 195, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com"}
-{"size": 194, "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:42", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com"}
-{"size": 190, "mtime": "2017-02-24T12:13:42", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net"}
-{"size": 191, "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:44", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com"}
-{"size": 194, "mtime": "2017-02-24T12:13:44", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com/settings.sol"}
-{"size": 0, "mtime": "2017-02-24T12:13:38", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net"}
-{"size": 199, "mtime": "2017-02-24T12:13:38", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net/settings.sol"}
-{"size": 188016, "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/NuFS.framework/Versions/A/NuFS"}
-{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext"}
-{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents"}
-{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS"}
-{"size": 229692, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS/transmitdiskfs"}
-{"size": 1908, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/Info.plist"}
-{"size": 339916, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/libfuse.dylib"}
-{"size": 47376, "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/load_nufs"}
-{"size": 74416, "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/mount_nufs"}
-{"size": 65853, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/License.pdf"}
-{"size": 2682, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Info.plist"}
-{"size": 551, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/version.plist"}
-{"size": 129893, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/disk-transmit.icns"}
-{"size": 1178, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/sparkle_dsa_pub.pem"}
-{"size": 0, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature"}
-{"size": 8378, "mtime": "2014-09-19T05:52:30", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature/CodeResources"}
-{"size": 1768, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Info.plist"}
-{"size": 8, "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/PkgInfo"}
-{"size": 239529, "mtime": "2018-11-29T08:51:51", "path": "Users/manu/Library/Application Support/Transmit/Connections.transmitstore"}
-{"size": 0, "mtime": "2018-11-13T09:02:33", "path": "Users/manu/Library/Application Support/coconutBattery"}
-{"size": 30939, "mtime": "2017-09-11T22:52:42", "path": "Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive.backup_3.6.3"}
-{"size": 31097, "mtime": "2017-04-08T18:45:35", "path": "Users/manu/Library/Application Support/coconutBattery/coconutBatteryData.ccbarchive"}
-{"size": 98162, "mtime": "2018-11-13T09:02:33", "path": "Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive"}
-{"size": 84803, "mtime": "2013-12-10T13:41:58", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-11-02.PDF"}
-{"size": 84228, "mtime": "2013-12-10T13:42:02", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-12-02.PDF"}
-{"size": 85337, "mtime": "2014-01-07T21:28:09", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-01-02.PDF"}
-{"size": 84228, "mtime": "2014-04-07T22:48:28", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-02-02.PDF"}
-{"size": 85095, "mtime": "2014-04-07T22:52:59", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-03-02.PDF"}
-{"size": 83329, "mtime": "2014-04-07T22:53:03", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-04-02.PDF"}
-{"size": 0, "mtime": "2016-03-15T19:29:23", "path": "Users/manu/Documents/financial/_archive/Direktanlage"}
-{"size": 117360, "mtime": "2013-08-27T14:53:25", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300001.PDF"}
-{"size": 156800, "mtime": "2013-10-16T20:21:38", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300002.PDF"}
-{"size": 80720, "mtime": "2014-01-04T21:05:34", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300003.PDF"}
-{"size": 1292665, "mtime": "2012-07-23T05:26:43", "path": "Users/manu/Documents/cooking/IMG_20120505_160225.jpg"}
-{"size": 1330876, "mtime": "2012-07-23T05:26:40", "path": "Users/manu/Documents/cooking/IMG_20120505_160425.jpg"}
-{"size": 1219294, "mtime": "2012-07-23T05:26:43", "path": "Users/manu/Documents/cooking/IMG_20120505_160842.jpg"}
-{"size": 1205672, "mtime": "2012-07-23T05:26:44", "path": "Users/manu/Documents/cooking/IMG_20120505_161225.jpg"}
-{"size": 1254561, "mtime": "2012-07-23T05:26:42", "path": "Users/manu/Documents/cooking/IMG_20120505_161247.jpg"}
-{"size": 1141842, "mtime": "2012-07-23T05:26:44", "path": "Users/manu/Documents/cooking/IMG_20120505_161525.jpg"}
-{"size": 1143566, "mtime": "2012-07-23T05:26:37", "path": "Users/manu/Documents/cooking/IMG_20120505_162547.jpg"}
-{"size": 1015435, "mtime": "2012-02-25T21:55:12", "path": "Users/manu/Documents/cooking/Jamie Oliver Tuna in Tomatoe Sauce.pdf"}
-{"size": 33762, "mtime": "2012-11-02T23:19:19", "path": "Users/manu/Documents/cooking/Mediterranean Beef Stew with Rosemary.pdf"}
-{"size": 1225647, "mtime": "2012-07-23T05:26:50", "path": "Users/manu/Documents/cooking/Schweinekotelett und Ratatouille.jpg"}
-{"size": 1038737, "mtime": "2012-12-12T21:38:43", "path": "Users/manu/Documents/cooking/Shrimp, Avocado and Red Pepper Salad.pdf"}
-{"size": 65393, "mtime": "2012-11-13T22:04:04", "path": "Users/manu/Documents/cooking/Tiramisu Semifreddo.pdf"}
-{"size": 1266835, "mtime": "2012-07-23T05:26:50", "path": "Users/manu/Documents/cooking/Tomaten-Paprika Suppe.jpg"}
+{"size": 0,"type": "d", "mtime": "2018-11-29T10:35:09", "path": "Users/manu/Desktop"}
+{"size": 0,"type": "-", "mtime": "2013-09-04T00:54:20", "path": "Users/manu/Desktop/.ipynb_checkpoints"}
+{"size": 247348,"type": "-", "mtime": "2013-09-04T01:00:31", "path": "Users/Untitled7-checkpoint.ipynb"}
+{"size": 888,"type": "d", "mtime": "2018-03-21T23:18:32", "path": "Users/manu/Desktop/Receipts"}
+{"size": 800,"type": "d", "mtime": "2018-03-21T23:18:58", "path": "Users/manu/Desktop/Documents"}
+{"size": 840,"type": "d", "mtime": "2018-03-27T00:42:58", "path": "Users/manu/Desktop/travel"}
+{"size": 199,"type": "-", "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.au/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my"}
+{"size": 199,"type": "-", "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com.my/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com"}
+{"size": 196,"type": "-", "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.com/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de"}
+{"size": 195,"type": "-", "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tripadvisor.de/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com"}
+{"size": 194,"type": "-", "mtime": "2017-02-24T12:13:41", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.tunescoop.com/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:42", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com"}
+{"size": 190,"type": "-", "mtime": "2017-02-24T12:13:42", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.udemy.com/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net"}
+{"size": 191,"type": "-", "mtime": "2017-02-24T12:13:39", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ulozto.net/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:44", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com"}
+{"size": 194,"type": "-", "mtime": "2017-02-24T12:13:44", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.ultimedia.com/settings.sol"}
+{"size": 0,"type": "-", "mtime": "2017-02-24T12:13:38", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net"}
+{"size": 199,"type": "-", "mtime": "2017-02-24T12:13:38", "path": "Users/manu/Library/Application Support/Google/Chrome/Default/Pepper Data/Shockwave Flash/WritableRoot/#SharedObjects/K4JZRG4W/macromedia.com/support/flashplayer/sys/#www.videodetective.net/settings.sol"}
+{"size": 188016,"type": "d", "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/NuFS.framework/Versions/A/NuFS"}
+{"size": 0,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext"}
+{"size": 0,"type": "d", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents"}
+{"size": 0,"type": "d", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS"}
+{"size": 229692,"type": "d", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/MacOS/transmitdiskfs"}
+{"size": 1908,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/transmitdiskfs.kext/Contents/Info.plist"}
+{"size": 339916,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/libfuse.dylib"}
+{"size": 47376,"type": "d", "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/load_nufs"}
+{"size": 74416,"type": "d", "mtime": "2014-09-19T05:52:28", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/com.panic.TransmitDisk.transmitdiskfs.components/mount_nufs"}
+{"size": 65853,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Resources/License.pdf"}
+{"size": 2682,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/Info.plist"}
+{"size": 551,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/transmitdiskfs.fs/Contents/version.plist"}
+{"size": 129893,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/disk-transmit.icns"}
+{"size": 1178,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Resources/sparkle_dsa_pub.pem"}
+{"size": 0,"type": "d", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature"}
+{"size": 8378,"type": "d", "mtime": "2014-09-19T05:52:30", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/_CodeSignature/CodeResources"}
+{"size": 1768,"type": "-", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/Info.plist"}
+{"size": 8,"type": "d", "mtime": "2014-09-19T05:51:56", "path": "Users/manu/Library/Application Support/Transmit/Transmit Disk.app/Contents/PkgInfo"}
+{"size": 239529,"type": "-", "mtime": "2018-11-29T08:51:51", "path": "Users/manu/Library/Application Support/Transmit/Connections.transmitstore"}
+{"size": 0,"type": "d", "mtime": "2018-11-13T09:02:33", "path": "Users/manu/Library/Application Support/coconutBattery"}
+{"size": 30939,"type": "-", "mtime": "2017-09-11T22:52:42", "path": "Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive.backup_3.6.3"}
+{"size": 31097,"type": "-", "mtime": "2017-04-08T18:45:35", "path": "Users/manu/Library/Application Support/coconutBattery/coconutBatteryData.ccbarchive"}
+{"size": 98162,"type": "-", "mtime": "2018-11-13T09:02:33", "path": "Users/manu/Library/Application Support/coconutBattery/Mac.ccbarchive"}
+{"size": 84803,"type": "-", "mtime": "2013-12-10T13:41:58", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-11-02.PDF"}
+{"size": 84228,"type": "-", "mtime": "2013-12-10T13:42:02", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2013-12-02.PDF"}
+{"size": 85337,"type": "-", "mtime": "2014-01-07T21:28:09", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-01-02.PDF"}
+{"size": 84228,"type": "-", "mtime": "2014-04-07T22:48:28", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-02-02.PDF"}
+{"size": 85095,"type": "-", "mtime": "2014-04-07T22:52:59", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-03-02.PDF"}
+{"size": 83329,"type": "-", "mtime": "2014-04-07T22:53:03", "path": "Users/manu/Documents/financial/_archive/Diners Club/kontoauszug-2014-04-02.PDF"}
+{"size": 0,"type": "d", "mtime": "2016-03-15T19:29:23", "path": "Users/manu/Documents/financial/_archive/Direktanlage"}
+{"size": 117360,"type": "-", "mtime": "2013-08-27T14:53:25", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300001.PDF"}
+{"size": 156800,"type": "-", "mtime": "2013-10-16T20:21:38", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300002.PDF"}
+{"size": 80720,"type": "-", "mtime": "2014-01-04T21:05:34", "path": "Users/manu/Documents/financial/_archive/Direktanlage/19250_65300182206_EUR_201300003.PDF"}
+{"size": 1292665,"type": "-", "mtime": "2012-07-23T05:26:43", "path": "Users/manu/Documents/cooking/IMG_20120505_160225.jpg"}
+{"size": 1330876,"type": "-", "mtime": "2012-07-23T05:26:40", "path": "Users/manu/Documents/cooking/IMG_20120505_160425.jpg"}
+{"size": 1219294,"type": "-", "mtime": "2012-07-23T05:26:43", "path": "Users/manu/Documents/cooking/IMG_20120505_160842.jpg"}
+{"size": 1205672,"type": "-", "mtime": "2012-07-23T05:26:44", "path": "Users/manu/Documents/cooking/IMG_20120505_161225.jpg"}
+{"size": 1254561,"type": "-", "mtime": "2012-07-23T05:26:42", "path": "Users/manu/Documents/cooking/IMG_20120505_161247.jpg"}
+{"size": 1141842,"type": "-", "mtime": "2012-07-23T05:26:44", "path": "Users/manu/Documents/cooking/IMG_20120505_161525.jpg"}
+{"size": 1143566,"type": "-", "mtime": "2012-07-23T05:26:37", "path": "Users/manu/Documents/cooking/IMG_20120505_162547.jpg"}
+{"size": 1015435,"type": "-", "mtime": "2012-02-25T21:55:12", "path": "Users/manu/Documents/cooking/Jamie Oliver Tuna in Tomatoe Sauce.pdf"}
+{"size": 33762,"type": "-", "mtime": "2012-11-02T23:19:19", "path": "Users/manu/Documents/cooking/Mediterranean Beef Stew with Rosemary.pdf"}
+{"size": 1225647,"type": "-", "mtime": "2012-07-23T05:26:50", "path": "Users/manu/Documents/cooking/Schweinekotelett und Ratatouille.jpg"}
+{"size": 1038737,"type": "-", "mtime": "2012-12-12T21:38:43", "path": "Users/manu/Documents/cooking/Shrimp, Avocado and Red Pepper Salad.pdf"}
+{"size": 65393,"type": "-", "mtime": "2012-11-13T22:04:04", "path": "Users/manu/Documents/cooking/Tiramisu Semifreddo.pdf"}
+{"size": 1266835,"type": "-", "mtime": "2012-07-23T05:26:50", "path": "Users/manu/Documents/cooking/Tomaten-Paprika Suppe.jpg"}


### PR DESCRIPTION
Fix for #915 . Folders are sorted with their type ('d') and not their size. It's a little first contribution (but I have deeply studied tree_view and extrac_dialog), so maybe it's not the better way to handle this issue. I don't understand why tests on archive tab are not passed from now on...