### PR TITLE
Remove installing python

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -20,10 +20,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.inputs.branch }}
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.9
     - name: Install system dependencies
       run: |
         brew install openssl readline xz


### PR DESCRIPTION
Python 3.9 is included in latest images of macos-10.15
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md