### PR TITLE
Added --content-only flag for borg 1.2.4 in diff view

### DIFF
--- a/src/vorta/borg/_compatibility.py
+++ b/src/vorta/borg/_compatibility.py
@@ -5,6 +5,7 @@ MIN_BORG_FOR_FEATURE = {
     'ZSTD': parse_version('1.1.4'),
     'JSON_LOG': parse_version('1.1.0'),
     'DIFF_JSON_LINES': parse_version('1.1.16'),
+    'DIFF_CONTENT_ONLY': parse_version('1.2.4'),
     'COMPACT_SUBCOMMAND': parse_version('1.2.0a1'),
     'V122': parse_version('1.2.2'),
     'V2': parse_version('2.0.0b1'),

--- a/src/vorta/borg/diff.py
+++ b/src/vorta/borg/diff.py
@@ -28,6 +28,9 @@ class BorgDiffJob(BorgJob):
             ret['cmd'].append('--json-lines')
             ret['json_lines'] = True
 
+        if borg_compat.check('DIFF_CONTENT_ONLY'):
+            ret['cmd'].append('--content-only')
+
         if borg_compat.check('V2'):
             ret['cmd'].extend(['-r', profile.repo.url, archive_name_1, archive_name_2])
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
[Borg 1.2.3 -> 1.2.4](https://github.com/borgbackup/borg/compare/1.2.3...1.2.4) introduced [--content-only](https://github.com/borgbackup/borg/pull/7414) which crashes vorta on diff action when files have metadata changed. This PR adds `--content-only` flag to diff command for this borg version.

### Related Issue
Fixes #1668

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
