### PR TITLE
Distinguish different errors in case `borg check` failed.

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from typing import Any, Dict
 
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QMessageBox
@@ -39,7 +40,7 @@ class VortaApp(QtSingleApplication):
     backup_cancelled_event = QtCore.pyqtSignal()
     backup_log_event = QtCore.pyqtSignal(str, dict)
     backup_progress_event = QtCore.pyqtSignal(str)
-    check_failed_event = QtCore.pyqtSignal(str)
+    check_failed_event = QtCore.pyqtSignal(dict)
 
     def __init__(self, args_raw, single_app=False):
         super().__init__(APP_ID, args_raw)
@@ -288,7 +289,7 @@ class VortaApp(QtSingleApplication):
             default_profile = BackupProfileModel(name='Default')
             default_profile.save()
 
-    def check_failed_response(self, repo_url: str):
+    def check_failed_response(self, result: Dict[str, Any]):
         """
         Process the signal that a repo consistency check failed.
 
@@ -299,6 +300,10 @@ class VortaApp(QtSingleApplication):
         repo_url : str
             The url of the repo of concern
         """
+        # extract repourl from the params for the borg job
+        repo_url = result['params']['repo_url']
+
+        # Create and display QMessageBox
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Critical)
         msg.setStandardButtons(QMessageBox.Ok)

--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -5,21 +5,21 @@ import sys
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QMessageBox
 
-from vorta.borg.create import BorgCreateJob
-from vorta.borg.version import BorgVersionJob
 from vorta.borg.break_lock import BorgBreakJob
-from vorta.config import TEMP_DIR, PROFILE_BOOTSTRAP_FILE
+from vorta.borg.create import BorgCreateJob
+from vorta.borg.jobs_manager import JobsManager
+from vorta.borg.version import BorgVersionJob
+from vorta.config import PROFILE_BOOTSTRAP_FILE, TEMP_DIR
 from vorta.i18n import init_translations, translate
-from vorta.store.models import BackupProfileModel, SettingsModel
-from vorta.store.connection import cleanup_db
+from vorta.notifications import VortaNotifications
+from vorta.profile_export import ProfileExport
 from vorta.qt_single_application import QtSingleApplication
 from vorta.scheduler import VortaScheduler
-from vorta.borg.jobs_manager import JobsManager
+from vorta.store.connection import cleanup_db
+from vorta.store.models import BackupProfileModel, SettingsModel
 from vorta.tray_menu import TrayMenu
 from vorta.utils import borg_compat, parse_args
 from vorta.views.main_window import MainWindow
-from vorta.notifications import VortaNotifications
-from vorta.profile_export import ProfileExport
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +288,17 @@ class VortaApp(QtSingleApplication):
             default_profile = BackupProfileModel(name='Default')
             default_profile.save()
 
-    def check_failed_response(self, repo_url):
+    def check_failed_response(self, repo_url: str):
+        """
+        Process the signal that a repo consistency check failed.
+
+        Displays a `QMessageBox` with an error message.
+
+        Parameters
+        ----------
+        repo_url : str
+            The url of the repo of concern
+        """
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Critical)
         msg.setStandardButtons(QMessageBox.Ok)

--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -305,7 +305,7 @@ class VortaApp(QtSingleApplication):
         repo_url = result['params']['repo_url']
         returncode = result['returncode']
         errors: List[Tuple[int, str]] = result['errors']
-        error_message = errors[-1][1] if errors else ''
+        error_message = errors[0][1] if errors else ''
 
         # Switch over returncodes
         if returncode == 0:

--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QMessageBox
@@ -304,6 +304,8 @@ class VortaApp(QtSingleApplication):
         # extract data from the params for the borg job
         repo_url = result['params']['repo_url']
         returncode = result['returncode']
+        errors: List[Tuple[int, str]] = result['errors']
+        error_message = errors[-1][1] if errors else ''
 
         # Switch over returncodes
         if returncode == 0:
@@ -313,10 +315,10 @@ class VortaApp(QtSingleApplication):
         elif returncode == 130:
             # Keyboard interupt
             pass
-        else: # Real error
+        else:  # Real error
             # Create QMessageBox
             msg = QMessageBox()
-            msg.setIcon(QMessageBox.Icon.Critical) # changed for warning
+            msg.setIcon(QMessageBox.Icon.Critical)  # changed for warning
             msg.setStandardButtons(QMessageBox.Ok)
             msg.setWindowTitle(self.tr('Repo Check Failed'))
 
@@ -324,7 +326,7 @@ class VortaApp(QtSingleApplication):
                 # warning
                 msg.setIcon(QMessageBox.Icon.Warning)
                 text = self.tr('Borg exited with a warning message. See logs for details.')
-                infotext = ""
+                infotext = error_message
             elif returncode > 128:
                 # 128+N - killed by signal N (e.g. 137 == kill -9)
                 signal = returncode - 128
@@ -339,7 +341,8 @@ class VortaApp(QtSingleApplication):
                     self.tr('Repository data check for repo %s failed. Error code %s')
                     % (repo_url, returncode)
                 )
-                infotext = self.tr('Repair or recreate the repository soon to avoid missing data.')
+                infotext = error_message + '\n'
+                infotext += self.tr('Consider repairing or recreating the repository soon to avoid missing data.')
 
             msg.setText(text)
             msg.setInformativeText(infotext)

--- a/src/vorta/borg/check.py
+++ b/src/vorta/borg/check.py
@@ -12,7 +12,7 @@ class BorgCheckJob(BorgJob):
         self.result.emit(result)
         if result['returncode'] != 0:
             self.app.backup_progress_event.emit(self.tr('Repo check failed. See logs for details.'))
-            self.app.check_failed_event.emit(self.params['repo_url'])
+            self.app.check_failed_event.emit(result)
         else:
             self.app.backup_progress_event.emit(self.tr('Check completed.'))
 

--- a/src/vorta/borg/check.py
+++ b/src/vorta/borg/check.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from .borg_job import BorgJob
 
 
@@ -7,7 +9,15 @@ class BorgCheckJob(BorgJob):
         self.app.backup_started_event.emit()
         self.app.backup_progress_event.emit(self.tr('Starting consistency check...'))
 
-    def finished_event(self, result):
+    def finished_event(self, result: Dict[str, Any]):
+        """
+        Process that the job terminated with the given results.
+
+        Parameters
+        ----------
+        result : Dict[str, Any]
+            The (json-like) dictionary containing the job results.
+        """
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
         if result['returncode'] != 0:


### PR DESCRIPTION
In case the `BorgCheckJob` fails vorta switches over the returncodes and reacts accordingly.
Fixes #1143.

| returncode | meaning | behaviour |
---------------  | ------------| --------------|
0                 | success (logged as INFO) | ignored
1                 | warning (operation reached its normal end, but there were warnings – you should check the log, logged as WARNING) | `QMessageBox` with warning icon and text stating the warning message from borg
2                 | error (like a fatal error, a local or remote exception, the operation did not reach its normal end, logged as ERROR) | `QMessageBox` with error icon stating the error message from borg and `Consider repairing or recreating the repository soon to avoid missing data.`
128+N |killed by signal N (e.g. 137 == kill -9) | `QMessageBox` with error icon stating that the borg process was killed by signal N|