### PR TITLE
feat: quick mount

### DIFF
--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -124,6 +124,9 @@
              <property name="toolButtonStyle">
               <enum>Qt::ToolButtonTextBesideIcon</enum>
              </property>
+             <property name="popupMode">
+              <enum>QToolButton::InstantPopup</enum>
+             </property>
             </widget>
            </item>
           </layout>


### PR DESCRIPTION

### Description
Adds a Quick Mount feature to vorta so a user can browse their backups quickly. Improves UX as it will no longer be required to create a folder separately, open it in vorta, and then mount.

### Related Issue
#1435 

### Motivation and Context
UX Improvement and an old feature request.

### How Has This Been Tested?
Tested with repos for now. The old functionality is "Mount to Folder" and the new one is "Quick Mount". This option opens the created folder and deletes it when the user unmounts the repository.

### Screenshots (if appropriate):
![Quick Mount](https://user-images.githubusercontent.com/41837037/226204862-3148219d-f5e3-4c58-8920-339ad921b9d9.gif)

### What's Left:
- [ ] Quick mount for archives
- [ ] Updating/Adding Tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
