### PR TITLE
Remove *unset* repository value from combobox when a repo is selected.

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -213,7 +213,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
                 self.tr('Profile import successful!'),
                 self.tr('Profile {} imported.').format(profile.name),
             )
-            self.repoTab.populate_repositories()
+            self.repoTab.populate_from_profile()
             self.scheduleTab.populate_logs()
             self.scheduleTab.populate_wifi()
             self.miscTab.populate()

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -50,7 +50,7 @@ def test_repo_unlink(qapp, qtbot):
     main = qapp.main_window
     tab = main.repoTab
 
-    main.tabWidget.setCurrentIndex(1)
+    main.tabWidget.setCurrentIndex(0)
     qtbot.mouseClick(tab.repoRemoveToolbutton, QtCore.Qt.LeftButton)
     qtbot.waitUntil(lambda: tab.repoSelector.count() == 1, **pytest._wait_defaults)
     assert RepoModel.select().count() == 0


### PR DESCRIPTION
Fixes #1462.

* src/vorta/views/repo_tab.py (init_repo_stats): Remove *unset* item from combobox.

* src/vorta/views/repo_tab.py (populate_from_profile): Move into `populate_repositories`.

* src/vorta/views/repo_tab.py populate_repositories -> populate_from_profile
* src/vorta/views/main_window.py