### PR TITLE
Allow copying the public part of the first SSH key

### DIFF
--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -203,7 +203,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         msg.setParent(self, QtCore.Qt.Sheet)
 
         index = self.sshComboBox.currentIndex()
-        if index > 1:
+        if index > 0:
             ssh_key_filename = self.sshComboBox.itemData(index)
             ssh_key_path = os.path.expanduser(f'~/.ssh/{ssh_key_filename}.pub')
             if os.path.isfile(ssh_key_path):


### PR DESCRIPTION
Previously this button would only work if you had more than one SSH key which prevents the first one from being copied.

### Description
This simple change allows copying the public part of the first ssh key, which wasn't accessible previously due to the if check failing on index 1 (which could be a valid key).

### Related Issue
Steps to reproduce:
* Have only one SSH key available.
   * The dropdown should list _"Auto"_ and then _"somekey (ssh-rsa)"_
* Select the _"somekey (ssh-rsa)"_
* The "Copy to Clipboard" function doesn't work, and asks you to select a key - despite you having selected one.

### Motivation and Context
I only have one ssh key registered in Vorta usually, so it's annoying that I can't use the "Copy to Clipboard" functionality to test the key.

### How Has This Been Tested?
I tested this via a local dev environment. The change is so extremely simple I can't imagine any side-effects.

### Screenshots (if appropriate):

Example of the bug:

![image](https://user-images.githubusercontent.com/54911369/219955335-453c32a5-1d8e-4f8a-a162-78b25d53b10b.png)

![image](https://user-images.githubusercontent.com/54911369/219955314-69e44e87-7a15-481a-8f32-c1116514dea6.png)

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/
