### PR TITLE
Restart timers after hibernation/sleep

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -76,8 +76,7 @@ class VortaScheduler(QtCore.QObject):
         if not data:
             now = dt.now()
 
-            current_time = now.strftime("%H:%M:%S")
-            logger.debug(f"Got login suspend/resume notification at %s", current_time)
+            logger.debug(f"Got login suspend/resume notification at {now.strftime("%H:%M:%S")}")
             self.reload_all_timers()
 
     def tr(self, *args, **kwargs):

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -69,16 +69,15 @@ class VortaScheduler(QtCore.QObject):
             self.bus.connect(service, path, interface, name, "b", self._slotOverloaded)
         else:
             logger.warn('Failed to connect to DBUS interface to detect sleep/resume events')
-         
+
     @QtCore.pyqtSlot(bool)
     def _slotOverloaded(self, data):
-        if data!=True:        
+        if data is not True:
             now = dt.now()
 
             current_time = now.strftime("%H:%M:%S")
             print(f"Got '{data}' from 'PrepareForSleep' Signal=", current_time)
             self.reload_all_timers()
-
 
     def tr(self, *args, **kwargs):
         scope = self.__class__.__name__

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -74,9 +74,7 @@ class VortaScheduler(QtCore.QObject):
     @QtCore.pyqtSlot(bool)
     def loginSuspendNotify(self, suspend: bool):
         if not suspend:
-            now = dt.now()
-
-            logger.debug(f"Got login suspend/resume notification at {now.strftime('%H:%M:%S')}")
+            logger.debug(f"Got login suspend/resume notification")
             self.reload_all_timers()
 
     def tr(self, *args, **kwargs):

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -72,11 +72,11 @@ class VortaScheduler(QtCore.QObject):
             logger.warn('Failed to connect to DBUS interface to detect sleep/resume events')
 
     @QtCore.pyqtSlot(bool)
-    def loginSuspendNotify(self, data: bool):
-        if not data:
+    def loginSuspendNotify(self, suspend: bool):
+        if not suspend:
             now = dt.now()
 
-            logger.debug(f"Got login suspend/resume notification at {now.strftime("%H:%M:%S")}")
+            logger.debug(f"Got login suspend/resume notification at {now.strftime('%H:%M:%S')}")
             self.reload_all_timers()
 
     def tr(self, *args, **kwargs):


### PR DESCRIPTION
Schedules get missed, if system has been in hibernation/sleep state as described in [#1214](https://github.com/borgbase/vorta/issues/1214) Although, timers should be refreshed every 15min, it seems that all timers get deranged by sleep state and schedules is still missed in most cases. This seems to be a general issue with the underlying QTimer implementation.

This fix doesn't distinguish host OS and has only by tested on Linux. If 'org.freedesktop.login1.Manager' is not available, Vorta simple doesn't get notified if system awakes again. So no impact on other OS is expected