### PR TITLE
Issue 1223 - Add missing translated strings on archive tab

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -122,16 +122,16 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             return menu
 
         if archive_name in self.mount_points:
-            unmountAction = menu.addAction("Unmount", self.umount_action)
+            unmountAction = menu.addAction(self.tr("Unmount"), self.umount_action)
             unmountAction.setIcon(get_colored_icon('eject'))
         else:
-            mountAction = menu.addAction("Mount", self.mount_action)
+            mountAction = menu.addAction(self.tr("Mount"), self.mount_action)
             mountAction.setIcon(get_colored_icon('folder-open'))
 
-        extractAction = menu.addAction("Extract", self.list_archive_action)
-        refreshAction = menu.addAction("Refresh", self.refresh_archive_action)
-        renameAction = menu.addAction("Rename", self.rename_action)
-        deleteAction = menu.addAction("Delete", self.delete_action)
+        extractAction = menu.addAction(self.tr("Extract"), self.list_archive_action)
+        refreshAction = menu.addAction(self.tr("Refresh"), self.refresh_archive_action)
+        renameAction = menu.addAction(self.tr("Rename"), self.rename_action)
+        deleteAction = menu.addAction(self.tr("Delete"), self.delete_action)
 
         extractAction.setIcon(get_colored_icon('cloud-download'))
         refreshAction.setIcon(get_colored_icon('refresh'))


### PR DESCRIPTION
These translations will allow the strings to be translated to different languages, instead of showing them always in English.

![missing-translations](https://user-images.githubusercontent.com/770967/159424467-ca72a241-cb25-45cf-858c-cba86a9dc900.png)
