### PR TITLE
Determine source files for `translations-from-source` dynamically.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@ bump-version:  ## Tag new version. First set new version number in src/vorta/_ve
 
 translations-from-source:  ## Extract strings from source code / UI files, merge into .ts.
 	pylupdate5 -verbose -translate-function trans_late \
-			   ${VORTA_SRC}/*.py ${VORTA_SRC}/views/*.py ${VORTA_SRC}/borg/*.py \
-			   ${VORTA_SRC}/store/*.py ${VORTA_SRC}/assets/UI/*.ui \
+			   $$(find ${VORTA_SRC} -regex ".*[.]\(py\|ui\)") \
 			   -ts ${VORTA_SRC}/i18n/ts/vorta.en.ts
 
 translations-push: translations-from-source  ## Upload .ts to Transifex.


### PR DESCRIPTION
Makefile (translations-from-source): Use a call to `find` to get a list
	of source files (*.ui and *.py) that is passed to `pylupdate5`.