### PR TITLE
Fix context menu not accessible on some setup

### DIFF
--- a/src/vorta/tray_menu.py
+++ b/src/vorta/tray_menu.py
@@ -16,6 +16,7 @@ class TrayMenu(QSystemTrayIcon):
 
         # Workaround to get `activated` signal on Unity: https://stackoverflow.com/a/43683895/3983708
         menu.aboutToShow.connect(self.on_user_click)
+        menu.aboutToHide.connect(self.on_menu_hide)
 
         self.setContextMenu(menu)
 
@@ -36,11 +37,16 @@ class TrayMenu(QSystemTrayIcon):
         else:
             self.on_user_click()
 
+    def on_menu_hide(self):
+        """Clear context menu when hidden from user"""
+
+        menu = self.contextMenu()
+        menu.clear()
+
     def on_user_click(self):
         """Build system tray menu based on current state."""
 
         menu = self.contextMenu()
-        menu.clear()
 
         open_action = menu.addAction(self.tr('Vorta for Borg Backup'))
         open_action.triggered.connect(self.app.open_main_window_action)


### PR DESCRIPTION
On some setup (i3 wm), there is a bug preventing user to access the context menu from the tray icon. The context menu is hidden from user after a right click : 

https://user-images.githubusercontent.com/1941583/125169047-c1f8de80-e1a8-11eb-905e-03cfc770b540.mp4

The `QMenu::clear()` method seems to be responsible for this behavior. Calling `clear()` on the menu widget only when menu is hidden fix the issue.
