### PR TITLE
feat: add settings to retain sort by column and order in source tab

### DIFF
--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -100,6 +100,18 @@ def get_misc_settings() -> List[Dict[str, str]]:
             'type': 'internal',
             'label': 'Previous window height',
         },
+        {
+            'key': 'sourcetab_sort_column',
+            'str_value': '0',
+            'type': 'internal',
+            'label': 'Source Tab Sort Column',
+        },
+        {
+            'key': 'sourcetab_sort_order',
+            'str_value': '0',
+            'type': 'internal',
+            'label': 'Source Tab Sort Order',
+        },
     ]
     if sys.platform == 'darwin':
         settings += [


### PR DESCRIPTION
### Description
Adds two new settings to retain the sort by details in source tab
- `sourcetab_sort_column`
- `sourcetab_sort_order`

### Related Issue
Fixes #1647 

### Motivation and Context
Retains the sort by details to improve UX

### How Has This Been Tested?
Tested all the columns and order sort method by reopening application and debug logging


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
