### PR TITLE
Rewrite label of `enable_background_question` to be understandable.

### DIFF
--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -92,9 +92,13 @@ def get_misc_settings() -> List[Dict[str, str]]:
     else:
         settings += [
             {
-                'key': 'enable_background_question', 'value': True, 'type': 'checkbox',
+                'key': 'enable_background_question',
+                'value': True,
+                'type': 'checkbox',
                 'label': trans_late('settings',
-                                    'Display background exit dialog')
+                                    "If the system tray isn't available, "
+                                    "ask whether to continue in the background"
+                                    " on exit.")
             },
             {
                 'key': 'disable_background_state', 'value': False, 'type': 'internal',

--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -97,8 +97,8 @@ def get_misc_settings() -> List[Dict[str, str]]:
                 'type': 'checkbox',
                 'label': trans_late('settings',
                                     "If the system tray isn't available, "
-                                    "ask whether to continue in the background"
-                                    " on exit.")
+                                    "ask whether to continue in the background "
+                                    "on exit")
             },
             {
                 'key': 'disable_background_state', 'value': False, 'type': 'internal',


### PR DESCRIPTION
Currently on systems with system tray support the user has no idea what this setting does.

* src/vorta/store/settings.py (get_misc_settings)

Suggestions for a better (especially shorter) wording are welcome!