### PR TITLE
Fix extract

### DIFF
--- a/src/vorta/borg/list_archive.py
+++ b/src/vorta/borg/list_archive.py
@@ -30,6 +30,7 @@ class BorgListArchiveJob(BorgJob):
             "{mode}{user}{group}{size}{"
             + ('isomtime' if borg_compat.check('V122') else 'mtime')
             + "}{path}{source}{health}{NL}",
+            f'{profile.repo.url}::{archive_name}',
         ]
         ret['ok'] = True
 

--- a/src/vorta/borg/list_archive.py
+++ b/src/vorta/borg/list_archive.py
@@ -27,9 +27,9 @@ class BorgListArchiveJob(BorgJob):
             '--json-lines',
             '--format',
             # fields to include in json output
-            "{mode}{user}{group}{size}{" + 'isomtime'
-            if borg_compat.check('V122')
-            else 'mtime' + "}{path}{source}{health}{NL}",
+            "{mode}{user}{group}{size}{"
+            + ('isomtime' if borg_compat.check('V122') else 'mtime')
+            + "}{path}{source}{health}{NL}",
         ]
         ret['ok'] = True
 


### PR DESCRIPTION
Fixes  #1474.

In python `+` takes precedence over the `if-else` operator.
Therefore brackets are needed around the latter.

* src/vorta/borg/list_archive.py (BorgListArchiveJob.prepare)

This also reverts an unwanted modification introduced in 0188b75.

* src/vorta/borg/list_archive.py (BorgListArchiveJob.prepare)