### PR TITLE
Add profile name to error notification.

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -34,7 +34,6 @@ class ScheduleStatus(NamedTuple):
 
 
 class VortaScheduler(QtCore.QObject):
-
     #: The schedule for the profile with the given id changed.
     schedule_changed = QtCore.pyqtSignal(int)
 
@@ -198,7 +197,6 @@ class VortaScheduler(QtCore.QObject):
             return
 
         with self.lock:  # Acquire lock
-
             self.remove_job(profile_id)  # reset schedule
 
             pause = self.pauses.get(profile_id)
@@ -292,7 +290,6 @@ class VortaScheduler(QtCore.QObject):
 
             # handle missing of a scheduled time
             if next_time <= dt.now():
-
                 if profile.schedule_make_up_missed:
                     self.lock.release()
                     try:
@@ -446,7 +443,7 @@ class VortaScheduler(QtCore.QObject):
         else:
             notifier.deliver(
                 self.tr('Vorta Backup'),
-                self.tr('Error during backup creation.'),
+                self.tr('Error during backup creation for %s.') % profile_name,
                 level='error',
             )
             logger.error('Error during backup creation.')


### PR DESCRIPTION
In a similar fashion like #1637 the commit adds the profile name to the error notification.

Remake of #1703.

* src/vorta/scheduler.py

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
