### PR TITLE
Always handle autosave setting when saving SettingsModel (fixes #1092)

### DIFF
--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -10,8 +10,10 @@ import sys
 from datetime import datetime, timedelta
 
 import peewee as pw
+from playhouse import signals
 from playhouse.migrate import SqliteMigrator, migrate
 
+from vorta.autostart import open_app_at_startup
 from vorta.i18n import trans_late
 from vorta.utils import slugify
 
@@ -36,7 +38,10 @@ class JSONField(pw.TextField):
         return value if value is None else json.loads(value)
 
 
-class RepoModel(pw.Model):
+class BaseModel(signals.Model):
+    """Common model superclass."""
+
+class RepoModel(BaseModel):
     """A single remote repo with unique URL."""
     url = pw.CharField(unique=True)
     added_at = pw.DateTimeField(default=datetime.now)
@@ -55,7 +60,7 @@ class RepoModel(pw.Model):
         database = db
 
 
-class RepoPassword(pw.Model):
+class RepoPassword(BaseModel):
     """Fallback to save repo passwords. Only used if no Keyring available."""
     url = pw.CharField(unique=True)
     password = pw.CharField()
@@ -64,7 +69,7 @@ class RepoPassword(pw.Model):
         database = db
 
 
-class BackupProfileModel(pw.Model):
+class BackupProfileModel(BaseModel):
     """Allows the user to switch between different configurations."""
     name = pw.CharField()
     added_at = pw.DateTimeField(default=datetime.now)
@@ -106,7 +111,7 @@ class BackupProfileModel(pw.Model):
         database = db
 
 
-class SourceFileModel(pw.Model):
+class SourceFileModel(BaseModel):
     """A folder to be backed up, related to a Backup Configuration."""
     dir = pw.CharField()
     dir_size = pw.BigIntegerField(default=-1)
@@ -120,7 +125,7 @@ class SourceFileModel(pw.Model):
         table_name = 'sourcedirmodel'
 
 
-class ArchiveModel(pw.Model):
+class ArchiveModel(BaseModel):
     """An archive in a remote repository."""
     snapshot_id = pw.CharField()
     name = pw.CharField()
@@ -136,7 +141,7 @@ class ArchiveModel(pw.Model):
         database = db
 
 
-class WifiSettingModel(pw.Model):
+class WifiSettingModel(BaseModel):
     """Save Wifi Settings"""
     ssid = pw.CharField()
     last_connected = pw.DateTimeField(null=True)
@@ -147,7 +152,7 @@ class WifiSettingModel(pw.Model):
         database = db
 
 
-class EventLogModel(pw.Model):
+class EventLogModel(BaseModel):
     """Keep a log of background jobs."""
     start_time = pw.DateTimeField(default=datetime.now)
     end_time = pw.DateTimeField(default=datetime.now)
@@ -163,7 +168,7 @@ class EventLogModel(pw.Model):
         database = db
 
 
-class SchemaVersion(pw.Model):
+class SchemaVersion(BaseModel):
     """Keep DB version to apply the correct migrations."""
     version = pw.IntegerField()
     changed_at = pw.DateTimeField(default=datetime.now)
@@ -172,7 +177,7 @@ class SchemaVersion(pw.Model):
         database = db
 
 
-class SettingsModel(pw.Model):
+class SettingsModel(BaseModel):
     """App settings unrelated to a single profile or repo"""
     key = pw.CharField(unique=True)
     value = pw.BooleanField(default=False)
@@ -277,6 +282,12 @@ def get_misc_settings():
             }
         ]
     return settings
+
+
+@signals.post_save(sender=SettingsModel)
+def setup_autostart(model_class, instance, created):
+    if instance.key == 'autostart':
+        open_app_at_startup(instance.value)
 
 
 def cleanup_db():

--- a/src/vorta/models.py
+++ b/src/vorta/models.py
@@ -41,6 +41,7 @@ class JSONField(pw.TextField):
 class BaseModel(signals.Model):
     """Common model superclass."""
 
+
 class RepoModel(BaseModel):
     """A single remote repo with unique URL."""
     url = pw.CharField(unique=True)

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -45,9 +45,6 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
         setting.value = bool(new_value)
         setting.save()
 
-        if key == 'autostart':
-            open_app_at_startup(new_value)
-
     def set_borg_details(self, version, path):
         self.borgVersion.setText(version)
         self.borgPath.setText(path)

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -2,7 +2,6 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QCheckBox
 
 from vorta._version import __version__
-from vorta.autostart import open_app_at_startup
 from vorta.config import LOG_DIR
 from vorta.i18n import translate
 from vorta.models import SettingsModel, BackupProfileMixin, get_misc_settings


### PR DESCRIPTION
Fixes #1092 - This PR attempts to fix the autostart setting not being set correctly when importing. I deliberately chose not to duplicate the code from the misc tab to the init_db function. Instead I tried to keep it DRY and use signals from Pewee. This has the advantage that is does not matter where the SettingsModel is saved - the autostart is always set up afterwards.
This is only a suggestion how to fix it and I know that this is a bit different from an architectural point of view. We basically pull logic from a view to the models. I am always open to a different approach.