### PR TITLE
Allow creating an SSH key when bootstrapping Vorta

### DIFF
--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -2,7 +2,7 @@ import os
 from pathlib import PurePath
 from PyQt5 import QtCore, uic
 from PyQt5.QtCore import QMimeData, QUrl
-from PyQt5.QtWidgets import QApplication, QMenu, QMessageBox
+from PyQt5.QtWidgets import QApplication, QLayout, QMenu, QMessageBox
 from vorta.store.models import ArchiveModel, BackupProfileMixin, RepoModel
 from vorta.utils import borg_compat, get_asset, get_private_keys, pretty_bytes
 from .repo_add_dialog import AddRepoWindow, ExistingRepoWindow
@@ -111,10 +111,12 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         # set labels
         repo: RepoModel = self.profile().repo
         if repo is not None:
-            self.frameRepoSettings.setEnabled(True)
             # remove *unset* item
             self.repoSelector.removeItem(self.repoSelector.findData(None))
 
+            # Start with every element enabled, then disable SSH-related if relevant
+            for child in self.frameRepoSettings.children():
+                child.setEnabled(True)
             # local repo doesn't use ssh
             ssh_enabled = repo.is_remote_repo()
             # self.bAddSSHKey.setEnabled(ssh_enabled)
@@ -147,7 +149,11 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
             self.repoEncryption.setText(str(repo.encryption))
         else:
             # Compression and SSH key are only valid entries for a repo
-            self.frameRepoSettings.setEnabled(False)
+            # Yet Add SSH key button must be enabled for bootstrapping
+            for child in self.frameRepoSettings.children():
+                if not isinstance(child, QLayout):
+                    child.setEnabled(False)
+            self.bAddSSHKey.setEnabled(True)
 
             # unset stats
             self.sizeCompressed.setText(na)


### PR DESCRIPTION
Fixes #1579

As discussed in the issue, I am not sure that this fix is the most relevant — it only makes the "+" button for SSH keys available at all times, in order to be able to bootstrap a remote backup without having to run `ssh-keygen` manually (eg. for non-tech users). A quickstart wizard, or even a similar "+" option in the repository creation dialog itself, would be better suited, I believe.