### PR TITLE
PR: `tests/unit/test_archives`: reduce code duplication and increase test coverage

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,7 @@ from vorta.store.models import (
     WifiSettingModel,
 )
 from vorta.utils import borg_compat
-from vorta.views.main_window import MainWindow
+from vorta.views.main_window import ArchiveTab, MainWindow
 
 models = [
     RepoModel,
@@ -204,6 +204,19 @@ def choose_file_dialog(tmpdir):
 @pytest.fixture
 def rootdir():
     return os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture()
+def archive_env(qapp, qtbot):
+    """
+    Common setup for integration tests involving the archive tab.
+    """
+    main: MainWindow = qapp.main_window
+    tab: ArchiveTab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+    tab.refresh_archive_list()
+    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    return main, tab
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -18,11 +18,9 @@ def test_repo_list(qapp, qtbot):
     """Test that the archives are created and repo list is populated correctly"""
     main = qapp.main_window
     tab = main.archiveTab
-
     main.tabWidget.setCurrentIndex(3)
     tab.refresh_archive_list()
     qtbot.waitUntil(lambda: not tab.bCheck.isEnabled(), **pytest._wait_defaults)
-
     assert not tab.bCheck.isEnabled()
 
     qtbot.waitUntil(lambda: 'Refreshing archives done.' in main.progressText.text(), **pytest._wait_defaults)
@@ -31,30 +29,18 @@ def test_repo_list(qapp, qtbot):
     assert tab.bCheck.isEnabled()
 
 
-def test_repo_prune(qapp, qtbot):
+def test_repo_prune(qapp, qtbot, archive_env):
     """Test for archive pruning"""
-    main = qapp.main_window
-    tab = main.archiveTab
-
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
-
+    main, tab = archive_env
     qtbot.mouseClick(tab.bPrune, QtCore.Qt.MouseButton.LeftButton)
     qtbot.waitUntil(lambda: 'Pruning old archives' in main.progressText.text(), **pytest._wait_defaults)
     qtbot.waitUntil(lambda: 'Refreshing archives done.' in main.progressText.text(), **pytest._wait_defaults)
 
 
 @pytest.mark.min_borg_version('1.2.0a1')
-def test_repo_compact(qapp, qtbot):
+def test_repo_compact(qapp, qtbot, archive_env):
     """Test for archive compaction"""
-    main = qapp.main_window
-    tab = main.archiveTab
-
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
-
+    main, tab = archive_env
     qtbot.waitUntil(lambda: tab.compactButton.isEnabled(), **pytest._wait_defaults)
     assert tab.compactButton.isEnabled()
 
@@ -62,14 +48,9 @@ def test_repo_compact(qapp, qtbot):
     qtbot.waitUntil(lambda: 'compaction freed about' in main.logText.text().lower(), **pytest._wait_defaults)
 
 
-def test_check(qapp, qtbot):
+def test_check(qapp, qtbot, archive_env):
     """Test for archive consistency check"""
-    main = qapp.main_window
-    tab = main.archiveTab
-
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    main, tab = archive_env
 
     qapp.check_failed_event.disconnect()
 
@@ -81,7 +62,7 @@ def test_check(qapp, qtbot):
 
 
 @pytest.mark.skipif(sys.platform == 'darwin', reason="Macos fuse support is uncertain")
-def test_mount(qapp, qtbot, monkeypatch, choose_file_dialog, tmpdir):
+def test_mount(qapp, qtbot, monkeypatch, choose_file_dialog, tmpdir, archive_env):
     """Test for archive mounting and unmounting"""
 
     def psutil_disk_partitions(**kwargs):
@@ -91,12 +72,7 @@ def test_mount(qapp, qtbot, monkeypatch, choose_file_dialog, tmpdir):
     monkeypatch.setattr(psutil, "disk_partitions", psutil_disk_partitions)
     monkeypatch.setattr(vorta.views.archive_tab, "choose_file_dialog", choose_file_dialog)
 
-    main = qapp.main_window
-    tab = main.archiveTab
-
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    main, tab = archive_env
     tab.archiveTable.selectRow(0)
 
     qtbot.waitUntil(lambda: tab.bMountRepo.isEnabled(), **pytest._wait_defaults)
@@ -114,14 +90,9 @@ def test_mount(qapp, qtbot, monkeypatch, choose_file_dialog, tmpdir):
     qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), **pytest._wait_defaults)
 
 
