### PR TITLE
Only schedule backup after a manual one.

### DIFF
--- a/src/vorta/i18n/__init__.py
+++ b/src/vorta/i18n/__init__.py
@@ -4,7 +4,7 @@ internationalisation (i18n) support code
 import logging
 import os
 
-from PyQt5.QtCore import QTranslator, QLocale
+from PyQt5.QtCore import QLocale, QTranslator
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +67,12 @@ def init_translations(app):
     if succeeded:
         app.installTranslator(translator)
     logger.debug('Loading translation %s for %r.' % ('succeeded' if succeeded else 'failed', ui_langs))
+
+
+def get_locale():
+    """Get the locale used for translation."""
+    global translator
+    return QLocale(translator.language())
 
 
 def translate(*args, **kwargs):

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -1,12 +1,15 @@
+import enum
 import logging
 import threading
 from datetime import datetime as dt
 from datetime import timedelta
-from typing import Dict, Union
+from typing import Dict, NamedTuple, Optional, Union
 
 from PyQt5 import QtCore
+from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QApplication
 
+from vorta import application
 from vorta.borg.check import BorgCheckJob
 from vorta.borg.create import BorgCreateJob
 from vorta.borg.list_repo import BorgListRepoJob
@@ -18,6 +21,18 @@ from vorta.store.models import BackupProfileModel, EventLogModel
 logger = logging.getLogger(__name__)
 
 
+class ScheduleStatusType(enum.Enum):
+    SCHEDULED = enum.auto()  # date provided
+    UNSCHEDULED = enum.auto()  # Unknown
+    TOO_FAR_AHEAD = enum.auto()  # QTimer range exceeded, date provided
+    NO_PREVIOUS_BACKUP = enum.auto()  # run a manual backup first
+
+
+class ScheduleStatus(NamedTuple):
+    type: ScheduleStatusType
+    time: Optional[dt] = None
+
+
 class VortaScheduler(QtCore.QObject):
 
     #: The schedule for the profile with the given id changed.
@@ -27,17 +42,22 @@ class VortaScheduler(QtCore.QObject):
         super().__init__()
 
         #: mapping of profiles to timers
-        self.timers: Dict[int, Dict[str, Union[QtCore.QTimer, dt]]] = dict()
+        self.timers: Dict[int, Dict[str, Union[
+            Optional[QTimer], Optional[dt], ScheduleStatusType]]] = dict()
 
-        self.app = QApplication.instance()
+        self.app: application.VortaApp = QApplication.instance()
         self.lock = threading.Lock()
 
         # Set additional timer to make sure background tasks stay scheduled.
         # E.g. after hibernation
-        self.qt_timer = QtCore.QTimer()
+        self.qt_timer = QTimer()
         self.qt_timer.timeout.connect(self.reload_all_timers)
         self.qt_timer.setInterval(15 * 60 * 1000)
         self.qt_timer.start()
+
+        # connect signals
+        self.app.backup_finished_event.connect(
+            lambda res: self.set_timer_for_profile(res['params']['profile_id']))
 
     def tr(self, *args, **kwargs):
         scope = self.__class__.__name__
@@ -61,17 +81,20 @@ class VortaScheduler(QtCore.QObject):
 
         with self.lock:  # Acquire lock
 
-            if profile_id in self.timers:
-                self.remove_job(profile_id)  # reset schedule
+            self.remove_job(profile_id)  # reset schedule
 
             if profile.repo is None:  # No backups without repo set
                 logger.debug(
                     'Nothing scheduled for profile %s because of unset repo.',
                     profile_id)
+                # Emit signal so that e.g. the GUI can react to the new schedule
+                self.schedule_changed.emit(profile_id)
                 return
 
             if profile.schedule_mode == 'off':
                 logger.debug('Scheduler for profile %s is disabled.', profile_id)
+                # Emit signal so that e.g. the GUI can react to the new schedule
+                self.schedule_changed.emit(profile_id)
                 return
 
             logger.info('Setting timer for profile %s', profile_id)
@@ -92,21 +115,26 @@ class VortaScheduler(QtCore.QObject):
                     0 <= EventLogModel.returncode <= 1,
                 ).order_by(EventLogModel.end_time.desc()).first()
 
+            if last_run_log is None:
+                logger.info(f"Nothing scheduled for profile {profile_id} " +
+                            "because it would be the first backup " +
+                            "for this profile.")
+                self.timers[profile_id] = {
+                    'type': ScheduleStatusType.NO_PREVIOUS_BACKUP
+                }
+                # Emit signal so that e.g. the GUI can react to the new schedule
+                self.schedule_changed.emit(profile_id)
+                return
+
             # calculate next scheduled time
             if profile.schedule_mode == 'interval':
-                if last_run_log is None:
-                    last_time = dt.now()
-                else:
-                    last_time = last_run_log.end_time
+                last_time = last_run_log.end_time
 
                 interval = {profile.schedule_interval_unit: profile.schedule_interval_count}
                 next_time = last_time + timedelta(**interval)
 
             elif profile.schedule_mode == 'fixed':
