### PR TITLE
Remove paramiko from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ python_requires = >=3.7
 install_requires =
   platformdirs >=3.0.0, <4.0.0; sys_platform == 'darwin'  # for macOS: breaking changes in 3.0.0,
   platformdirs >=2.6.0, <4.0.0; sys_platform != 'darwin'  # for others: 2.6+ works consistently.
-  paramiko
   pyqt5
   peewee
   psutil


### PR DESCRIPTION
Seems like we forgot to remove this.

@m3nu after you merged this, could you please create another point release?