### PR TITLE
SecretStorage: Unlock item if it is locked. Fixes #1232 and #1233.

### DIFF
--- a/src/vorta/keyring/secretstorage.py
+++ b/src/vorta/keyring/secretstorage.py
@@ -21,9 +21,8 @@ class VortaSecretStorageKeyring(VortaKeyring):
         except secretstorage.exceptions.SecretServiceNotAvailableException as e:
             logger.debug("SecretStorage provider or DBus daemon is not available.")
             raise e
-        else:
-            asyncio.set_event_loop(asyncio.new_event_loop())
-            self.collection = secretstorage.get_default_collection(self.connection)
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        self.collection = secretstorage.get_default_collection(self.connection)
 
     def set_password(self, service, repo_url, password):
         """
@@ -60,9 +59,7 @@ class VortaSecretStorageKeyring(VortaKeyring):
     @property
     def is_unlocked(self):
         # unlock() will return True if the unlock prompt is dismissed
-        if self.collection.is_locked() and self.collection.unlock():
-            return False
-        return True
+        return not (self.collection.is_locked() and self.collection.unlock())
 
     @classmethod
     def get_priority(cls):

--- a/src/vorta/keyring/secretstorage.py
+++ b/src/vorta/keyring/secretstorage.py
@@ -51,7 +51,10 @@ class VortaSecretStorageKeyring(VortaKeyring):
             items = list(collection.search_items(attributes))
             logger.debug('Found %i passwords matching repo URL.', len(items))
             if len(items) > 0:
-                return items[0].get_secret().decode("utf-8")
+                item = items[0]
+                if item.is_locked():  # Some providers lock items until the user manually approves it
+                    item.unlock()
+                return item.get_secret().decode("utf-8")
         return None
 
     @property

--- a/src/vorta/keyring/secretstorage.py
+++ b/src/vorta/keyring/secretstorage.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 
 import secretstorage
 
@@ -19,26 +18,23 @@ class VortaSecretStorageKeyring(VortaKeyring):
         """
         self.connection = secretstorage.dbus_init()
         asyncio.set_event_loop(asyncio.new_event_loop())
-        secretstorage.get_default_collection(self.connection)
+        self.collection = secretstorage.get_default_collection(self.connection)
 
     def set_password(self, service, repo_url, password):
         """
         Writes a password to the underlying store.
         """
-        try:
+        if self.is_unlocked:
             asyncio.set_event_loop(asyncio.new_event_loop())
-            collection = secretstorage.get_default_collection(self.connection)
             attributes = {
                 'application': 'Vorta',
                 'service': service,
                 'repo_url': repo_url,
                 'xdg:schema': 'org.freedesktop.Secret.Generic'}
-            collection.create_item(LABEL_TEMPLATE.format(repo_url=repo_url),
-                                   attributes,
-                                   password,
-                                   replace=True)
-        except secretstorage.exceptions.ItemNotFoundException:
-            logger.error("SecretStorage writing failed", exc_info=sys.exc_info())
+            self.collection.create_item(LABEL_TEMPLATE.format(repo_url=repo_url),
+                                        attributes,
+                                        password,
+                                        replace=True)
 
     def get_password(self, service, repo_url):
         """
@@ -46,26 +42,24 @@ class VortaSecretStorageKeyring(VortaKeyring):
         """
         if self.is_unlocked:
             asyncio.set_event_loop(asyncio.new_event_loop())
-            collection = secretstorage.get_default_collection(self.connection)
             attributes = {'application': 'Vorta', 'service': service, 'repo_url': repo_url}
-            items = list(collection.search_items(attributes))
+            items = list(self.collection.search_items(attributes))
             logger.debug('Found %i passwords matching repo URL.', len(items))
             if len(items) > 0:
                 item = items[0]
-                if item.is_locked():  # Some providers lock items until the user manually approves it
-                    item.unlock()
+                if item.is_locked() and item.unlock():
+                    return None
                 return item.get_secret().decode("utf-8")
         return None
 
     @property
     def is_unlocked(self):
         try:
-            collection = secretstorage.get_default_collection(self.connection)
-            if collection.is_locked():  # Prompt for unlock
-                collection.unlock()
-            return not collection.is_locked()  # In case of denial
+            if self.collection.is_locked():  # Prompt for unlock
+                self.collection.unlock()
+            return not self.collection.is_locked()  # In case of denial
         except secretstorage.exceptions.SecretServiceNotAvailableException:
-            logger.debug('SecretStorage is closed.')
+            logger.debug('SecretStorage is not available.')
             return False
 
     @classmethod


### PR DESCRIPTION
Some password managers (like KeePassXC) will lock an SecretStorage item behind a manual user approval dialog even when the collection is already unlocked. This prevents Vorta from using SecretStorage compatible password managers that exhibit this behavior.

This pull request fixes the way an item is obtained so any manual user approval dialog is triggered.