### PR TITLE
Fully remove setup_requires, pin black 

### DIFF
--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -1,4 +1,4 @@
-black
+black<23.0
 coverage
 flake8
 isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ package_dir =
     =src
 include_package_data = true
 python_requires = >=3.7
-setup_requires =
-  pip >= 10
+#setup_requires =
+#  pip >= 10
 install_requires =
   appdirs
   paramiko

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,6 @@ package_dir =
     =src
 include_package_data = true
 python_requires = >=3.7
-#setup_requires =
-#  pip >= 10
 install_requires =
   appdirs
   paramiko


### PR DESCRIPTION
I'm far from being an expert, but it seems `pip` is not necessary in `setup_requires` as per this [suggestion](https://github.com/void-linux/void-packages/pull/41672#discussion_r1071176890).

Also, testing fails complaining about missing module `six`. Could you please check it out?