### PR TITLE
Update `acions/checkout` to v3.

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Check out selected branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.branch }}
     - name: Install system dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
@@ -43,7 +43,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
The second version of the checkout action is deprecated and won't be supported by Github Actions in the future because it uses Node.js 12.