### PR TITLE
Fix context menu not accessible on some setup

### DIFF
--- a/src/vorta/tray_menu.py
+++ b/src/vorta/tray_menu.py
@@ -33,8 +33,6 @@ class TrayMenu(QSystemTrayIcon):
         if reason in [QSystemTrayIcon.Trigger, QSystemTrayIcon.DoubleClick] and \
                 os.environ.get('XDG_CURRENT_DESKTOP'):
             self.app.toggle_main_window_visibility()
-        else:
-            self.on_user_click()
 
     def on_user_click(self):
         """Build system tray menu based on current state."""


### PR DESCRIPTION
This PR fix #1030.

It was tested on : 
- i3 (Arch)
- sway / Wayland (Arch)
- Cinnamon (Mint)
- Unity (Ubuntu 20.04)
- Windows 10

The `aboutToShow` signal should be reliable on Mac as well (not tested).