### PR TITLE
feat: block after vorta create and log status

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -52,7 +52,6 @@ class VortaApp(QtSingleApplication):
             elif args.profile:
                 self.sendMessage(f"create {args.profile}")
                 logger.info('Creating backup using existing Vorta instance.')
-                sys.exit()
         elif args.profile:
             sys.exit('Vorta must already be running for --create to work')
 
@@ -147,6 +146,9 @@ class VortaApp(QtSingleApplication):
     def message_received_event_response(self, message):
         if message == "open main window":
             self.open_main_window_action()
+        elif message.startswith("created"):
+            logger.debug(f"Backup created: {message[8:]}")
+            sys.exit()
         elif message.startswith("create"):
             message = message[7:]  # Remove create
             if self.jobs_manager.is_worker_running():

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -45,6 +45,7 @@ class BorgCreateJob(BorgJob):
         self.app.backup_progress_event.emit(self.tr('Backup started.'))
 
     def finished_event(self, result):
+        self.app.reply(f"created {result['data']['archive']['name']}")
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
         self.pre_post_backup_cmd(self.params, cmd='post_backup_cmd', returncode=result['returncode'])

--- a/src/vorta/qt_single_application.py
+++ b/src/vorta/qt_single_application.py
@@ -53,6 +53,7 @@ class QtSingleApplication(QApplication):
             # Yes, there is.
             self._outStream = QTextStream(self._outSocket)
             self._outStream.setCodec('UTF-8')
+            self._outSocket.readyRead.connect(self._onReadyReply)
         else:
             # No, there isn't.
             self._outSocket = None
@@ -93,3 +94,15 @@ class QtSingleApplication(QApplication):
             if not msg:
                 break
             self.message_received_event.emit(msg)
+
+    def _onReadyReply(self):
+        while True:
+            msg = self._outStream.readLine()
+            if not msg:
+                break
+            self.message_received_event.emit(msg)
+
+    def reply(self, msg):
+        self._inStream << msg << '\n'
+        self._inStream.flush()
+        self._inSocket.waitForBytesWritten()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes #1380 
blocks `vorta --create` to log the result of the backing up operation.

### Motivation and Context
Better UX for `vorta --create`

### How Has This Been Tested?
Test GIF:
![create-block](https://user-images.githubusercontent.com/41837037/225720684-c548ed52-e77c-45a4-b6d4-dcf785e0c9e4.gif)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
