### PR TITLE
Run pre-commit in lint ci and polish ci setup.

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,55 @@
+name: Setup
+description: Sets up python and pre-commit
+
+# note:
+# this is a local composite action
+# documentation: https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
+# code example: https://github.com/GuillaumeFalourd/poc-github-actions/blob/main/.github/actions/local-action/action.yaml
+
+inputs:
+  pre-commit:
+    description: Whether pre-commit shall be setup, too
+    required: false
+    default: "" # == false
+  python-version:
+    description: The python version to install
+    required: true
+    default: "3.10"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Get pip cache dir
+      shell: bash
+      id: pip-cache
+      run: |
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+    - name: pip cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg', 'requirements.d/**') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install Vorta
+      shell: bash
+      run: |
+        pip install -e .
+        pip install -r requirements.d/dev.txt
+
+    - name: Hash python version
+      if: ${{ inputs.setup-pre-commit }}
+      shell: bash
+      run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+    - name: Caching for Pre-Commit
+      if: ${{ inputs.setup-pre-commit }}
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         env:
           OS: ${{ runner.os }}
           python: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       debug_enabled:
         type: boolean
-        description: 'Run the build with tmate debugging enabled'
+        description: "Run the build with tmate debugging enabled"
         required: false
         default: false
 
@@ -15,20 +15,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.11
-    - name: Install Vorta
-      run: |
-        pip install .
-        pip install -r requirements.d/dev.txt
-    - name: Test formatting with Flake8, ruff and Black
-      run: make lint
-    # - name: Run PyLint (info only)
-    #   run: pylint --rcfile=setup.cfg src --exit-zero
-
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install Vorta
+        run: |
+          pip install .
+          pip install -r requirements.d/dev.txt
+      - name: Test formatting with Flake8, ruff and Black
+        run: make lint
 
   test:
     timeout-minutes: 20
@@ -37,63 +34,63 @@ jobs:
       fail-fast: false
 
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-    - name: pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg', 'requirements.d/**') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg', 'requirements.d/**') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-    - name: Install system dependencies (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt update && sudo apt install -y \
-          xvfb libssl-dev openssl libacl1-dev libacl1 build-essential borgbackup \
-          libxkbcommon-x11-0 dbus-x11 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
-          libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 \
-          libegl1 libxcb-cursor0
-    - name: Install system dependencies (macOS)
-      if: runner.os == 'macOS'
-      run: |
-        brew install openssl readline xz borgbackup
-    - name: Install Vorta
-      run: |
-        pip install -e .
-        pip install -r requirements.d/dev.txt
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update && sudo apt install -y \
+            xvfb libssl-dev openssl libacl1-dev libacl1 build-essential borgbackup \
+            libxkbcommon-x11-0 dbus-x11 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+            libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 \
+            libegl1 libxcb-cursor0
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install openssl readline xz borgbackup
+      - name: Install Vorta
+        run: |
+          pip install -e .
+          pip install -r requirements.d/dev.txt
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
-    - name: Test with pytest (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        xvfb-run --server-args="-screen 0 1024x768x24+32" \
-                 -a dbus-run-session -- make test
-    - name: Test with pytest (macOS)
-      if: runner.os == 'macOS'
-      run: make test
+      - name: Test with pytest (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          xvfb-run --server-args="-screen 0 1024x768x24+32" \
+                   -a dbus-run-session -- make test
+      - name: Test with pytest (macOS)
+        if: runner.os == 'macOS'
+        run: make test
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      env:
-        OS: ${{ runner.os }}
-        python: ${{ matrix.python-version }}
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        env_vars: OS, python
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        env:
+          OS: ${{ runner.os }}
+          python: ${{ matrix.python-version }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS, python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+      - name: Setup python, vorta and dev deps
+        uses: ./.github/actions/setup
         with:
           python-version: 3.11
-      - name: Install Vorta
-        run: |
-          pip install .
-          pip install -r requirements.d/dev.txt
+          pre-commit: true
+
       - name: Test formatting with Flake8, ruff and Black
+        shell: bash
         run: make lint
 
   test:
@@ -39,22 +38,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg', 'requirements.d/**') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
@@ -68,10 +51,11 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install openssl readline xz borgbackup
-      - name: Install Vorta
-        run: |
-          pip install -e .
-          pip install -r requirements.d/dev.txt
+
+      - name: Setup python, vorta and dev deps
+        uses: ./.github/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export VORTA_SRC := src/vorta
 export APPSTREAM_METADATA := src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
 VERSION := $(shell python -c "from src.vorta._version import __version__; print(__version__)")
 
-.PHONY : help
+.PHONY : help clean lint test
 .DEFAULT_GOAL := help
 
 clean:
@@ -57,9 +57,7 @@ flatpak-install: translations-to-qm
 	install -D src/vorta/assets/metadata/com.borgbase.Vorta.desktop ${FLATPAK_DEST}/share/applications/com.borgbase.Vorta.desktop
 
 lint:
-	flake8
-	black --check .
-	ruff check .
+	pre-commit run --all-files --show-diff-on-failure
 
 test:
 	pytest --cov=vorta


### PR DESCRIPTION
Fixes #1709 

##### Fix phonies in Makefile and run pre-commit for lint target.

Instead of running black, flake8 and ruff the lint phony now runs pre-commit which has these tools configured as hooks.

* Makefile

##### Define common composite action for setting up pre-commit and python.

* .github/actions/setup/action.yml

* .github/workflows/test.yml

##### Update codecov/codecov-action used in test ci.

Updated to v3

* .github/workflows/test.yml