### PR TITLE
ci: add flake8-print linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-print]
 
 # configuration for the pre-commit.ci bot
 # only relevant when actually using the bot

--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -1,9 +1,10 @@
-pre-commit
 black==22.*
 coverage
 flake8
+flake8-print
 isort
 macholib
+pre-commit
 pyinstaller
 pylint
 pytest


### PR DESCRIPTION
#1611 
Added [flake8-print](https://github.com/JBKahn/flake8-print), 
referred the flake-8 docs for additional-dependencies - https://flake8.pycqa.org/en/latest/user/using-hooks.html