### PR TITLE
Close SVG files

### DIFF
--- a/src/vorta/views/utils.py
+++ b/src/vorta/views/utils.py
@@ -6,7 +6,8 @@ def get_colored_icon(icon_name):
     """
     Return SVG icon in the correct color.
     """
-    svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
+    with open(get_asset(f"icons/{icon_name}.svg"), 'rb') as svg_file:
+        svg_str = svg_file.read()
     if uses_dark_mode():
         svg_str = svg_str.replace(b'#000000', b'#ffffff')
     # Reduce image size to 128 height


### PR DESCRIPTION
This is the warning to see with debug build of Python:

    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/icon.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/unlink.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/copy.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/check-circle.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/stream-solid.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/cut.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/refresh.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/tasks.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/ellipsis-v.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    2021-12-11 18:43:07,649 - root - INFO - Using NetworkManagerMonitor NetworkStatusMonitor implementation.
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/clock-o.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/wifi.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/terminal.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/plus.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/edit.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/file-import-solid.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /usr/lib/python3.10/site-packages/vorta/views/utils.py:9: ResourceWarning: unclosed file <_io.BufferedReader name='/usr/lib/python3.10/site-packages/vorta/assets/icons/trash.svg'>
      svg_str = open(get_asset(f"icons/{icon_name}.svg"), 'rb').read()