### PR TITLE
Disable ssh key option in repo tab for local repos.

### DIFF
--- a/src/vorta/assets/UI/repotab.ui
+++ b/src/vorta/assets/UI/repotab.ui
@@ -165,7 +165,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QFrame" name="frame">
+       <widget class="QFrame" name="frameRepoSettings">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>3</horstretch>
@@ -220,7 +220,7 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout">
+          <layout class="QHBoxLayout" name="layoutSSHKey">
            <item>
             <widget class="QComboBox" name="sshComboBox">
              <property name="sizePolicy">

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -108,6 +108,16 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         # set labels
         repo: RepoModel = self.profile().repo
         if repo is not None:
+            self.frameRepoSettings.setEnabled(True)
+
+            # local repo doesn't use ssh
+            ssh_enabled = repo.is_remote_repo()
+            # self.bAddSSHKey.setEnabled(ssh_enabled)
+            # otherwise one cannot add a ssh key for adding a repo
+            self.sshComboBox.setEnabled(ssh_enabled)
+            self.sshKeyToClipboardButton.setEnabled(ssh_enabled)
+
+            # update stats
             if repo.unique_csize is not None:
                 self.sizeCompressed.setText(pretty_bytes(repo.unique_csize))
                 self.sizeCompressed.setToolTip('')
@@ -131,6 +141,10 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
 
             self.repoEncryption.setText(str(repo.encryption))
         else:
+            # Compression and SSH key are only valid entries for a repo
+            self.frameRepoSettings.setEnabled(False)
+
+            # unset stats
             self.sizeCompressed.setText(na)
             self.sizeCompressed.setToolTip(no_repo_selected)
 


### PR DESCRIPTION
Fixes #1400.

* src/vorta/assets/UI/repotab.ui : Name `frameRepoSettings` and `layoutSSHKey`.

* src/vorta/views/repo_tab.py (RepoTab.init_repo_stats): Disable `frameRepoSettings` if no repo is selected.
	Disable widgets in `layoutSSHKey` in case of a local repository except from `bAddSSHKey` so the
	the user can add a key for a adding a repo.