### PR TITLE
feat: add settings for files list views

### DIFF
--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -93,6 +93,12 @@ def get_misc_settings() -> List[Dict[str, str]]:
             'type': 'internal',
             'label': 'Previous window height',
         },
+        {
+            'key': 'files_display_mode',
+            'str_value': '0',
+            'type': 'internal',
+            'label': 'Files view display mode',
+        },
     ]
     if sys.platform == 'darwin':
         settings += [

--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -94,10 +94,16 @@ def get_misc_settings() -> List[Dict[str, str]]:
             'label': 'Previous window height',
         },
         {
-            'key': 'files_display_mode',
+            'key': 'diff_files_display_mode',
             'str_value': '0',
             'type': 'internal',
-            'label': 'Files view display mode',
+            'label': 'Diff dialog display mode',
+        },
+        {
+            'key': 'extract_files_display_mode',
+            'str_value': '0',
+            'type': 'internal',
+            'label': 'Extract dialog display mode',
         },
     ]
     if sys.platform == 'darwin':

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -715,7 +715,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         else:
             self._set_status(self.tr('Select an archive to restore first.'))
 
-    def get_extract_display_mode(self):
+    def get_extract_tree(self):
         """
         Get the display mode for the extract dialog.
         """
@@ -732,7 +732,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self._set_status('')
         if result['returncode'] == 0:
             archive = ArchiveModel.get(name=result['params']['archive_name'])
-            model = self.get_extract_display_mode()
+            model = self.get_extract_tree()
             self._set_status(self.tr("Processing archive contents"))
             self._t = extract_dialog.ParseThread(result['data'], model)
             self._t.finished.connect(lambda: self.extract_show_dialog(archive, model))
@@ -879,7 +879,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         else:
             self._set_status(params['message'])
 
-    def get_diff_display_mode(self):
+    def get_diff_tree(self):
         """
         Get the display mode for the diff dialog.
         """
@@ -910,7 +910,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             archive_older = ArchiveModel.get(name=result['params']['archive_name_older'])
             self._set_status(self.tr("Processing diff results."))
 
-            model = self.get_diff_display_mode()
+            model = self.get_diff_tree()
 
             self._t = diff_result.ParseThread(result['data'], result['params']['json_lines'], model)
             self._t.finished.connect(lambda: self.show_diff_result(archive_newer, archive_older, model))

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -31,7 +31,7 @@ from vorta.borg.prune import BorgPruneJob
 from vorta.borg.rename import BorgRenameJob
 from vorta.borg.umount import BorgUmountJob
 from vorta.i18n import translate
