### PR TITLE
Add a button to mount whole repository.

### DIFF
--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -104,6 +104,22 @@
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QToolButton" name="bMountRepo">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string notr="true">bMountRepo</string>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonTextBesideIcon</enum>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
          <item row="0" column="0">
@@ -196,7 +212,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QToolButton" name="bMount">
+               <widget class="QToolButton" name="bMountArchive">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                   <horstretch>0</horstretch>
@@ -204,7 +220,7 @@
                  </sizepolicy>
                 </property>
                 <property name="text">
-                 <string notr="true">bMount</string>
+                 <string notr="true">bMountArchive</string>
                 </property>
                 <property name="toolButtonStyle">
                  <enum>Qt::ToolButtonTextBesideIcon</enum>

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -99,7 +99,7 @@ def test_check(qapp, mocker, borg_json_output, qtbot):
     qtbot.waitUntil(lambda: main.logText.text().startswith(success_text), **pytest._wait_defaults)
 
 
-def test_archive_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choose_file_dialog):
+def test_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choose_file_dialog):
     def psutil_disk_partitions(**kwargs):
         DiskPartitions = namedtuple('DiskPartitions', ['device', 'mountpoint'])
         return [DiskPartitions('borgfs', '/tmp')]
@@ -122,10 +122,16 @@ def test_archive_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choos
         vorta.views.archive_tab, "choose_file_dialog", choose_file_dialog
     )
 
-    tab.mount_action()
+    tab.bmountarchive_clicked()
     qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Mounted'), **pytest._wait_defaults)
 
-    tab.umount_action()
+    tab.bmountarchive_clicked()
+    qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), **pytest._wait_defaults)
+
+    tab.bmountrepo_clicked()
+    qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Mounted'), **pytest._wait_defaults)
+
+    tab.bmountrepo_clicked()
     qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), **pytest._wait_defaults)
 
 


### PR DESCRIPTION
Fixes #1256.

* src/vorta/assets/UI/archivetab.ui : Rename `bMount` to `bMountArchive`.

* src/vorta/assets/UI/archivetab.ui : Add `bMountRepo`.

* src/vorta/views/archive_tab.py (ArchiveTab): Rename `bMount` to `bMountArchive`.

* src/vorta/views/archive_tab.py (ArchiveTab): Implement behaviour for `bMountRepo`.
	Add `repo_mount_point` attribute.

* src/vorta/views/archive_tab.py (ArchiveTab): Add tooltips to `bMountArchive`.

* src/vorta/views/archive_tab.py (ArchiveTab): Adjust `mount_action` and `unmount_action` to
	mount and unmount the full repository as well.

* src/vorta/utils.py (get_mount_points): Also search for full repo mounts.