### PR TITLE
feat: settings to allow new networks and show notif when a network is disallowed

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -113,12 +113,16 @@ class VortaApp(QtSingleApplication):
             job = BorgCreateJob(msg['cmd'], msg, profile.repo.id)
             self.jobs_manager.add_job(job)
         else:
-            notifier = VortaNotifications.pick()
-            notifier.deliver(
-                self.tr('Vorta Backup'),
-                translate('messages', msg['message']),
-                level='error',
-            )
+            if not (
+                msg['message'] == 'Current Wifi is not allowed.'
+                and not profile.show_notification_when_network_disallowed
+            ):
+                notifier = VortaNotifications.pick()
+                notifier.deliver(
+                    self.tr('Vorta Backup'),
+                    translate('messages', msg['message']),
+                    level='error',
+                )
             self.backup_progress_event.emit(translate('messages', msg['message']))
             return None
 

--- a/src/vorta/assets/UI/scheduletab.ui
+++ b/src/vorta/assets/UI/scheduletab.ui
@@ -38,8 +38,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>687</width>
-        <height>384</height>
+        <width>898</width>
+        <height>361</height>
        </rect>
       </property>
       <property name="font">
@@ -520,7 +520,7 @@
         <x>0</x>
         <y>0</y>
         <width>687</width>
-        <height>384</height>
+        <height>378</height>
        </rect>
       </property>
       <attribute name="label">
@@ -530,7 +530,7 @@
        <property name="verticalSpacing">
         <number>12</number>
        </property>
-       <item row="1" column="0">
+       <item row="3" column="0">
         <layout class="QVBoxLayout" name="verticalLayout_8">
          <property name="spacing">
           <number>4</number>
@@ -567,6 +567,20 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="allowNewNetworksCheckBox">
+         <property name="text">
+          <string>Allow new networks by default</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="networkDisallowedNotificationCheckBox">
+         <property name="text">
+          <string>Show notification when a network is disallowed</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="page">
@@ -575,7 +589,7 @@
         <x>0</x>
         <y>0</y>
         <width>687</width>
-        <height>384</height>
+        <height>378</height>
        </rect>
       </property>
       <attribute name="label">
@@ -634,7 +648,7 @@
         <x>0</x>
         <y>0</y>
         <width>687</width>
-        <height>384</height>
+        <height>378</height>
        </rect>
       </property>
       <attribute name="label">

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -418,11 +418,15 @@ class VortaScheduler(QtCore.QObject):
             else:
                 logger.error('Conditions for backup not met. Aborting.')
                 logger.error(msg['message'])
-                notifier.deliver(
-                    self.tr('Vorta Backup'),
-                    translate('messages', msg['message']),
-                    level='error',
-                )
+                if not (
+                    msg['message'] == 'Current Wifi is not allowed.'
+                    and not profile.show_notification_when_network_disallowed
+                ):
+                    notifier.deliver(
+                        self.tr('Vorta Backup'),
+                        translate('messages', msg['message']),
+                        level='error',
+                    )
                 self.pause(profile_id)
 
     def notify(self, result):

--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -18,7 +18,7 @@ from .models import (
 )
 from .settings import get_misc_settings
 
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 
 
 @signals.post_save(sender=SettingsModel)

--- a/src/vorta/store/migrations.py
+++ b/src/vorta/store/migrations.py
@@ -226,6 +226,22 @@ def run_migrations(current_schema, db_connection):
             migrator.add_column(SettingsModel._meta.table_name, 'tooltip', pw.CharField(default='')),
         )
 
