### PR TITLE
Add default `unset` value to repo combobox.

### DIFF
--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -140,7 +140,7 @@ class BorgJob(JobInterface, BackupProfileMixin):
             return ret
 
         if profile.repo is None:
-            ret['message'] = trans_late('messages', 'Add a backup repository first.')
+            ret['message'] = trans_late('messages', 'Select a backup repository first.')
             return ret
 
         if not borg_compat.check('JSON_LOG'):

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -75,6 +75,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
 
     def set_repos(self):
         self.repoSelector.clear()
+        self.repoSelector.addItem(self.tr('No repository selected'), None)
         for repo in RepoModel.select():
             self.repoSelector.addItem(repo.url, repo.id)
 
@@ -266,8 +267,8 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         selected_repo_id = self.repoSelector.currentData()
         selected_repo_index = self.repoSelector.currentIndex()
 
-        if selected_repo_index < 0:
-            # QComboBox is empty
+        if selected_repo_index <= 0:
+            # QComboBox is empty / repo unset
             return
 
         repo = RepoModel.get(id=selected_repo_id)
@@ -289,7 +290,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
     def copy_URL_action(self):
         selected_repo_id = self.repoSelector.currentData()
         if not selected_repo_id:
-            # QComboBox is empty
+            # QComboBox is empty / repo unset
             return
 
         repo = RepoModel.get(id=selected_repo_id)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -50,17 +50,17 @@ def test_repo_unlink(qapp, qtbot):
     main = qapp.main_window
     tab = main.repoTab
 
-    main.tabWidget.setCurrentIndex(0)
+    main.tabWidget.setCurrentIndex(1)
     qtbot.mouseClick(tab.repoRemoveToolbutton, QtCore.Qt.LeftButton)
-    qtbot.waitUntil(lambda: tab.repoSelector.count() == 0, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.repoSelector.count() == 1, **pytest._wait_defaults)
     assert RepoModel.select().count() == 0
 
     qtbot.mouseClick(main.createStartBtn, QtCore.Qt.LeftButton)
     # -1 is the repo id in this test
     qtbot.waitUntil(
-        lambda: main.progressText.text().startswith('Add a backup repository first.'), **pytest._wait_defaults
+        lambda: main.progressText.text().startswith('Select a backup repository first.'), **pytest._wait_defaults
     )
-    assert main.progressText.text() == 'Add a backup repository first.'
+    assert main.progressText.text() == 'Select a backup repository first.'
 
 
 def test_password_autofill(qapp, qtbot):


### PR DESCRIPTION
First element with index 0 is always the 'unset' option with data `None`. Label is `No repository selected`.

Fixes #1428.

* src/vorta/views/repo_tab.py (RepoTab.set_repos): Add element.

* src/vorta/views/repo_tab.py (RepoTab.repo_unlink_action): Handle the first element as unset.

* src/vorta/views/repo_tab.py (RepoTab.copy_URL_action): Handle unset state.