-def test_archive_extract(qapp, qtbot, monkeypatch, choose_file_dialog, tmpdir):
+def test_archive_extract(qapp, qtbot, monkeypatch, choose_file_dialog, tmpdir, archive_env):
     """Test for archive extraction"""
-    main = qapp.main_window
-    tab = main.archiveTab
-
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    main, tab = archive_env
 
     tab.archiveTable.selectRow(2)
     tab.extract_action()
@@ -139,14 +110,9 @@ def test_archive_extract(qapp, qtbot, monkeypatch, choose_file_dialog, tmpdir):
     assert [item.basename for item in tmpdir.listdir()] == ['private' if sys.platform == 'darwin' else 'tmp']
 
 
-def test_archive_delete(qapp, qtbot, mocker):
+def test_archive_delete(qapp, qtbot, mocker, archive_env):
     """Test for archive deletion"""
-    main = qapp.main_window
-    tab = main.archiveTab
-
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    main, tab = archive_env
 
     archivesCount = tab.archiveTable.rowCount()
 
@@ -160,14 +126,9 @@ def test_archive_delete(qapp, qtbot, mocker):
     assert tab.archiveTable.rowCount() == archivesCount - 1
 
 
-def test_archive_rename(qapp, qtbot, mocker):
+def test_archive_rename(qapp, qtbot, mocker, archive_env):
     """Test for archive renaming"""
-    main = qapp.main_window
-    tab = main.archiveTab
-
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    main, tab = archive_env
 
     tab.archiveTable.selectRow(0)
     new_archive_name = 'idf89d8f9d8fd98'

--- a/tests/integration/test_borg.py
+++ b/tests/integration/test_borg.py
@@ -24,7 +24,6 @@ def test_borg_prune(qapp, qtbot):
     assert blocker.args[0]['returncode'] == 0
 
 
-# test borg info
 def test_borg_repo_info(qapp, qtbot, tmpdir):
     """This test runs borg info on a test repo directly without UI"""
     repo_info = {
@@ -45,14 +44,8 @@ def test_borg_repo_info(qapp, qtbot, tmpdir):
     assert blocker.args[0]['returncode'] == 0
 
 
-def test_borg_archive_info(qapp, qtbot, tmpdir):
+def test_borg_archive_info(qapp, qtbot, archive_env):
     """Check that archive info command works"""
-    main = qapp.main_window
-    tab = main.archiveTab
-    main.tabWidget.setCurrentIndex(3)
-    tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
-
     params = BorgInfoArchiveJob.prepare(vorta.store.models.BackupProfileModel.select().first(), "test-archive1")
     thread = BorgInfoArchiveJob(params['cmd'], params, qapp)
 

--- a/tests/integration/test_repo.py
+++ b/tests/integration/test_repo.py
@@ -7,11 +7,9 @@ from PyQt6 import QtCore
 from vorta.store.models import ArchiveModel, EventLogModel
 
 
-def test_create(qapp, qtbot):
+def test_create(qapp, qtbot, archive_env):
     """Test for manual archive creation"""
-    main = qapp.main_window
-    main.archiveTab.refresh_archive_list()
-    qtbot.waitUntil(lambda: main.archiveTab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    main, tab = archive_env
 
     qtbot.mouseClick(main.createStartBtn, QtCore.Qt.MouseButton.LeftButton)
     qtbot.waitUntil(lambda: 'Backup finished.' in main.progressText.text(), **pytest._wait_defaults)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,7 +17,7 @@ from vorta.store.models import (
     SourceFileModel,
     WifiSettingModel,
 )
-from vorta.views.main_window import MainWindow
+from vorta.views.main_window import ArchiveTab, MainWindow
 
 models = [
     RepoModel,
@@ -105,3 +105,16 @@ def borg_json_output():
 @pytest.fixture
 def rootdir():
     return os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture()
+def archive_env(qapp, qtbot):
+    """
+    Common setup for unit tests involving the archive tab.
+    """
+    main: MainWindow = qapp.main_window
+    tab: ArchiveTab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+    tab.populate_from_profile()
+    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2, **pytest._wait_defaults)
+    return main, tab

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -144,25 +144,6 @@ def test_archive_delete(qapp, qtbot, mocker, borg_json_output, archive_env):
     assert tab.archiveTable.rowCount() == 1
 
 
-def test_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_env):
-    main, tab = archive_env
-
-    tab.archiveTable.selectRow(0)
-    new_archive_name = 'idf89d8f9d8fd98'
-    stdout, stderr = borg_json_output('rename')
-    popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
-    mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
-
-    pos = tab.archiveTable.visualRect(tab.archiveTable.model().index(0, 4)).center()
-    qtbot.mouseClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=pos)
-    qtbot.mouseDClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=pos)
-    qtbot.keyClicks(tab.archiveTable.viewport().focusWidget(), new_archive_name)
-    qtbot.keyClick(tab.archiveTable.viewport().focusWidget(), QtCore.Qt.Key.Key_Return)
-    
-    # Successful rename case
-    qtbot.waitUntil(lambda: tab.archiveTable.model().index(0, 4).data() == new_archive_name, **pytest._wait_defaults)
-
-
 def test_archive_copy(qapp, qtbot, monkeypatch, mocker, archive_env):
     main, tab = archive_env
 
