### PR TITLE
Show error dialog when .vorta-init.json is malformed (fixes #1053)

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -257,8 +257,22 @@ class VortaApp(QtSingleApplication):
         or add an empty "Default" profile.
         """
         if bootstrap_file.is_file():
-            profile_export = ProfileExport.from_json(bootstrap_file)
-            profile = profile_export.to_db(overwrite_profile=True, overwrite_settings=True)
+            try:
+                profile_export = ProfileExport.from_json(bootstrap_file)
+                profile = profile_export.to_db(overwrite_profile=True, overwrite_settings=True)
+            except Exception as exception:
+                double_newline = os.linesep + os.linesep
+                QMessageBox.critical(None,
+                                     self.tr('Failed to import profile'),
+                                     "{}{}\"{}\"{}{}".format(
+                                         self.tr('Failed to import a profile from {}:').format(bootstrap_file),
+                                         double_newline,
+                                         str(exception),
+                                         double_newline,
+                                         self.tr('Consider removing or repairing this file to '
+                                                 'get rid of this message.'),
+                                     ))
+                return
             bootstrap_file.unlink()
             notifier = VortaNotifications.pick()
             notifier.deliver(self.tr('Profile import successful!'),

--- a/src/vorta/profile_export.py
+++ b/src/vorta/profile_export.py
@@ -145,8 +145,10 @@ class ProfileExport:
         with open(filename, 'r') as file:
             try:
                 profile_export = ProfileExport(json.loads(file.read()))
-            except JSONDecodeError:
-                return None
+            except JSONDecodeError as exception:
+                raise ImportFailedException(
+                    'This file does not contain valid JSON: {}'.format(str(exception))
+                ) from exception
         return profile_export
 
     def to_json(self):
@@ -160,4 +162,9 @@ class ProfileExport:
 
 class VersionException(Exception):
     """ For when current_version < export_version. Should only occur if downgrading """
+    pass
+
+
+class ImportFailedException(Exception):
+    """Raised when a profile could not be imported."""
     pass

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -10,7 +10,7 @@ from vorta.models import BackupProfileModel, SettingsModel
 from vorta.utils import borg_compat, get_asset, is_system_tray_available, get_network_status_monitor
 from vorta.views.partials.loading_button import LoadingButton
 from vorta.views.utils import get_colored_icon
-from vorta.profile_export import ProfileExport
+from vorta.profile_export import ProfileExport, ImportFailedException
 from .archive_tab import ArchiveTab
 from .export_window import ExportWindow
 from .import_window import ImportWindow
@@ -217,11 +217,12 @@ class MainWindow(MainWindowBase, MainWindowUI):
             str(Path.home()),
             self.tr("JSON (*.json);;All files (*)"))[0]
         if filename:
-            profile_export = ProfileExport.from_json(filename)
-            if profile_export is None:
+            try:
+                profile_export = ProfileExport.from_json(filename)
+            except ImportFailedException as exception:
                 QMessageBox.critical(None,
-                                     self.tr('Error'),
-                                     self.tr('This file does not contain valid JSON.'))
+                                     self.tr('Failed to import profile'),
+                                     self.tr(str(exception)))
                 return
             window = ImportWindow(profile_export=profile_export)
             self.window = window

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -72,7 +72,7 @@ def test_import_fail_not_json(qapp, rootdir, monkeypatch):
     main.profile_import_action()
 
     # assert somehow that an alert is shown
-    assert alert_message == 'This file does not contain valid JSON.'
+    assert alert_message == 'This file does not contain valid JSON: Expecting value: line 1 column 1 (char 0)'
 
 
 def test_export_success(qapp, qtbot, tmpdir, monkeypatch):


### PR DESCRIPTION
See #1053 for a description of the problem.

This solution catches all exceptions during bootstrap and prints them. The normal exception handler is not yet ready to show the error graphically so we do it ourselves.
While catching all exception is not considered good style I think it is justified in this case because the program should still be in an operable state if the import fails. Currently the program crashes silently on start rendering Vorta inoperable.