### PR TITLE
Make {hostname} name template consistent with Borg, add {fqdn} template option

### DIFF
--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -618,7 +618,7 @@
             <item row="0" column="1">
              <widget class="QLineEdit" name="prunePrefixTemplate">
               <property name="toolTip">
-               <string>Available variables: hostname, profile_id, profile_slug, now, utc_now, user</string>
+               <string>Available variables: hostname, fqdn, profile_id, profile_slug, now, utc_now, user</string>
               </property>
               <property name="placeholderText">
                <string>{hostname}-{profile_slug}-</string>
@@ -675,7 +675,7 @@
             <item row="0" column="1">
              <widget class="QLineEdit" name="archiveNameTemplate">
               <property name="toolTip">
-               <string>Available variables: hostname, profile_id, profile_slug, now, utc_now, user</string>
+               <string>Available variables: hostname, fqdn, profile_id, profile_slug, now, utc_now, user</string>
               </property>
               <property name="placeholderText">
                <string>{hostname}-{profile_slug}-{now:%Y-%m-%d-%H%M%S}</string>

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -4,8 +4,8 @@ import fnmatch
 import getpass
 import math
 import os
-import platform
 import re
+import socket
 import sys
 import unicodedata
 from datetime import datetime as dt
@@ -376,12 +376,36 @@ def uses_dark_mode():
     return palette.windowText().color().lightness() > palette.window().color().lightness()
 
 
+# patched socket.getfqdn() - see https://bugs.python.org/issue5004
+# Reused with permission from https://github.com/borgbackup/borg/blob/master/src/borg/platform/base.py (BSD-3-Clause)
+def _getfqdn(name=""):
+    """Get fully qualified domain name from name.
+    An empty argument is interpreted as meaning the local host.
+    """
+    name = name.strip()
+    if not name or name == "0.0.0.0":
+        name = socket.gethostname()
+    try:
+        addrs = socket.getaddrinfo(name, None, 0, socket.SOCK_DGRAM, 0, socket.AI_CANONNAME)
+    except OSError:
+        pass
+    else:
+        for addr in addrs:
+            if addr[3]:
+                name = addr[3]
+                break
+    return name
+
+
 def format_archive_name(profile, archive_name_tpl):
     """
     Generate an archive name. Default set in models.BackupProfileModel
     """
+    hostname = socket.gethostname()
+    hostname = hostname.split(".")[0]
     available_vars = {
-        'hostname': platform.node(),
+        'hostname': hostname,
+        'fqdn': _getfqdn(hostname),
         'profile_id': profile.id,
         'profile_slug': profile.slug(),
         'now': dt.now(),


### PR DESCRIPTION
### Description
Before, using `{hostname}` as archive or prune name template may include the network domain, like `.local` or `.fritzbox`. This can interfere with pruning and generate different archive names.

With this PR, only the short hostname will be used and `fqdn` is added as option.

### Related Issue
Fixes #1696 