+    if current_schema.version < 21:
+        _apply_schema_update(
+            current_schema,
+            21,
+            migrator.add_column(
+                BackupProfileModel._meta.table_name,
+                'allow_new_networks',
+                pw.BooleanField(default=False),
+            ),
+            migrator.add_column(
+                BackupProfileModel._meta.table_name,
+                "show_notification_when_network_disallowed",
+                pw.BooleanField(default=True),
+            ),
+        )
+
 
 def _apply_schema_update(current_schema, version_after, *operations):
     with DB.atomic():

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -95,6 +95,8 @@ class BackupProfileModel(BaseModel):
     pre_backup_cmd = pw.CharField(default='')
     post_backup_cmd = pw.CharField(default='')
     dont_run_on_metered_networks = pw.BooleanField(default=True)
+    allow_new_networks = pw.BooleanField(default=False)
+    show_notification_when_network_disallowed = pw.BooleanField(default=True)
 
     def refresh(self):
         return type(self).get(self._pk_expr())

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -322,12 +322,13 @@ def get_sorted_wifis(profile):
     # Pull networks known to OS and all other backup profiles
     system_wifis = get_network_status_monitor().get_known_wifis()
     from_other_profiles = WifiSettingModel.select().where(WifiSettingModel.profile != profile.id).execute()
+    allow_new_networks = profile.allow_new_networks
 
     for wifi in list(from_other_profiles) + system_wifis:
         db_wifi, created = WifiSettingModel.get_or_create(
             ssid=wifi.ssid,
             profile=profile.id,
-            defaults={'last_connected': wifi.last_connected, 'allowed': True},
+            defaults={'last_connected': wifi.last_connected, 'allowed': allow_new_networks},
         )
 
         # Update last connected time

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -75,6 +75,12 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.meteredNetworksCheckBox.stateChanged.connect(
             lambda new_val, attr='dont_run_on_metered_networks': self.save_profile_attr(attr, not new_val)
         )
+        self.allowNewNetworksCheckBox.stateChanged.connect(
+            lambda new_val, attr='allow_new_networks': self.save_profile_attr(attr, new_val)
+        )
+        self.networkDisallowedNotificationCheckBox.stateChanged.connect(
+            lambda new_val, attr='show_notification_when_network_disallowed': self.save_profile_attr(attr, new_val)
+        )
         self.postBackupCmdLineEdit.textEdited.connect(
             lambda new_val, attr='post_backup_cmd': self.save_profile_attr(attr, new_val)
         )
@@ -148,6 +154,12 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         )
         self.meteredNetworksCheckBox.setChecked(
             QtCore.Qt.Unchecked if profile.dont_run_on_metered_networks else QtCore.Qt.Checked
+        )
+        self.allowNewNetworksCheckBox.setChecked(
+            QtCore.Qt.Checked if profile.allow_new_networks else QtCore.Qt.Unchecked
+        )
+        self.networkDisallowedNotificationCheckBox.setChecked(
+            QtCore.Qt.Checked if profile.show_notification_when_network_disallowed else QtCore.Qt.Unchecked
         )
 
         self.preBackupCmdLineEdit.setText(profile.pre_backup_cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,8 @@ def init_db(qapp, qtbot, tmpdir_factory):
 
     default_profile.repo = new_repo.id
     default_profile.dont_run_on_metered_networks = False
+    default_profile.allow_new_networks = False
+    default_profile.show_notification_when_network_disallowed = True
     default_profile.validation_on = False
     default_profile.save()
 

--- a/tests/profile_exports/valid.json
+++ b/tests/profile_exports/valid.json
@@ -36,6 +36,8 @@
     "password": "Tr0ub4dor&3",
     "post_backup_cmd": "",
     "dont_run_on_metered_networks": true,
+    "allow_new_networks": false,
+    "show_notification_when_network_disallowed": true,
     "SourceFileModel": [
         {
             "dir": "/this/is/a/test/file",


### PR DESCRIPTION
Adds 2 columns to the profile model:
1. shows the "This wifi is not allowed" notification only when it is checked. Shows the notif by default.
2. adds new networks to allowed networks only when checked. Does not add by default.

### Related Issue
#1655 

### Motivation and Context
#1654 

### How Has This Been Tested?
Manually tested.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
