### PR TITLE
Don't close temp file before running `borg extract`.

### DIFF
--- a/src/vorta/borg/extract.py
+++ b/src/vorta/borg/extract.py
@@ -48,7 +48,6 @@ class BorgExtractJob(BorgJob):
 
         pattern_file.write("- *\n")
         pattern_file.flush()
-        pattern_file.close()  # wont delete temp file
         cmd.extend(['--patterns-from', pattern_file.name])
         ret['cleanup_files'].append(pattern_file)
 


### PR DESCRIPTION
Fixes #1488.
Closing deletes the temp file. Closing is already done by `BorgJob.run` after running the command.

* src/vorta/borg/extract.py (BorgExtractJob.prepare): Remove call to `close` of temporary file.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the Developer Certificate of Origin.*

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
