### PR TITLE
fix repository compression size

### DIFF
--- a/src/vorta/assets/UI/repotab.ui
+++ b/src/vorta/assets/UI/repotab.ui
@@ -421,7 +421,7 @@
           </widget>
          </item>
          <item row="4" column="0">
-          <widget class="QLabel" name="label_12">
+          <widget class="QLabel" name="sizeCompressedLabel">
            <property name="text">
             <string>Compressed Size:</string>
            </property>

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -36,7 +36,11 @@ class BorgCreateJob(BorgJob):
                 stats = result['data']['cache']['stats']
                 repo = RepoModel.get(id=result['params']['repo_id'])
                 repo.total_size = stats['total_size']
-                # repo.unique_csize = stats['unique_csize']
+
+                # Compressed Repository size only supported in borg v1.
+                if not borg_compat.check('V2'):
+                    repo.unique_csize = stats['unique_csize']
+
                 repo.unique_size = stats['unique_size']
                 repo.total_unique_chunks = stats['total_unique_chunks']
                 repo.save()

--- a/src/vorta/borg/info_archive.py
+++ b/src/vorta/borg/info_archive.py
@@ -52,6 +52,11 @@ class BorgInfoArchiveJob(BorgJob):
                 stats = result['data']['cache']['stats']
                 repo = RepoModel.get(id=result['params']['repo_id'])
                 repo.total_size = stats['total_size']
+
+                # Compressed Repository size only supported in borg v1.
+                if not borg_compat.check('V2'):
+                    repo.unique_csize = stats['unique_csize']
+
                 repo.unique_size = stats['unique_size']
                 repo.total_unique_chunks = stats['total_unique_chunks']
                 repo.save()

--- a/src/vorta/borg/info_repo.py
+++ b/src/vorta/borg/info_repo.py
@@ -61,6 +61,11 @@ class BorgInfoRepoJob(BorgJob):
             if 'cache' in result['data']:
                 stats = result['data']['cache']['stats']
                 new_repo.total_size = stats['total_size']
+
+                # Compressed Repository size only supported in borg v1.
+                if not borg_compat.check('V2'):
+                    new_repo.unique_csize = stats['unique_csize']
+
                 new_repo.unique_size = stats['unique_size']
                 new_repo.total_unique_chunks = stats['total_unique_chunks']
             if 'encryption' in result['data']:

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -67,7 +67,12 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         # Connect to palette change
         QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
 
-        self.populate_from_profile()  # needs init of ssh and compression items
+        self.populate_from_profile()  # needs init of ssh and compression
+
+        # Compressed Repository size only supported in borg v1.
+        if borg_compat.check('V2'):
+            self.sizeCompressed.hide()
+            self.sizeCompressedLabel.hide()
 
     def set_icons(self):
         self.bAddSSHKey.setIcon(get_colored_icon("plus"))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
`unique_csize` field was removed in commit https://github.com/borgbase/vorta/commit/f9d12603164bc663263a86abd17502198059a006 as the field was dropped in Borg V2.

This PR adds a check to only display the field in Borg V1.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1750

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the Compressed Size field displays N/A for new repos and a stale size for old repos which is never updated.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Compression size updated again on Borg V1.
- Field hidden on Borg V2.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
