### PR TITLE
Remove call to `QTranslator.language()` in `get_locale`.

### DIFF
--- a/src/vorta/i18n/__init__.py
+++ b/src/vorta/i18n/__init__.py
@@ -71,8 +71,11 @@ def init_translations(app):
 
 def get_locale():
     """Get the locale used for translation."""
-    global translator
-    return QLocale(translator.language())
+    # global translator
+    # QTranslator.language was added with Qt 15.15
+    # return QLocale(translator.language())
+    global locale
+    return locale
 
 
 def translate(*args, **kwargs):

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -68,5 +68,11 @@ def test_schedule_tab(qapp: VortaApp, qtbot, clockmock):
 
     qapp.scheduler.set_timer_for_profile(profile.id)
     tab.draw_next_scheduled_backup()
-    assert next_backup.strftime('%B %Y %H:%M:%S') in tab.nextBackupDateTimeLabel.text()
+
+    assert tab.nextBackupDateTimeLabel.text() not in [
+        "Run a manual backup first",
+        "None scheduled",
+    ]
+    assert qapp.scheduler.next_job_for_profile(profile.id).time == next_backup
+
     qapp.scheduler.remove_job(profile.id)


### PR DESCRIPTION
The `language` method was added with Qt 5.15, which not all linux distributions use yet.

* src/vorta/i18n/__init__.py (get_locale): Return the global locale.

*That's a disadvantage of using a clean test system: You won't notice such issues.*