### PR TITLE
Resolve #1242 Add translations to treeView columns

### DIFF
--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -87,6 +87,7 @@ class ExtractTree(TreeModel):
         super().__init__(
             files_with_attributes, nested_file_list, selected_files_folders, parent
         )
+        self.column_names = [self.tr("Name"), self.tr("Modified"), self.tr("Size")]
 
     def data(self, index, role):
         if not index.isValid():


### PR DESCRIPTION
I'm not sure if this is the right approach for these dialogs since the translate functions can't be used on the partial tree_view.py file.

Let me know if this is not the right way.

![Selection_002](https://user-images.githubusercontent.com/770967/160753176-5c01018d-66ab-4d5d-9c81-035bdd7c1a77.png)

