### PR TITLE
Pass int to `QPoint` constructor.

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -180,7 +180,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
 
         else:
             warn = self.tr("Cannot delete the last profile.")
-            point = QPoint(0, self.profileDeleteButton.size().height() / 2)
+            point = QPoint(0, int(self.profileDeleteButton.size().height() / 2))
             QToolTip.showText(self.profileDeleteButton.mapToGlobal(point), warn)
 
     def profile_add_action(self):


### PR DESCRIPTION
Before a float was passed to `QPoint(int, int)`. While this worked fine, on some machines it lead to an error. Fixes #1535.

* src/vorta/views/main_window.py : cast division value to int.