### PR TITLE
fix(makefile): Correct homebrew path on modern macOS machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,19 @@ VERSION := $(shell python -c "from src.vorta._version import __version__; print(
 .PHONY : help clean lint test
 .DEFAULT_GOAL := help
 
+# Set Homebrew location to /opt/homebrew on Apple Silicon, /usr/local on Intel
+ifeq ($(shell uname -m),arm64)
+	export HOMEBREW = /opt/homebrew
+else
+	export HOMEBREW = /usr/local
+endif
+
 clean:
 	rm -rf dist/*
 
 dist/Vorta.app:  ## Build macOS app locally (without Borg)
 	pyinstaller --clean --noconfirm package/vorta.spec
-	cp -R /usr/local/Caskroom/sparkle/*/Sparkle.framework dist/Vorta.app/Contents/Frameworks/
+	cp -R ${HOMEBREW}/Caskroom/sparkle/*/Sparkle.framework dist/Vorta.app/Contents/Frameworks/
 	rm -rf build/vorta dist/vorta
 
 dist/Vorta.dmg: dist/Vorta.app  ## Create notarized macOS DMG for distribution.


### PR DESCRIPTION
Fix the location of the Sparkle Caskroom location on macOS.

### Description

Homebrew's Caskroom moved from /usr/local to /opt/homebrew with the release of Apple Silicon, /usr/local is now only used for older Intel based machines.

This Makefile change detects if the machine is ARM based and if so sets the correct homebrew location.

This allows Vorta to build locally where previously it would error out.

### Related Issue

- #727 

### Motivation and Context

Otherwise you can't build Vorta on modern macOS machines.

### How Has This Been Tested?

I've run it on two machines, both worked as expected.

### Screenshots (if appropriate):

N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [-] My change requires a change to the documentation.
- [-] I have updated the documentation accordingly.
- [-] I have added tests to cover my changes.
- [-] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
