### PR TITLE
Fix string starting with a space in `archivetab.ui`.

### DIFF
--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -483,7 +483,7 @@
             <item>
              <widget class="QLabel" name="label_9">
               <property name="text">
-               <string> Monthly:</string>
+               <string>Monthly:</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
String ` Monthly`: starts with a space by mistake as reported by pavelb on [transifex](https://www.transifex.com/borgbase/vorta/translate/#cs/vorta/413641141).

* src/vorta/assets/UI/archivetab.ui