### PR TITLE
Handle ctime and mtime diff changes

### DIFF
--- a/src/vorta/borg/_compatibility.py
+++ b/src/vorta/borg/_compatibility.py
@@ -5,7 +5,6 @@ MIN_BORG_FOR_FEATURE = {
     'ZSTD': parse_version('1.1.4'),
     'JSON_LOG': parse_version('1.1.0'),
     'DIFF_JSON_LINES': parse_version('1.1.16'),
-    'DIFF_CONTENT_ONLY': parse_version('1.2.4'),
     'COMPACT_SUBCOMMAND': parse_version('1.2.0a1'),
     'V122': parse_version('1.2.2'),
     'V2': parse_version('2.0.0b1'),

--- a/src/vorta/borg/diff.py
+++ b/src/vorta/borg/diff.py
@@ -28,9 +28,6 @@ class BorgDiffJob(BorgJob):
             ret['cmd'].append('--json-lines')
             ret['json_lines'] = True
 
-        if borg_compat.check('DIFF_CONTENT_ONLY'):
-            ret['cmd'].append('--content-only')
-
         if borg_compat.check('V2'):
             ret['cmd'].extend(['-r', profile.repo.url, archive_name_1, archive_name_2])
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implements *ctime* and *mtime* diff types added in borg 1.2.4.
Resolves #1672

### Description
<!--- Describe your changes in detail -->
Added handling for *ctime* and *mtime* diff and will show changes in tooltip in archive diff window.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/borgbase/vorta/issues/1672

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevents crash on borg >= 1.2.4

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on borg 1.2.4 and added tests for handling *ctime* and *mtime*.

### Screenshots (if appropriate):
![Screenshot 2023-04-01 at 21 16 47](https://user-images.githubusercontent.com/10375269/229310072-7bd47fcd-4275-4088-86d7-e7493513e587.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
