### PR TITLE
Show status updates while compacting

### DIFF
--- a/src/vorta/borg/compact.py
+++ b/src/vorta/borg/compact.py
@@ -38,7 +38,7 @@ class BorgCompactJob(BorgJob):
             ret['message'] = trans_late('messages', 'This feature needs Borg 1.2.0 or higher.')
             return ret
 
-        cmd = ['borg', '--info', '--log-json', 'compact', '--cleanup-commits']
+        cmd = ['borg', '--info', '--log-json', 'compact', '--cleanup-commits', '--progress']
         cmd.append(f'{profile.repo.url}')
 
         ret['ok'] = True


### PR DESCRIPTION
It's nice to have status updates during compacting, as it can take a while to compact a large repository if it hasn't been done in a while. As an example, compacting my 10 TB backup for the first time took half an hour, so it was nice being able to see the progress.