### PR TITLE
Exclude the last backup creation from log deletion.

### DIFF
--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime, timedelta
 
+from peewee import Tuple, fn
 from playhouse import signals
 
 from vorta.autostart import open_app_at_startup
@@ -34,9 +35,27 @@ def init_db(con=None):
     DB.create_tables([RepoModel, RepoPassword, BackupProfileModel, SourceFileModel, SettingsModel,
                       ArchiveModel, WifiSettingModel, EventLogModel, SchemaVersion])
 
-    # Delete old log entries after 3 months.
-    three_months_ago = datetime.now() - timedelta(days=180)
-    EventLogModel.delete().where(EventLogModel.start_time < three_months_ago)
+    # Delete old log entries after 6 months.
+    # The last `create` command of each profile must not be deleted
+    # since the scheduler uses it to determine the last backup time.
+    last_backups_per_profile = (
+        EventLogModel.select(EventLogModel.profile,
+                             fn.MAX(EventLogModel.start_time))
+        .where(EventLogModel.subcommand == 'create')
+        .group_by(EventLogModel.profile))
+    last_scheduled_backups_per_profile = (
+        EventLogModel.select(EventLogModel.profile,
+                             fn.MAX(EventLogModel.start_time))
+        .where(EventLogModel.subcommand == 'create',
+               EventLogModel.category == 'scheduled')
+        .group_by(EventLogModel.profile))
+
+    three_months_ago = datetime.now() - timedelta(days=6 * 30)
+    entry = Tuple(EventLogModel.profile, EventLogModel.start_time)
+    EventLogModel.delete().where(
+        EventLogModel.start_time < three_months_ago,
+        entry.not_in(last_backups_per_profile),
+        entry.not_in(last_scheduled_backups_per_profile)).execute()
 
     # Migrations
     current_schema, created = SchemaVersion.get_or_create(id=1, defaults={'version': SCHEMA_VERSION})
@@ -57,7 +76,3 @@ def init_db(con=None):
             s.group = setting['group']
 
         s.save()
-
-    # Delete old log entries after 3 months.
-    three_months_ago = datetime.now() - timedelta(days=3)
-    EventLogModel.delete().where(EventLogModel.start_time < three_months_ago).execute()


### PR DESCRIPTION
The scheduler uses the log entry of the last (scheduled) `create` command to determine the next backup time. Logs older than 180 days (actually 6 days but that seems to be typo in the code) are automatically deleted. 
This PR ensures  that t latest `create` entry and the latest scheduled one will be excluded from deletion so that the scheduler always knows the last backup time.

* src/vorta/store/connection.py (init_db): Remove the doubling of the deletion statement. One statement used 6 days the other one 180 days as expire time. 180 days it is.

* src/vorta/store/connection.py (init_db): Add a subquery to determine last `create` call per profile. Only delete entries that are not in the subquery.