### PR TITLE
Add spaces after `assert` and enhance git py diff.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py diff=python

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -37,7 +37,7 @@ def test_autostart(qapp, qtbot):
         with open(autostart_path) as desktop_file:
             desktop_file_text = desktop_file.read()
 
-        assert(desktop_file_text.startswith("[Desktop Entry]"))
+        assert (desktop_file_text.startswith("[Desktop Entry]"))
 
     click_autostart()
     if sys.platform == 'linux':

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -76,7 +76,7 @@ def test_password_autofill(qapp, qtbot):
 
     qtbot.keyClicks(add_repo_window.repoURL, test_repo_url)
 
-    assert(add_repo_window.passwordLineEdit.text() == password)
+    assert (add_repo_window.passwordLineEdit.text() == password)
 
 
 def test_repo_add_success(qapp, qtbot, mocker, borg_json_output):


### PR DESCRIPTION
* tests/test_misc.py
* tests/test_repo.py

* .gitattributes : Set `diff` mode for `.py` files to python.