-                if last_run_log is None:
-                    last_time = dt.now()
-                else:
-                    last_time = last_run_log.end_time + timedelta(days=1)
+                last_time = last_run_log.end_time + timedelta(days=1)
 
                 next_time = last_time.replace(
                     hour=profile.schedule_fixed_hour,
@@ -155,19 +183,28 @@ class VortaScheduler(QtCore.QObject):
             if timer_ms < 2**31 - 1:
                 logger.debug('Scheduling next run for %s', next_time)
 
-                timer = QtCore.QTimer()
+                timer = QTimer()
                 timer.setSingleShot(True)
                 timer.setInterval(int(timer_ms))
                 timer.timeout.connect(lambda: self.create_backup(profile_id))
                 timer.start()
 
-                self.timers[profile_id] = {'qtt': timer, 'dt': next_time}
+                self.timers[profile_id] = {
+                    'qtt': timer,
+                    'dt': next_time,
+                    'type': ScheduleStatusType.SCHEDULED
+                }
             else:
                 # int to big to pass it to qt which expects a c++ int
                 # wait 15 min for regular reschedule
                 logger.debug(
                     f"Couldn't schedule for {next_time} because "
                     f"timer value {timer_ms} too large.")
+
+                self.timers[profile_id] = {
+                    'dt': next_time,
+                    'type': ScheduleStatusType.TOO_FAR_AHEAD
+                }
 
         # Emit signal so that e.g. the GUI can react to the new schedule
         self.schedule_changed.emit(profile_id)
@@ -181,6 +218,9 @@ class VortaScheduler(QtCore.QObject):
         next_job = now = dt.now()
         next_profile = None
         for profile_id, timer in self.timers.items():
+            if timer['type'] != ScheduleStatusType.SCHEDULED:
+                continue
+
             if next_job == now and timer['dt'] > next_job and timer['qtt'].isActive():
                 next_job = timer['dt']
                 next_profile = profile_id
@@ -194,12 +234,11 @@ class VortaScheduler(QtCore.QObject):
         else:
             return self.tr('None scheduled')
 
-    def next_job_for_profile(self, profile_id):
+    def next_job_for_profile(self, profile_id: int) -> ScheduleStatus:
         job = self.timers.get(profile_id)
         if job is None:
-            return self.tr('None scheduled')
-        else:
-            return job['dt'].strftime('%Y-%m-%d %H:%M')
+            return ScheduleStatus(ScheduleStatusType.UNSCHEDULED)
+        return ScheduleStatus(job['type'], time=job.get('dt'))
 
     def create_backup(self, profile_id):
         notifier = VortaNotifications.pick()
@@ -287,5 +326,8 @@ class VortaScheduler(QtCore.QObject):
 
     def remove_job(self, profile_id):
         if profile_id in self.timers:
-            self.timers[profile_id]['qtt'].stop()
+            qtimer = self.timers[profile_id].get('qtt')
+            if qtimer is not None:
+                qtimer.stop()
+
             del self.timers[profile_id]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,8 @@ def init_db(qapp, qtbot, tmpdir_factory):
     yield
 
     qapp.jobs_manager.cancel_all_jobs()
+    qapp.backup_finished_event.disconnect()
+    qapp.scheduler.schedule_changed.disconnect()
     qtbot.waitUntil(lambda: not qapp.jobs_manager.is_worker_running(), **pytest._wait_defaults)
     mock_db.close()
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,7 +8,7 @@ from pytest import mark
 
 import vorta.borg
 import vorta.scheduler
-from vorta.scheduler import VortaScheduler
+from vorta.scheduler import ScheduleStatus, ScheduleStatusType, VortaScheduler
 from vorta.store.models import BackupProfileModel, EventLogModel
 
 PROFILE_NAME = 'Default'
@@ -50,8 +50,7 @@ def test_scheduler_create_backup(qapp, qtbot, mocker, borg_json_output):
     with qtbot.waitSignal(qapp.backup_finished_event, **pytest._wait_defaults):
         qapp.scheduler.create_backup(1)
 
-    assert EventLogModel.select().where(
-        EventLogModel.returncode == 0).count() == events_before + 1
+    assert EventLogModel.select().count() == events_before + 1
 
 
 def test_manual_mode():
@@ -74,7 +73,8 @@ def test_simple_schedule(clockmock):
     scheduler = VortaScheduler()
 
     # setup
-    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+    time = dt(2020, 5, 6, 4, 30)
+    clockmock.now.return_value = time
 
     profile = BackupProfileModel.get(name=PROFILE_NAME)
     profile.schedule_make_up_missed = False
@@ -83,17 +83,26 @@ def test_simple_schedule(clockmock):
     profile.schedule_interval_count = 3
     profile.save()
 
+    event = EventLogModel(subcommand='create',
+                          profile=profile.id,
+                          returncode=0,
+                          category='scheduled',
+                          start_time=time,
+                          end_time=time)
+    event.save()
+
     # test set timer and next_job
     scheduler.set_timer_for_profile(profile.id)
     assert len(scheduler.timers) == 1
     assert scheduler.next_job() == '07:30 ({})'.format(PROFILE_NAME)
-    assert scheduler.next_job_for_profile(profile.id) == '2020-05-06 07:30'
+    assert scheduler.next_job_for_profile(profile.id) == ScheduleStatus(
+        ScheduleStatusType.SCHEDULED, dt(2020, 5, 6, 7, 30))
 
     # test remove_job and next_job
     scheduler.remove_job(profile.id)
     assert len(scheduler.timers) == 0
     assert scheduler.next_job() == 'None scheduled'
-    assert scheduler.next_job_for_profile(profile.id) == 'None scheduled'
+    assert scheduler.next_job_for_profile(profile.id) == ScheduleStatus(ScheduleStatusType.UNSCHEDULED)
 
 
 @mark.parametrize("scheduled", [True, False])
@@ -138,35 +147,6 @@ def test_interval(clockmock, passed_time, scheduled, now, unit, count,
                           start_time=time - passed_time,
                           end_time=time - passed_time)
     event.save()
-
-    # run test
-    scheduler.set_timer_for_profile(profile.id)
-    assert scheduler.timers[profile.id]['dt'] == time + added_time
-
-
-@mark.parametrize(
-    "now, unit, count, added_time",
-    [
-        # simple
-        (td(hours=4, minutes=30), 'hours', 3, td(hours=3)),
-
-        # next day
-        (td(hours=4, minutes=30), 'hours', 20, td(hours=20)),
-    ])
-def test_first_interval(clockmock, now, unit, count, added_time):
-    """Test scheduling in interval mode without a previous backup."""
-    # setup
-    scheduler = VortaScheduler()
-
-    time = dt(2020, 5, 4, 0, 0) + now
-    clockmock.now.return_value = time
-
-    profile = BackupProfileModel.get(name=PROFILE_NAME)
-    profile.schedule_make_up_missed = False
-    profile.schedule_mode = INTERVAL_SCHEDULE
-    profile.schedule_interval_unit = unit
-    profile.schedule_interval_count = count
-    profile.save()
 
     # run test
     scheduler.set_timer_for_profile(profile.id)
@@ -219,32 +199,3 @@ def test_fixed(clockmock, passed_time, scheduled, now, hour, minute):
 
     scheduler.set_timer_for_profile(profile.id)
     assert scheduler.timers[profile.id]['dt'] == expected
-
-
-@mark.parametrize(
-    "now, hour, minute, added_time",
-    [
-        # same day
-        (td(hours=4, minutes=30), 15, 00, td(hours=10, minutes=30)),
-
-        # next day
-        (td(hours=4, minutes=30), 3, 30, td(hours=23)),
-    ])
-def test_first_fixed(clockmock, now, hour, minute, added_time):
-    """Test scheduling in fixed mode without a previous backup."""
-    # setup
-    scheduler = VortaScheduler()
-
-    time = dt(2020, 5, 4, 0, 0) + now
-    clockmock.now.return_value = time
-
-    profile = BackupProfileModel.get(name=PROFILE_NAME)
-    profile.schedule_make_up_missed = False
-    profile.schedule_mode = FIXED_SCHEDULE
-    profile.schedule_fixed_hour = hour
-    profile.schedule_fixed_minute = minute
-    profile.save()
-
-    # run test
-    scheduler.set_timer_for_profile(profile.id)
-    assert scheduler.timers[profile.id]['dt'] == time + added_time


### PR DESCRIPTION
A backup will only be scheduled if there already was a previous backup for this profile.
The `Next backup time` status label now supports more than two messages. It can show `None scheduled`, `Run a manual backup first` and the scheduled time **in the format of the translation locale**.

Fixes #1291.

* src/vorta/scheduler.py (VortaScheduler.\_\_init\_\_): Connect `VortaApp.backup_finished_event`
	to `set_timer_for_profile`.

* src/vorta/scheduler.py (VortaScheduler.set_timer_for_profile): Only schedule if there was a previous backup.

* src/vorta/scheduler.py (VortaScheduler.set_timer_for_profile): Emit `schedule_changed` also when no backup is scheduled.

* src/vorta/scheduler.py: Add `ScheduleStatusType` and `ScheduleStatus` representing
	the scheduler status  for a profile.

* src/vorta/scheduler.py (VortaScheduler.next_job_for_profile): Return a `ScheduleStatus`.

* src/vorta/i18n/\_\_init\_\_.py (get_locale): Added and implemented so that it returns the locale
	corresponding to the used translator.

* src/vorta/views/schedule_tab.py (ScheduleTab.draw_next_scheduled_backup): Handle `ScheduleStatus`
	returned by `next_job_for_profile` and select the string to display.
	Use `QLocale` to format the `datetime`.

* src/vorta/views/schedule_tab.py (ScheduleTab.popuolate_from_profile): Call `draw_next_scheduled_backup`.