### PR TITLE
Check-strings

### DIFF
--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -34,7 +34,7 @@
         <x>0</x>
         <y>0</y>
         <width>781</width>
-        <height>367</height>
+        <height>371</height>
        </rect>
       </property>
       <attribute name="label">
@@ -71,7 +71,7 @@
            <item>
             <widget class="QToolButton" name="bCheck">
              <property name="toolTip">
-              <string>Check the consistancy of the repository</string>
+              <string>Check the consistency of the repository</string>
              </property>
              <property name="text">
               <string>Check</string>
@@ -96,6 +96,9 @@
            </item>
            <item>
             <widget class="QToolButton" name="compactButton">
+             <property name="toolTip">
+              <string>Optimize disk space by defragmenting the repository</string>
+             </property>
              <property name="text">
               <string>Compact</string>
              </property>
@@ -111,6 +114,9 @@
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string notr="true">see source code</string>
              </property>
              <property name="text">
               <string notr="true">bMountRepo</string>
@@ -219,6 +225,9 @@
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
+                <property name="toolTip">
+                 <string notr="true">see source code</string>
+                </property>
                 <property name="text">
                  <string notr="true">bMountArchive</string>
                 </property>
@@ -309,7 +318,7 @@
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Delete selected archive</string>
+              <string>Delete selected archive(s)</string>
              </property>
              <property name="text">
               <string>Delete</string>
@@ -350,7 +359,7 @@
         <x>0</x>
         <y>0</y>
         <width>781</width>
-        <height>367</height>
+        <height>371</height>
        </rect>
       </property>
       <attribute name="label">

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -117,7 +117,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         )
 
         self.populate_from_profile()
-        self.selected_archives = None
+        self.selected_archives = None  # TODO: remove unused variable
         self.set_icons()
 
         # Connect to palette change
@@ -137,7 +137,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.bDelete.setIcon(get_colored_icon('trash'))
         self.bExtract.setIcon(get_colored_icon('cloud-download'))
 
-        self.bmountarchive_refresh()
+        self.bmountarchive_refresh(icon_only=True)
         self.bmountrepo_refresh()
 
     @pyqtSlot(QPoint)
@@ -315,7 +315,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         else:
             self.bDelete.setEnabled(False)
             tooltip = self.tooltip_dict[self.bDelete]
-            self.bDelete.setToolTip(tooltip + " " + self.tr("(Select two archives)"))
+            self.bDelete.setToolTip(tooltip + " " + self.tr("(Select minimum one archive)"))
 
         # Toggle diff button
         if len(indexes) == 2:
@@ -349,6 +349,11 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
 
                 tooltip = self.tooltip_dict.setdefault(widget, tooltip)
                 widget.setToolTip(tooltip + " " + self.tr("(Select exactly one archive)"))
+
+            # special treatment for dynamic mount/unmount button.
+            self.bmountarchive_refresh()
+            tooltip = self.bMountArchive.toolTip()
+            self.bMountArchive.setToolTip(tooltip + " " + self.tr("(Select exactly one archive)"))
 
     def archive_copy(self, index=None):
         """
@@ -511,7 +516,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         else:
             self.mount_action()
 
-    def bmountarchive_refresh(self):
+    def bmountarchive_refresh(self, icon_only=False):
         """
         Update label, tooltip and state of `bMountArchive`.
 
@@ -521,13 +526,15 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         archive_name = self.selected_archive_name()
 
         if archive_name in self.mount_points:
-            self.bMountArchive.setText(self.tr("Unmount"))
             self.bMountArchive.setIcon(get_colored_icon('eject'))
-            self.bMountArchive.setToolTip(self.tr('Unmount the selected archive from the file system.'))
+            if not icon_only:
+                self.bMountArchive.setText(self.tr("Unmount"))
+                self.bMountArchive.setToolTip(self.tr('Unmount the selected archive from the file system'))
         else:
-            self.bMountArchive.setText(self.tr("Mount…"))
             self.bMountArchive.setIcon(get_colored_icon('folder-open'))
-            self.bMountRepo.setToolTip(self.tr("Mount the selected archive " + "as a folder in the file system."))
+            if not icon_only:
+                self.bMountArchive.setText(self.tr("Mount…"))
+                self.bMountArchive.setToolTip(self.tr("Mount the selected archive " + "as a folder in the file system"))
 
     def bmountrepo_refresh(self):
         """
@@ -538,12 +545,12 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         """
         if self.repo_mount_point:
             self.bMountRepo.setText(self.tr("Unmount"))
-            self.bMountRepo.setToolTip(self.tr('Unmount the repository from the file system.'))
+            self.bMountRepo.setToolTip(self.tr('Unmount the repository from the file system'))
             self.bMountRepo.setIcon(get_colored_icon('eject'))
         else:
             self.bMountRepo.setText(self.tr("Mount…"))
             self.bMountRepo.setIcon(get_colored_icon('folder-open'))
-            self.bMountRepo.setToolTip(self.tr("Mount the repository as a folder in the file system."))
+            self.bMountRepo.setToolTip(self.tr("Mount the repository as a folder in the file system"))
 
     def mount_action(self, archive_name=None):
         """


### PR DESCRIPTION
Resolves #1398.

* src/vorta/assets/UI/archivetab.ui (bCheck): Fix typo.
* src/vorta/assets/UI/archivetab.ui (compactButton): Add tooltip.
* src/vorta/assets/UI/archivetab.ui (bDelete): Fix typo.
* src/vorta/views/archive_tab.py (on_selection_change): Fix tooltip for `bMountArchive`.
* src/vorta/views/archive_tab.py (bmountarchive_refresh): Fix punctuation and set tooltip correctly. Add option for setting the icon only.
* src/vorta/views/archive_tab.py (bmountrepo_refresh): Fix punctutation.
* src/vorta/views/archive_tab.py (set_icons): Refresh only the icon of `bMountArchive`.