### PR TITLE
Set repo stats to `N/A` after deleting an archive or pruning a repo.

### DIFF
--- a/src/vorta/borg/delete.py
+++ b/src/vorta/borg/delete.py
@@ -1,3 +1,5 @@
+from vorta.store.models import RepoModel
+
 from .borg_job import BorgJob
 
 
@@ -8,6 +10,14 @@ class BorgDeleteJob(BorgJob):
         self.app.backup_progress_event.emit(self.tr('Deleting archive…'))
 
     def finished_event(self, result):
+        # set repo stats to N/A
+        repo = RepoModel.get(id=result['params']['repo_id'])
+        repo.total_size = None
+        repo.unique_csize = None
+        repo.unique_size = None
+        repo.total_unique_chunks = None
+        repo.save()
+
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
         self.app.backup_progress_event.emit(self.tr('Archive deleted.'))

--- a/src/vorta/borg/prune.py
+++ b/src/vorta/borg/prune.py
@@ -1,5 +1,7 @@
-from .borg_job import BorgJob
+from vorta.store.models import RepoModel
 from vorta.utils import format_archive_name
+
+from .borg_job import BorgJob
 
 
 class BorgPruneJob(BorgJob):
@@ -9,6 +11,14 @@ class BorgPruneJob(BorgJob):
         self.app.backup_progress_event.emit(self.tr('Pruning old archives…'))
 
     def finished_event(self, result):
+        # set repo stats to N/A
+        repo = RepoModel.get(id=result['params']['repo_id'])
+        repo.total_size = None
+        repo.unique_csize = None
+        repo.unique_size = None
+        repo.total_unique_chunks = None
+        repo.save()
+
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
         self.app.backup_progress_event.emit(self.tr('Pruning done.'))

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -63,7 +63,6 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         self.sshKeyToClipboardButton.clicked.connect(self.ssh_copy_to_clipboard_action)
         self.bAddSSHKey.clicked.connect(self.create_ssh_key)
 
-        self.init_repo_stats()
         self.populate_from_profile()
         self.set_icons()
 
@@ -100,17 +99,50 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         self.init_repo_stats()
 
     def init_repo_stats(self):
-        repo = self.profile().repo
+        """Set the strings of the repo stats labels."""
+        # prepare translations
+        na = self.tr('N/A', "Not available.")
+        no_repo_selected = self.tr("Select a repository first.")
+        refresh = self.tr("Try refreshing the metadata of any archive.")
+
+        # set labels
+        repo: RepoModel = self.profile().repo
         if repo is not None:
-            self.sizeCompressed.setText(pretty_bytes(repo.unique_csize))
-            self.sizeDeduplicated.setText(pretty_bytes(repo.unique_size))
-            self.sizeOriginal.setText(pretty_bytes(repo.total_size))
+            if repo.unique_csize is not None:
+                self.sizeCompressed.setText(pretty_bytes(repo.unique_csize))
+                self.sizeCompressed.setToolTip('')
+            else:
+                self.sizeCompressed.setText(na)
+                self.sizeCompressed.setToolTip(refresh)
+
+            if repo.unique_size is not None:
+                self.sizeDeduplicated.setText(pretty_bytes(repo.unique_size))
+                self.sizeDeduplicated.setToolTip('')
+            else:
+                self.sizeDeduplicated.setText(na)
+                self.sizeDeduplicated.setToolTip(refresh)
+
+            if repo.total_size is not None:
+                self.sizeOriginal.setText(pretty_bytes(repo.total_size))
+                self.sizeOriginal.setToolTip('')
+            else:
+                self.sizeOriginal.setText(na)
+                self.sizeOriginal.setToolTip(refresh)
+
             self.repoEncryption.setText(str(repo.encryption))
         else:
-            self.sizeCompressed.setText('')
-            self.sizeDeduplicated.setText('')
-            self.sizeOriginal.setText('')
-            self.repoEncryption.setText('')
+            self.sizeCompressed.setText(na)
+            self.sizeCompressed.setToolTip(no_repo_selected)
+
+            self.sizeDeduplicated.setText(na)
+            self.sizeDeduplicated.setToolTip(no_repo_selected)
+
+            self.sizeOriginal.setText(na)
+            self.sizeOriginal.setToolTip(no_repo_selected)
+
+            self.repoEncryption.setText(na)
+            self.repoEncryption.setToolTip(no_repo_selected)
+
         self.repo_changed.emit()
 
     def init_ssh(self):


### PR DESCRIPTION
Fixes #338.

* src/vorta/views/repo_tab.py (RepoTab.init_repo_stats): Cope with stat value `None`.

* src/vorta/borg/delete.py (BorgDeleteJob.finished_event): Set stats to `None`.

* src/vorta/borg/prune.py (BorgPruneJob.finished_event): Set stats to `None`.