### PR TITLE
Update use of `--prefix` for borg V2.

### DIFF
--- a/src/vorta/borg/prune.py
+++ b/src/vorta/borg/prune.py
@@ -46,7 +46,11 @@ class BorgPruneJob(BorgJob):
 
         if profile.prune_prefix:
             formatted_prune_prefix = format_archive_name(profile, profile.prune_prefix)
-            pruning_opts += ['--prefix', formatted_prune_prefix]
+
+            if borg_compat.check('V2'):
+                pruning_opts += ['-a', formatted_prune_prefix + '*']  # sh: pattern
+            else:
+                pruning_opts += ['--prefix', formatted_prune_prefix]
 
         if profile.prune_keep_within:
             pruning_opts += ['--keep-within', profile.prune_keep_within]


### PR DESCRIPTION
* src/vorta/borg/prune.py (BorgPruneJob.prepare): Use `-a prefix*` instead of `--prefix prefix` for V2.