### PR TITLE
Don't schedule backup if repo isn't set.

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -68,6 +68,7 @@ class VortaScheduler(QtCore.QObject):
                 logger.debug(
                     'Nothing scheduled for profile %s because of unset repo.',
                     profile_id)
+                return
 
             if profile.schedule_mode == 'off':
                 logger.debug('Scheduler for profile %s is disabled.', profile_id)


### PR DESCRIPTION
Fixes #1286.

* src/vorta/scheduler.py (set_timer_for_profile): Return if repo is not set. (Return statement was missing)