### PR TITLE
cleanup temp files at end of job

### DIFF
--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -301,9 +301,8 @@ class BorgJob(JobInterface, BackupProfileMixin):
             self.process_result(result)
 
         self.finished_event(result)
-        for filename in self.cleanup_files:
-            if os.path.exists(filename):
-                os.remove(filename)
+        for tmpfile in self.cleanup_files:
+            tmpfile.close()
 
     def process_result(self, result):
         pass

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -104,6 +104,7 @@ class BorgJob(JobInterface, BackupProfileMixin):
         self.cwd = params.get('cwd', None)
         self.params = params
         self.process = None
+        self.cleanup_files = params.get('cleanup_files', [])
 
     def repo_id(self):
         return self.site_id
@@ -182,6 +183,7 @@ class BorgJob(JobInterface, BackupProfileMixin):
         ret['profile_id'] = profile.id
 
         ret['ok'] = True
+        ret['cleanup_files'] = []
 
         return ret
 
@@ -299,6 +301,9 @@ class BorgJob(JobInterface, BackupProfileMixin):
             self.process_result(result)
 
         self.finished_event(result)
+        for filename in self.cleanup_files:
+            if os.path.exists(filename):
+                os.remove(filename)
 
     def process_result(self, result):
         pass

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -145,11 +145,11 @@ class BorgCreateJob(BorgJob):
                     exclude_dirs.append(expanded_directory)
 
             if exclude_dirs:
-                pattern_file = tempfile.NamedTemporaryFile('w', delete=False)
+                pattern_file = tempfile.NamedTemporaryFile('w', delete=True)
                 pattern_file.write('\n'.join(exclude_dirs))
                 pattern_file.flush()
                 cmd.extend(['--exclude-from', pattern_file.name])
-                ret['cleanup_files'].append(pattern_file.name)
+                ret['cleanup_files'].append(pattern_file)
 
         if profile.exclude_if_present is not None:
             for f in profile.exclude_if_present.split('\n'):

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -149,6 +149,7 @@ class BorgCreateJob(BorgJob):
                 pattern_file.write('\n'.join(exclude_dirs))
                 pattern_file.flush()
                 cmd.extend(['--exclude-from', pattern_file.name])
+                ret['cleanup_files'].append(pattern_file.name)
 
         if profile.exclude_if_present is not None:
             for f in profile.exclude_if_present.split('\n'):

--- a/src/vorta/borg/extract.py
+++ b/src/vorta/borg/extract.py
@@ -35,7 +35,7 @@ class BorgExtractJob(BorgJob):
         # dialog.
         # Unselected (and excluded) parent folders will be restored by borg
         # but without the metadata stored in the archive.
-        pattern_file = tempfile.NamedTemporaryFile('w', delete=False)
+        pattern_file = tempfile.NamedTemporaryFile('w', delete=True)
         pattern_file.write("P fm\n")
 
         indexes = [QModelIndex()]
@@ -54,6 +54,7 @@ class BorgExtractJob(BorgJob):
         pattern_file.flush()
         pattern_file.close()  # wont delete temp file
         cmd.extend(['--patterns-from', pattern_file.name])
+        ret['cleanup_files'].append(pattern_file)
 
         ret['ok'] = True
         ret['cmd'] = cmd


### PR DESCRIPTION
Closes #1383

This only has been tested locally, but seems to work. The file is only cleaned in case of a success