### PR TITLE
Link to report form chooser in case of critical errors.

### DIFF
--- a/src/vorta/__main__.py
+++ b/src/vorta/__main__.py
@@ -17,7 +17,7 @@ def main():
         from PyQt5.QtWidgets import QMessageBox
 
         logger.critical(
-            "Uncaught exception, file a report at https://github.com/borgbase/vorta/issues/new",
+            "Uncaught exception, file a report at https://github.com/borgbase/vorta/issues/new/choose",
             exc_info=(type, value, tb),
         )
         full_exception = ''.join(format_exception(type, value, tb))


### PR DESCRIPTION
Currently the link will open an empty issue. Now the user can choose one of the templates.

* src/vorta/__main__.py : Replace link.