### PR TITLE
Use `pf` pattern format for specifying what to extract.

### DIFF
--- a/src/vorta/borg/extract.py
+++ b/src/vorta/borg/extract.py
@@ -36,7 +36,7 @@ class BorgExtractJob(BorgJob):
         # Unselected (and excluded) parent folders will be restored by borg
         # but without the metadata stored in the archive.
         pattern_file = tempfile.NamedTemporaryFile('w', delete=True)
-        pattern_file.write("P fm\n")
+        pattern_file.write("P pf\n")
 
         indexes = [QModelIndex()]
         while indexes:
@@ -50,7 +50,7 @@ class BorgExtractJob(BorgJob):
                 if item.data.checkstate == Qt.CheckState.Checked:
                     pattern_file.write("+ " + path_to_str(item.path) + "\n")
 
-        pattern_file.write("- *\n")
+        pattern_file.write("- fm:*\n")
         pattern_file.flush()
         cmd.extend(['--patterns-from', pattern_file.name])
         ret['cleanup_files'].append(pattern_file)


### PR DESCRIPTION
(Hopefully) fixes #1623.

* src/vorta/borg/extract.py : The pattern file passed to borg now contains `pf`-style patterns for included paths.