### PR TITLE
Add tooltip containing path name

### DIFF
--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -112,8 +112,10 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
 
         index_row = self.sourceFilesWidget.rowCount()
         self.sourceFilesWidget.insertRow(index_row)
-        # Insert all items on current row
-        self.sourceFilesWidget.setItem(index_row, SourceColumn.Path, QTableWidgetItem(source.dir))
+        # Insert all items on current row, add tooltip containg the path name
+        new_item = QTableWidgetItem(source.dir)
+        new_item.setToolTip(source.dir)
+        self.sourceFilesWidget.setItem(index_row, SourceColumn.Path, new_item)
         self.sourceFilesWidget.setItem(index_row, SourceColumn.Type, QTableWidgetItem(""))
         self.sourceFilesWidget.setItem(index_row, SourceColumn.Size, SizeItem(""))
         self.sourceFilesWidget.setItem(index_row, SourceColumn.FilesCount, FilesCount(""))


### PR DESCRIPTION
Minor improvement, avoiding situations which might lead to path names not readable because they're too long (Or vorta-window too small):
![added-tooltip](https://user-images.githubusercontent.com/30773753/136226259-4cf03a9e-2d9d-4d87-a154-d8a8657eb404.png)
