### PR TITLE
Raise `ValueError` in case of unknown change type in diff json.

### DIFF
--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -120,7 +120,10 @@ def parse_diff_json_lines(diffs):
                     #                                       change['new_user'], change['new_group'])
                     change_type = 'modified'
                     change_type_priority = 1
-        assert change_type  # either no changes, or unrecognized change(s)
+
+        if not change_type:
+            # either no changes, or unrecognized change(s)
+            raise ValueError(f"Unknown change type {change['type']}")
 
         files_with_attributes.append((size, change_type, name, dirpath, file_type))
 


### PR DESCRIPTION
Currently an assert statement checks whether a change type was recognized.
This assert statement won't give any information on the actual change type that
is not implemented. Now a ValueError that mentiones the unknown change type in
its message will be raised instead. This will help debugging future problems but also present ones like #1347.

* src/vorta/views/diff_result.py (parse_diff_json_lines): Replace assert statement by
	if and raise statements.