### PR TITLE
Fix pyobjc imports, bump minimum Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
-      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 # v4.3.1
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install Vorta
       run: |
         pip install .
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 # v4.3.1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 package_dir =
     =src
 include_package_data = true
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
   platformdirs >=3.0.0, <4.0.0; sys_platform == 'darwin'  # for macOS: breaking changes in 3.0.0,
   platformdirs >=2.6.0, <4.0.0; sys_platform != 'darwin'  # for others: 2.6+ works consistently.

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,9 @@ install_requires =
   psutil
   setuptools
   secretstorage; sys_platform != 'darwin'
-  pyobjc-core < 9.1; sys_platform == 'darwin'
-  pyobjc-framework-Cocoa < 9.1; sys_platform == 'darwin'
-  pyobjc-framework-LaunchServices < 9.1; sys_platform == 'darwin'
+  pyobjc-core < 10; sys_platform == 'darwin'
+  pyobjc-framework-Cocoa < 10; sys_platform == 'darwin'
+  pyobjc-framework-LaunchServices < 10; sys_platform == 'darwin'
 tests_require =
   pytest
   pytest-qt

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -1,4 +1,21 @@
 import sys
+try:
+    from Cocoa import NSURL, NSBundle
+    from CoreFoundation import kCFAllocatorDefault
+    from Foundation import NSDictionary
+    from LaunchServices import (
+        LSSharedFileListCopySnapshot,
+        LSSharedFileListCreate,
+        LSSharedFileListInsertItemURL,
+        LSSharedFileListItemRemove,
+        LSSharedFileListItemResolve,
+        kLSSharedFileListItemHidden,
+        kLSSharedFileListItemLast,
+        kLSSharedFileListNoUserInteraction,
+        kLSSharedFileListSessionLoginItems,
+    )
+except ImportError:
+    pass
 
 AUTOSTART_DELAY = """StartupNotify=false
 X-GNOME-Autostart-enabled=true
@@ -11,23 +28,6 @@ def open_app_at_startup(enabled=True):
     while on Linux it adds a .desktop file at ~/.config/autostart
     """
     if sys.platform == 'darwin':
-        from Cocoa import NSURL, NSBundle
-        from CoreFoundation import kCFAllocatorDefault
-        from Foundation import NSDictionary
-
-        # CF = CDLL(find_library('CoreFoundation'))
-        from LaunchServices import (
-            LSSharedFileListCopySnapshot,
-            LSSharedFileListCreate,
-            LSSharedFileListInsertItemURL,
-            LSSharedFileListItemRemove,
-            LSSharedFileListItemResolve,
-            kLSSharedFileListItemHidden,
-            kLSSharedFileListItemLast,
-            kLSSharedFileListNoUserInteraction,
-            kLSSharedFileListSessionLoginItems,
-        )
-
         app_path = NSBundle.mainBundle().bundlePath()
         url = NSURL.alloc().initFileURLWithPath_(app_path)
         login_items = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, None)

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -1,4 +1,5 @@
 import sys
+
 try:
     from Cocoa import NSURL, NSBundle
     from CoreFoundation import kCFAllocatorDefault
@@ -14,6 +15,8 @@ try:
         kLSSharedFileListNoUserInteraction,
         kLSSharedFileListSessionLoginItems,
     )
+
+    APP_PATH = NSBundle.mainBundle().bundlePath()
 except ImportError:
     pass
 
@@ -28,8 +31,8 @@ def open_app_at_startup(enabled=True):
     while on Linux it adds a .desktop file at ~/.config/autostart
     """
     if sys.platform == 'darwin':
-        app_path = NSBundle.mainBundle().bundlePath()
-        url = NSURL.alloc().initFileURLWithPath_(app_path)
+
+        url = NSURL.alloc().initFileURLWithPath_(APP_PATH)
         login_items = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, None)
         props = NSDictionary.dictionaryWithObject_forKey_(True, kLSSharedFileListItemHidden)
 

--- a/src/vorta/keyring/darwin.py
+++ b/src/vorta/keyring/darwin.py
@@ -9,6 +9,9 @@ Adapted from https://gist.github.com/apettinen/5dc7bf1f6a07d148b2075725db6b1950
 """
 import logging
 import sys
+from ctypes import c_char
+import objc
+from Foundation import NSBundle
 from .abc import VortaKeyring
 
 logger = logging.getLogger(__name__)
@@ -23,8 +26,6 @@ class VortaDarwinKeyring(VortaKeyring):
         """
         Lazy import to avoid conflict with pytest-xdist.
         """
-        import objc
-        from Foundation import NSBundle
 
         Security = NSBundle.bundleWithIdentifier_('com.apple.security')
 
@@ -121,7 +122,5 @@ class VortaDarwinKeyring(VortaKeyring):
 
 
 def _resolve_password(password_length, password_buffer):
-    from ctypes import c_char
-
     s = (c_char * password_length).from_address(password_buffer.__pointer__)[:]
     return s.decode()

--- a/src/vorta/notifications.py
+++ b/src/vorta/notifications.py
@@ -3,6 +3,11 @@ import sys
 from PyQt6 import QtCore, QtDBus
 from vorta.store.models import SettingsModel
 
+try:
+    from Foundation import NSUserNotification, NSUserNotificationCenter
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,8 +54,6 @@ class DarwinNotifications(VortaNotifications):
     def deliver(self, title, text, level='info'):
         if self.notifications_suppressed(level):
             return
-
-        from Foundation import NSUserNotification, NSUserNotificationCenter
 
         notification = NSUserNotification.alloc().init()
         notification.setTitle_(title)


### PR DESCRIPTION
### Description
Moved pyobjc imports to modul level, since lazy imports would cause a segfault starting with version 9.1
Also set minimum Python version to 3.8 and removed pinning of GH Action's Python action.

### Related Issue
Fixes #1695 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
