### PR TITLE
Log json diff line if there was an error parsing it.

### DIFF
--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 
@@ -13,6 +14,8 @@ from vorta.views.partials.tree_view import TreeModel
 
 uifile = get_asset('UI/diffresult.ui')
 DiffResultUI, DiffResultBase = uic.loadUiType(uifile)
+
+logger = logging.getLogger(__name__)
 
 
 class DiffResult(DiffResultBase, DiffResultUI):
@@ -123,6 +126,7 @@ def parse_diff_json_lines(diffs):
 
         if not change_type:
             # either no changes, or unrecognized change(s)
+            logger.error(f"Error parsing diff line {json.dumps(item)}")
             raise ValueError(f"Unknown change type {change['type']}")
 
         files_with_attributes.append((size, change_type, name, dirpath, file_type))


### PR DESCRIPTION
This should help debugging errors like #1347.

* src/vorta/views/diff_result.py (parse_diff_json_lines): Before raising ValueError for unknown change type,
	log the diff line with level ERROR.