### PR TITLE
Specify the use of a `sh:`-style pattern when pruning with borg v2.

### DIFF
--- a/src/vorta/borg/prune.py
+++ b/src/vorta/borg/prune.py
@@ -48,7 +48,7 @@ class BorgPruneJob(BorgJob):
             formatted_prune_prefix = format_archive_name(profile, profile.prune_prefix)
 
             if borg_compat.check('V2'):
-                pruning_opts += ['-a', formatted_prune_prefix + '*']  # sh: pattern
+                pruning_opts += ['-a', 'sh:' + formatted_prune_prefix + '*']  # sh: pattern
             else:
                 pruning_opts += ['--prefix', formatted_prune_prefix]
 


### PR DESCRIPTION
With borg v2.0.0b3 the default pattern style was changed to identical matching.

* src/vorta/borg/prune.py (BorgPruneJob.prepare)