-from vorta.store.models import ArchiveModel, BackupProfileMixin
+from vorta.store.models import ArchiveModel, BackupProfileMixin, SettingsModel
 from vorta.utils import (
     choose_file_dialog,
     find_best_unit_for_sizes,
@@ -43,6 +43,7 @@ from vorta.utils import (
 from vorta.views import diff_result, extract_dialog
 from vorta.views.diff_result import DiffResultDialog, DiffTree
 from vorta.views.extract_dialog import ExtractDialog, ExtractTree
+from vorta.views.partials.treemodel import FileTreeModel
 from vorta.views.source_tab import SizeItem
 from vorta.views.utils import get_colored_icon
 
@@ -714,12 +715,24 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         else:
             self._set_status(self.tr('Select an archive to restore first.'))
 
+    def get_extract_display_mode(self):
+        """
+        Get the display mode for the extract dialog.
+        """
+        display_mode = SettingsModel.get(key='extract_files_display_mode').str_value
+        if display_mode == '0':
+            return ExtractTree(mode=FileTreeModel.DisplayMode.TREE)
+        elif display_mode == '1':
+            return ExtractTree(mode=FileTreeModel.DisplayMode.SIMPLIFIED_TREE)
+        else:
+            raise ValueError("Invalid extract dialog display mode: {}".format(display_mode))
+
     def extract_list_result(self, result):
         """Process the contents of the archive to extract."""
         self._set_status('')
         if result['returncode'] == 0:
             archive = ArchiveModel.get(name=result['params']['archive_name'])
-            model = ExtractTree()
+            model = self.get_extract_display_mode()
             self._set_status(self.tr("Processing archive contents"))
             self._t = extract_dialog.ParseThread(result['data'], model)
             self._t.finished.connect(lambda: self.extract_show_dialog(archive, model))
@@ -866,6 +879,20 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         else:
             self._set_status(params['message'])
 
+    def get_diff_display_mode(self):
+        """
+        Get the display mode for the diff dialog.
+        """
+        display_mode = SettingsModel.get(key='diff_files_display_mode').str_value
+        if display_mode == '0':
+            return DiffTree(mode=FileTreeModel.DisplayMode.TREE)
+        elif display_mode == '1':
+            return DiffTree(mode=FileTreeModel.DisplayMode.SIMPLIFIED_TREE)
+        elif display_mode == '2':
+            return DiffTree(mode=FileTreeModel.DisplayMode.FLAT)
+        else:
+            raise ValueError("Invalid diff dialog display mode: {}".format(display_mode))
+
     def list_diff_result(self, result):
         """
         Process the result of the `BorgDiffJob`.
@@ -883,7 +910,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             archive_older = ArchiveModel.get(name=result['params']['archive_name_older'])
             self._set_status(self.tr("Processing diff results."))
 
-            model = DiffTree()
+            model = self.get_diff_display_mode()
 
             self._t = diff_result.ParseThread(result['data'], result['params']['json_lines'], model)
             self._t.finished.connect(lambda: self.show_diff_result(archive_newer, archive_older, model))

--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -9,6 +9,7 @@ from PyQt5 import uic
 from PyQt5.QtCore import QMimeData, QModelIndex, QPoint, Qt, QThread, QUrl
 from PyQt5.QtGui import QColor, QKeySequence
 from PyQt5.QtWidgets import QApplication, QHeaderView, QMenu, QShortcut, QTreeView
+from vorta.store.models import SettingsModel
 from vorta.utils import get_asset, pretty_bytes, uses_dark_mode
 from vorta.views.partials.treemodel import (
     FileSystemItem,
@@ -97,6 +98,8 @@ class DiffResultDialog(DiffResultBase, DiffResultUI):
         self.archiveNameLabel_1.setText(f'{archive_newer.name}')
         self.archiveNameLabel_2.setText(f'{archive_older.name}')
 
+        diff_result_display_mode = SettingsModel.get(key='files_display_mode').str_value
+        self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)
         self.bCollapseAll.clicked.connect(self.treeView.collapseAll)
@@ -182,6 +185,10 @@ class DiffResultDialog(DiffResultBase, DiffResultUI):
             mode = FileTreeModel.DisplayMode.FLAT
         else:
             raise Exception("Unknown item in comboBoxDisplayMode with index {}".format(selection))
+
+        SettingsModel.update({SettingsModel.str_value: str(selection)}).where(
+            SettingsModel.key == 'files_display_mode'
+        ).execute()
 
         self.model.setMode(mode)
 

--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -853,5 +853,5 @@ class DiffTree(FileTreeModel[DiffData]):
 
             return tooltip
 
-    def __init__(self, mode, parent=None):
+    def __init__(self, mode=None, parent=None):
         super().__init__(mode, parent)

--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -98,8 +98,8 @@ class DiffResultDialog(DiffResultBase, DiffResultUI):
         self.archiveNameLabel_1.setText(f'{archive_newer.name}')
         self.archiveNameLabel_2.setText(f'{archive_older.name}')
 
-        diff_result_display_mode = SettingsModel.get(key='diff_files_display_mode').str_value
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
+        diff_result_display_mode = SettingsModel.get(key='diff_files_display_mode').str_value
         self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)
         self.bCollapseAll.clicked.connect(self.treeView.collapseAll)

--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -98,7 +98,7 @@ class DiffResultDialog(DiffResultBase, DiffResultUI):
         self.archiveNameLabel_1.setText(f'{archive_newer.name}')
         self.archiveNameLabel_2.setText(f'{archive_older.name}')
 
-        diff_result_display_mode = SettingsModel.get(key='files_display_mode').str_value
+        diff_result_display_mode = SettingsModel.get(key='diff_files_display_mode').str_value
         self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)
@@ -187,7 +187,7 @@ class DiffResultDialog(DiffResultBase, DiffResultUI):
             raise Exception("Unknown item in comboBoxDisplayMode with index {}".format(selection))
 
         SettingsModel.update({SettingsModel.str_value: str(selection)}).where(
-            SettingsModel.key == 'files_display_mode'
+            SettingsModel.key == 'diff_files_display_mode'
         ).execute()
 
         self.model.setMode(mode)
@@ -852,3 +852,6 @@ class DiffTree(FileTreeModel[DiffData]):
                 )
 
             return tooltip
+
+    def __init__(self, mode, parent=None):
+        super().__init__(mode, parent)

--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -99,8 +99,8 @@ class DiffResultDialog(DiffResultBase, DiffResultUI):
         self.archiveNameLabel_2.setText(f'{archive_older.name}')
 
         diff_result_display_mode = SettingsModel.get(key='diff_files_display_mode').str_value
-        self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
+        self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)
         self.bCollapseAll.clicked.connect(self.treeView.collapseAll)
 
@@ -852,6 +852,3 @@ class DiffTree(FileTreeModel[DiffData]):
                 )
 
             return tooltip
-
-    def __init__(self, mode=None, parent=None):
-        super().__init__(mode, parent)

--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -89,9 +89,9 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
         self.buttonBox.addButton(self.extractButton, QDialogButtonBox.ButtonRole.AcceptRole)
 
         self.archiveNameLabel.setText(f"{archive.name}, {archive.time}")
+        diff_result_display_mode = SettingsModel.get(key='extract_files_display_mode').str_value
 
         # connect signals
-        diff_result_display_mode = SettingsModel.get(key='extract_files_display_mode').str_value
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
         self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)

--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -9,6 +9,7 @@ from PyQt5 import uic
 from PyQt5.QtCore import QDateTime, QLocale, QMimeData, QModelIndex, QPoint, Qt, QThread, QUrl
 from PyQt5.QtGui import QColor, QKeySequence
 from PyQt5.QtWidgets import QApplication, QDialogButtonBox, QHeaderView, QMenu, QPushButton, QShortcut
+from vorta.store.models import SettingsModel
 from vorta.utils import borg_compat, get_asset, pretty_bytes, uses_dark_mode
 from vorta.views.utils import get_colored_icon
 from .partials.treemodel import FileSystemItem, FileTreeModel, FileTreeSortProxyModel, path_to_str, relative_path
@@ -90,6 +91,8 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
         self.archiveNameLabel.setText(f"{archive.name}, {archive.time}")
 
         # connect signals
+        diff_result_display_mode = SettingsModel.get(key='files_display_mode').str_value
+        self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)
         self.bCollapseAll.clicked.connect(self.treeView.collapseAll)

--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -91,7 +91,7 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
         self.archiveNameLabel.setText(f"{archive.name}, {archive.time}")
 
         # connect signals
-        diff_result_display_mode = SettingsModel.get(key='files_display_mode').str_value
+        diff_result_display_mode = SettingsModel.get(key='extract_files_display_mode').str_value
         self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)
@@ -165,6 +165,10 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
             mode = FileTreeModel.DisplayMode.SIMPLIFIED_TREE
         else:
             raise Exception("Unknown item in comboBoxDisplayMode with index {}".format(selection))
+
+        SettingsModel.update({SettingsModel.str_value: str(selection)}).where(
+            SettingsModel.key == 'extract_files_display_mode'
+        ).execute()
 
         self.model.setMode(mode)
 
@@ -409,6 +413,9 @@ class ExtractTree(FileTreeModel[FileData]):
                 return self.tr("Health")
 
         return None
+
+    def __init__(self, mode, parent=None):
+        super().__init__(mode, parent)
 
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):
         """

--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -92,8 +92,8 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
 
         # connect signals
         diff_result_display_mode = SettingsModel.get(key='extract_files_display_mode').str_value
-        self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.comboBoxDisplayMode.currentIndexChanged.connect(self.change_display_mode)
+        self.comboBoxDisplayMode.setCurrentIndex(int(diff_result_display_mode))
         self.bFoldersOnTop.toggled.connect(self.sortproxy.keepFoldersOnTop)
         self.bCollapseAll.clicked.connect(self.treeView.collapseAll)
 
@@ -413,9 +413,6 @@ class ExtractTree(FileTreeModel[FileData]):
                 return self.tr("Health")
 
         return None
-
-    def __init__(self, mode=None, parent=None):
-        super().__init__(mode, parent)
 
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):
         """

--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -414,7 +414,7 @@ class ExtractTree(FileTreeModel[FileData]):
 
         return None
 
-    def __init__(self, mode, parent=None):
+    def __init__(self, mode=None, parent=None):
         super().__init__(mode, parent)
 
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):

--- a/src/vorta/views/partials/treemodel.py
+++ b/src/vorta/views/partials/treemodel.py
@@ -10,7 +10,6 @@ from functools import reduce
 from pathlib import PurePath
 from typing import Generic, List, Optional, Sequence, Tuple, TypeVar, Union, overload
 from PyQt5.QtCore import QAbstractItemModel, QModelIndex, QObject, QSortFilterProxyModel, Qt, pyqtSignal
-from vorta.store.models import SettingsModel
 
 #: A representation of a path
 Path = Tuple[str, ...]
@@ -324,20 +323,12 @@ class FileTreeModel(QAbstractItemModel, Generic[T]):
         #: simple list of items
         FLAT = enum.auto()
 
-    def __init__(self, parent=None):
+    def __init__(self, mode, parent=None):
         """Init."""
         super().__init__(parent)
         self.root: FileSystemItem[T] = FileSystemItem([], None)
 
-        display_mode = SettingsModel.get(key='files_display_mode').str_value
-        if display_mode == '0':
-            self.mode: 'FileTreeModel.DisplayMode' = self.DisplayMode.TREE
-        elif display_mode == '1':
-            self.mode: 'FileTreeModel.DisplayMode' = self.DisplayMode.SIMPLIFIED_TREE
-        elif display_mode == '2':
-            self.mode: 'FileTreeModel.DisplayMode' = self.DisplayMode.FLAT
-        else:
-            raise ValueError("Invalid display mode: {}".format(display_mode))
+        self.mode = mode
         #: flat representation of the tree
         self._flattened: List[FileSystemItem] = []
 

--- a/src/vorta/views/partials/treemodel.py
+++ b/src/vorta/views/partials/treemodel.py
@@ -10,6 +10,7 @@ from functools import reduce
 from pathlib import PurePath
 from typing import Generic, List, Optional, Sequence, Tuple, TypeVar, Union, overload
 from PyQt5.QtCore import QAbstractItemModel, QModelIndex, QObject, QSortFilterProxyModel, Qt, pyqtSignal
+from vorta.store.models import SettingsModel
 
 #: A representation of a path
 Path = Tuple[str, ...]
@@ -328,9 +329,15 @@ class FileTreeModel(QAbstractItemModel, Generic[T]):
         super().__init__(parent)
         self.root: FileSystemItem[T] = FileSystemItem([], None)
 
-        #: mode
-        self.mode: 'FileTreeModel.DisplayMode' = self.DisplayMode.TREE
-
+        display_mode = SettingsModel.get(key='files_display_mode').str_value
+        if display_mode == '0':
+            self.mode: 'FileTreeModel.DisplayMode' = self.DisplayMode.TREE
+        elif display_mode == '1':
+            self.mode: 'FileTreeModel.DisplayMode' = self.DisplayMode.SIMPLIFIED_TREE
+        elif display_mode == '2':
+            self.mode: 'FileTreeModel.DisplayMode' = self.DisplayMode.FLAT
+        else:
+            raise ValueError("Invalid display mode: {}".format(display_mode))
         #: flat representation of the tree
         self._flattened: List[FileSystemItem] = []
 

--- a/src/vorta/views/partials/treemodel.py
+++ b/src/vorta/views/partials/treemodel.py
@@ -323,7 +323,7 @@ class FileTreeModel(QAbstractItemModel, Generic[T]):
         #: simple list of items
         FLAT = enum.auto()
 
-    def __init__(self, mode, parent=None):
+    def __init__(self, mode: 'FileTreeModel.DisplayMode' = DisplayMode.TREE, parent=None):
         """Init."""
         super().__init__(parent)
         self.root: FileSystemItem[T] = FileSystemItem([], None)


### PR DESCRIPTION
Added two settings to remember user's preferred files list view in the diff and extract dialogs
- `extract_files_display_mode`
- `diff_files_display_mode`

fixes #1516 
### Motivation and Context
Improves UX

### How Has This Been Tested?
Tested by changing the views and reopening vorta.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I have to update the tests, then I'll make this ready for review.

*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