@@ -196,3 +177,22 @@ def test_refresh_archive_info(qapp, qtbot, mocker, borg_json_output, archive_env
         qtbot.mouseClick(tab.bRefreshArchive, QtCore.Qt.MouseButton.LeftButton)
 
     qtbot.waitUntil(lambda: tab.mountErrors.text() == 'Refreshed archives.', **pytest._wait_defaults)
+
+
+def test_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_env):
+    main, tab = archive_env
+
+    tab.archiveTable.selectRow(0)
+    new_archive_name = 'idf89d8f9d8fd98'
+    stdout, stderr = borg_json_output('rename')
+    popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
+    mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
+
+    pos = tab.archiveTable.visualRect(tab.archiveTable.model().index(0, 4)).center()
+    qtbot.mouseClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=pos)
+    qtbot.mouseDClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=pos)
+    qtbot.keyClicks(tab.archiveTable.viewport().focusWidget(), new_archive_name)
+    qtbot.keyClick(tab.archiveTable.viewport().focusWidget(), QtCore.Qt.Key.Key_Return)
+
+    # Successful rename case
+    qtbot.waitUntil(lambda: tab.archiveTable.model().index(0, 4).data() == new_archive_name, **pytest._wait_defaults)

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -221,7 +221,7 @@ def test_double_click(qapp, qtbot, borg_json_output, setup_archiver_tab):
     assert item is not None
     cell_pos = tab.archiveTable.visualItemRect(item).center()
 
-    # Through testing I found one must click the cell first, then double click to trigger emit
+    # single click to select cell, then double click to trigger emit
     with qtbot.waitSignal(tab.archiveTable.cellDoubleClicked, timeout=1000):
         qtbot.mouseClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=cell_pos)
         qtbot.mouseDClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=cell_pos)

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -17,21 +17,6 @@ class MockFileDialog:
         return ['/tmp']
 
 
-@pytest.fixture()
-def archive_env(qapp, qtbot):
-    def setup():
-        main = qapp.main_window
-        tab = main.archiveTab
-        main.tabWidget.setCurrentIndex(3)
-
-        tab.populate_from_profile()
-        qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2, timeout=2000)
-
-        return main, tab
-
-    return setup
-
-
 def test_prune_intervals(qapp, qtbot):
     prune_intervals = ['hour', 'day', 'week', 'month', 'year']
     main = qapp.main_window
