### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+b6a24debb78b953117a3f637db18942f370a4b85


### PR DESCRIPTION
This will exclude the commit reformatting the whole repository with black from git blame as suggested by [black ](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html?highlight=migrating#avoiding-ruining-git-blame) and in #929.