### PR TITLE
Modify pre-commit config file using autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ minimum_pre_commit_version: "1.15"
 repos:
   # general stuff
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       # check file system problems
       - id: check-case-conflict
@@ -30,14 +30,14 @@ repos:
 
   # format python files
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black
         files: ^(src/vorta/|tests)
 
   # sort python imports
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
@@ -58,7 +58,7 @@ repos:
 
   # check pep8 conformity using flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
 
   # format python files
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 22.12.0
     hooks:
       - id: black
         files: ^(src/vorta/|tests)


### PR DESCRIPTION
### Description
A new version of Poetry broke isort which caused errors when running pre-commit.

Running the command `pre-commit autoupdate` updates the configuration to use the newest isort, which has a hotfix for the bug. It also updates pre-commit, black, and flake8 as a side-effect.

### Related Issue
https://github.com/borgbase/vorta/issues/1600

### Motivation and Context
It fixes the pre-commit checks

### How Has This Been Tested?
I ran pre-commit and it works, when it hasn't before

### Screenshots (if appropriate):

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