@@ -46,7 +31,7 @@ def test_prune_intervals(qapp, qtbot):
 
 
 def test_repo_list(qapp, qtbot, mocker, borg_json_output, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
 
     stdout, stderr = borg_json_output('list')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -63,7 +48,7 @@ def test_repo_list(qapp, qtbot, mocker, borg_json_output, archive_env):
 
 
 def test_repo_prune(qapp, qtbot, mocker, borg_json_output, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
 
     stdout, stderr = borg_json_output('prune')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -76,7 +61,7 @@ def test_repo_prune(qapp, qtbot, mocker, borg_json_output, archive_env):
 
 def test_repo_compact(qapp, qtbot, mocker, borg_json_output, archive_env):
     vorta.utils.borg_compat.version = '1.2.0'
-    main, tab = archive_env()
+    main, tab = archive_env
 
     stdout, stderr = borg_json_output('compact')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -91,7 +76,7 @@ def test_repo_compact(qapp, qtbot, mocker, borg_json_output, archive_env):
 
 
 def test_check(qapp, mocker, borg_json_output, qtbot, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
 
     stdout, stderr = borg_json_output('check')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -108,7 +93,7 @@ def test_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choose_file_d
         return [DiskPartitions('borgfs', '/tmp')]
 
     monkeypatch.setattr(psutil, "disk_partitions", psutil_disk_partitions)
-    main, tab = archive_env()
+    main, tab = archive_env
     tab.archiveTable.selectRow(0)
 
     stdout, stderr = borg_json_output('prune')  # TODO: fully mock mount command?
@@ -131,7 +116,7 @@ def test_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choose_file_d
 
 
 def test_archive_extract(qapp, qtbot, mocker, borg_json_output, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
     tab.archiveTable.selectRow(0)
     stdout, stderr = borg_json_output('list_archive')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -146,7 +131,7 @@ def test_archive_extract(qapp, qtbot, mocker, borg_json_output, archive_env):
 
 
 def test_archive_delete(qapp, qtbot, mocker, borg_json_output, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
 
     tab.archiveTable.selectRow(0)
     stdout, stderr = borg_json_output('delete')
@@ -160,7 +145,7 @@ def test_archive_delete(qapp, qtbot, mocker, borg_json_output, archive_env):
 
 
 def test_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
 
     tab.archiveTable.selectRow(0)
     new_archive_name = 'idf89d8f9d8fd98'
@@ -183,7 +168,7 @@ def test_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_env):
 
 
 def test_archive_copy(qapp, qtbot, monkeypatch, mocker, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
 
     # mock the clipboard to ensure no changes are made to it during testing
     mocker.patch.object(qapp.clipboard(), "setMimeData")
@@ -205,7 +190,7 @@ def test_archive_copy(qapp, qtbot, monkeypatch, mocker, archive_env):
 
 
 def test_refresh_archive_info(qapp, qtbot, mocker, borg_json_output, archive_env):
-    main, tab = archive_env()
+    main, tab = archive_env
     tab.archiveTable.selectRow(0)
     stdout, stderr = borg_json_output('info')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -218,9 +203,11 @@ def test_refresh_archive_info(qapp, qtbot, mocker, borg_json_output, archive_env
 
 
 def test_double_click(qapp, qtbot, borg_json_output, archive_env):
-    # Currently this test just ensures the 'cellDoubleClicked' emit works as intended.
-    # functionality will be more useful when the "inline edit for archive renaming" gets merged in
-    main, tab = archive_env()
+    """
+    Currently this test just ensures the 'cellDoubleClicked' emit works as intended.
+    functionality will be more useful when the "inline edit for archive renaming" gets merged in
+    """
+    main, tab = archive_env
     # (0, 4) is the cell which contains the archive name
     item = tab.archiveTable.item(0, 4)
     assert item is not None

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -18,13 +18,8 @@ from vorta.views.diff_result import (
 @pytest.mark.parametrize(
     'json_mock_file,folder_root', [('diff_archives', 'test'), ('diff_archives_dict_issue', 'Users')]
 )
-def test_archive_diff(qapp, qtbot, mocker, borg_json_output, json_mock_file, folder_root):
-    main = qapp.main_window
-    tab = main.archiveTab
-    main.tabWidget.setCurrentIndex(3)
-
-    tab.populate_from_profile()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2)
+def test_archive_diff(qapp, qtbot, mocker, borg_json_output, json_mock_file, folder_root, archive_env):
+    main, tab = archive_env
 
     stdout, stderr = borg_json_output(json_mock_file)
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)


### PR DESCRIPTION
### Description
It is possible to reduce code duplication in the archive unit tests by using a fixture to handle repeated setup. Additionally, there are a some archive_tab methods that still needed testing. In this PR, I aim to solve both of these issues.

### Related Issue
#1754 

### Motivation and Context
One of my Google Summer of Code projects involves cleaning up the Vorta tests, reducing duplicated code, and increasing code coverage.

### How Has This Been Tested?
Tests work locally by running pytest, and they pass the GitHub CI checks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
