### PR TITLE
Add reasonable, default ignores to flake8.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,6 @@ jobs:
         pip install .
         pip install -r requirements.d/dev.txt
     - name: Run Flake8
-      run: flake8
+      run: flake8 --ignore=E121,E123,E126,E226,E24,E704,W503,W504
     # - name: Run PyLint (info only)
     #   run: pylint --rcfile=setup.cfg src --exit-zero


### PR DESCRIPTION
The tool *flake8* used in the tests runs on github allows for ignoring specific codes. The default named in the [docs](https://flake8.pycqa.org/en/latest/user/options.html?highlight=ignore#cmdoption-flake8-ignore) are `E121,E123,E126,E226,E24,E704,W503,W504`, although these default reasonable it seems as if flake actually doesn't use them by default. I would therefore like to add them to the test runs.