### PR TITLE
Update label displaying next backup time.

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 
 
 class VortaScheduler(QtCore.QObject):
+
+    #: The schedule for the profile with the given id changed.
+    schedule_changed = QtCore.pyqtSignal(int)
+
     def __init__(self):
         super().__init__()
         self.timers = dict()  # keep mapping of profiles to timers
@@ -117,6 +121,9 @@ class VortaScheduler(QtCore.QObject):
         self.timers[profile_id] = {'qtt': timer, 'dt': next_run}
 
         self.lock.release()
+
+        # Emit signal so that e.g. the GUI can react to the new schedule
+        self.schedule_changed.emit(profile_id)
 
     def reload_all_timers(self):
         logger.debug('Refreshing all scheduler timers')

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -77,6 +77,9 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.validationWeeksCount.valueChanged.connect(
             lambda new_val, attr='validation_weeks': self.save_profile_attr(attr, new_val))
 
+        # Connect to schedule update
+        self.app.scheduler.schedule_changed.connect(lambda pid: self.draw_next_scheduled_backup())
+
     def on_scheduler_change(self, _):
         profile = self.profile()
         # Save scheduler settings, apply new scheduler and display next task for profile.

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,10 +1,20 @@
-from datetime import datetime as dt, date, time
+from datetime import date
+from datetime import datetime as dt
+from datetime import time
+
 from PyQt5 import QtCore
 
 
 def test_schedule_tab(qapp, qtbot):
     main = qapp.main_window
     tab = main.scheduleTab
+
+    # Work around
+    # because already 'deleted' scheduletabs are still connected to the signal
+    qapp.scheduler.schedule_changed.disconnect()
+    qapp.scheduler.schedule_changed.connect(lambda *args: tab.draw_next_scheduled_backup())
+
+    # Test
     qtbot.mouseClick(tab.scheduleOffRadio, QtCore.Qt.LeftButton)
     assert tab.nextBackupDateTimeLabel.text() == 'None scheduled'
 


### PR DESCRIPTION
Always update the label in the schedule tab that displays the next time to start a backup when the scheduler updates its timer.
Fixes #1116.

* src/vorta/scheduler.py (VortaScheduler): Add `schedule_changed` signal.

* src/vorta/scheduler.py (VortaScheduler.set_timer_for_profile): Emit `schedule_changed` signal.

* src/vorta/views/schedule_tab.py (ScheduleTab): Connect `draw_next_scheduled_backup` to `schedule_changed` signal.