### PR TITLE
Upgrade flatpak runtime org.kde.Platform to v5.15

### DIFF
--- a/flatpak/com.borgbase.Vorta.json
+++ b/flatpak/com.borgbase.Vorta.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.borgbase.Vorta",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.14",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "command": "vorta",
     "branch": "devel",

--- a/flatpak/dependencies/pyqt5.json
+++ b/flatpak/dependencies/pyqt5.json
@@ -13,7 +13,7 @@
         {
             "type": "script",
             "commands": [
-                "python3 configure.py --assume-shared --confirm-license --no-designer-plugin --no-qml-plugin --sysroot=/app --qsci-api --qsci-api-destdir=/app/qsci --sipdir=/app/share/sip --sip=/app/bin/sip --sip-incdir=/app/include QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.7m/' QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.7m/'"
+                "python3 configure.py --assume-shared --verbose --confirm-license --no-designer-plugin --no-qml-plugin --sysroot=/app --qsci-api --qsci-api-destdir=/app/qsci --sipdir=/app/share/sip --sip=/app/bin/sip --sip-incdir=/app/include QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.8/' QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.8/'"
             ],
             "dest-filename": "configure"
         }
@@ -30,7 +30,7 @@
                 {
                     "type": "script",
                     "commands": [
-                        "python3 configure.py --sip-module PyQt5.sip -b ${FLATPAK_DEST}/bin -d ${FLATPAK_DEST}/lib/python3.7/site-packages -e ${FLATPAK_DEST}/include -v ${FLATPAK_DEST}/share/sip --stubsdir=${FLATPAK_DEST}/lib/python3.7/site-packages"
+                        "python3 configure.py --sip-module PyQt5.sip -b ${FLATPAK_DEST}/bin -d ${FLATPAK_DEST}/lib/python3.8/site-packages -e ${FLATPAK_DEST}/include -v ${FLATPAK_DEST}/share/sip --stubsdir=${FLATPAK_DEST}/lib/python3.8/site-packages"
                     ],
                     "dest-filename": "configure"
                 }


### PR DESCRIPTION
This MR partially fixes #1023. The theming looks closer to the system theme, but dialogs are still missing window decoration.
Here are some screenshots taken with Ubuntu 21.10:
![grafik](https://user-images.githubusercontent.com/1387322/146850871-e45bb37d-3e5b-442c-813e-2e92b1938268.png)
![grafik](https://user-images.githubusercontent.com/1387322/146850891-e6d936ec-cf8d-488e-a00e-7f02cfaee6fd.png)
![grafik](https://user-images.githubusercontent.com/1387322/146850907-14e4024a-a0d4-4c89-8054-852db62b519a.png)

The verbose flag when compiling PyQt is not strictly necessary but it helps detecting issues like I had when I did not know that the new runtime is based on Python 3.8 instead of 3.7.