### PR TITLE
PR: `tests/unit/test_diff`: increase test coverage

### DIFF
--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -17,21 +17,6 @@ class MockFileDialog:
         return ['/tmp']
 
 
-@pytest.fixture()
-def setup_archiver_tab(qapp, qtbot):
-    def setup():
-        main = qapp.main_window
-        tab = main.archiveTab
-        main.tabWidget.setCurrentIndex(3)
-
-        tab.populate_from_profile()
-        qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2, **pytest._wait_defaults)
-
-        return main, tab
-
-    return setup
-
-
 def test_prune_intervals(qapp, qtbot):
     prune_intervals = ['hour', 'day', 'week', 'month', 'year']
     main = qapp.main_window
@@ -45,15 +30,18 @@ def test_prune_intervals(qapp, qtbot):
         assert getattr(profile, f'prune_{i}') == 9
 
 
-def test_repo_list(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
+def test_repo_list(qapp, qtbot, mocker, borg_json_output):
+    main = qapp.main_window
+    tab = main.archiveTab
 
     stdout, stderr = borg_json_output('list')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
     mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
 
+    main.tabWidget.setCurrentIndex(3)
     tab.refresh_archive_list()
     qtbot.waitUntil(lambda: not tab.bCheck.isEnabled(), **pytest._wait_defaults)
+
     assert not tab.bCheck.isEnabled()
 
     qtbot.waitUntil(lambda: 'Refreshing archives done.' in main.progressText.text(), **pytest._wait_defaults)
@@ -62,9 +50,11 @@ def test_repo_list(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
     assert tab.bCheck.isEnabled()
 
 
-def test_repo_prune(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
-
+def test_repo_prune(qapp, qtbot, mocker, borg_json_output):
+    main = qapp.main_window
+    tab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+    tab.populate_from_profile()
     stdout, stderr = borg_json_output('prune')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
     mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
@@ -74,10 +64,12 @@ def test_repo_prune(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
     qtbot.waitUntil(lambda: 'Refreshing archives done.' in main.progressText.text(), **pytest._wait_defaults)
 
 
-def test_repo_compact(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
+def test_repo_compact(qapp, qtbot, mocker, borg_json_output):
+    main = qapp.main_window
+    tab = main.archiveTab
     vorta.utils.borg_compat.version = '1.2.0'
-    main, tab = setup_archiver_tab()
-
+    main.tabWidget.setCurrentIndex(3)
+    tab.populate_from_profile()
     stdout, stderr = borg_json_output('compact')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
     mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
@@ -90,8 +82,11 @@ def test_repo_compact(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab)
     vorta.utils.borg_compat.version = '1.1.0'
 
 
-def test_check(qapp, mocker, borg_json_output, qtbot, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
+def test_check(qapp, mocker, borg_json_output, qtbot):
+    main = qapp.main_window
+    tab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+    tab.populate_from_profile()
 
     stdout, stderr = borg_json_output('check')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -102,13 +97,17 @@ def test_check(qapp, mocker, borg_json_output, qtbot, setup_archiver_tab):
     qtbot.waitUntil(lambda: success_text in main.logText.text(), **pytest._wait_defaults)
 
 
-def test_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choose_file_dialog, setup_archiver_tab):
+def test_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choose_file_dialog):
     def psutil_disk_partitions(**kwargs):
         DiskPartitions = namedtuple('DiskPartitions', ['device', 'mountpoint'])
         return [DiskPartitions('borgfs', '/tmp')]
 
     monkeypatch.setattr(psutil, "disk_partitions", psutil_disk_partitions)
-    main, tab = setup_archiver_tab()
+
+    main = qapp.main_window
+    tab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+    tab.populate_from_profile()
     tab.archiveTable.selectRow(0)
 
     stdout, stderr = borg_json_output('prune')  # TODO: fully mock mount command?
@@ -130,8 +129,14 @@ def test_mount(qapp, qtbot, mocker, borg_json_output, monkeypatch, choose_file_d
     qtbot.waitUntil(lambda: tab.mountErrors.text().startswith('Un-mounted successfully.'), **pytest._wait_defaults)
 
 
-def test_archive_extract(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
+def test_archive_extract(qapp, qtbot, mocker, borg_json_output):
+    main = qapp.main_window
+    tab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+
+    tab.populate_from_profile()
+    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2)
+
     tab.archiveTable.selectRow(0)
     stdout, stderr = borg_json_output('list_archive')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -146,8 +151,14 @@ def test_archive_extract(qapp, qtbot, mocker, borg_json_output, setup_archiver_t
     assert 'test-archive, 2000' in tab._window.archiveNameLabel.text()
 
 
-def test_archive_delete(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
+def test_archive_delete(qapp, qtbot, mocker, borg_json_output):
+    main = qapp.main_window
+    tab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+
+    tab.populate_from_profile()
+    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2)
+
     tab.archiveTable.selectRow(0)
     stdout, stderr = borg_json_output('delete')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
@@ -159,8 +170,14 @@ def test_archive_delete(qapp, qtbot, mocker, borg_json_output, setup_archiver_ta
     assert tab.archiveTable.rowCount() == 1
 
 
-def test_archive_rename(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
+def test_archive_rename(qapp, qtbot, mocker, borg_json_output):
+    main = qapp.main_window
+    tab = main.archiveTab
+    main.tabWidget.setCurrentIndex(3)
+
+    tab.populate_from_profile()
+    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2)
+
     tab.archiveTable.selectRow(0)
     new_archive_name = 'idf89d8f9d8fd98'
     stdout, stderr = borg_json_output('rename')
@@ -179,49 +196,3 @@ def test_archive_rename(qapp, qtbot, mocker, borg_json_output, setup_archiver_ta
     mocker.patch.object(vorta.views.archive_tab.QInputDialog, 'getText', return_value=(new_archive_name, True))
     tab.rename_action()
     qtbot.waitUntil(lambda: tab.mountErrors.text() == exp_text, **pytest._wait_defaults)
-
-
-def test_archive_copy(qapp, qtbot, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
-    # test 'archive_copy()' by passing it an index to copy
-    tab.archiveTable.selectRow(0)
-    index = tab.archiveTable.selectionModel().selectedRows()[0]
-    tab.archive_copy(index)
-    clipboard = qapp.clipboard().mimeData()
-    assert clipboard.hasText()
-    assert clipboard.text() == "test-archive"
-
-    # test 'archive_copy()' without passing it an index
-    tab.archiveTable.selectRow(1)
-    tab.archive_copy()
-    clipboard = qapp.clipboard().mimeData()
-    assert clipboard.hasText()
-    assert clipboard.text() == "test-archive1"
-
-
-def test_refresh_archive_info(qapp, qtbot, mocker, borg_json_output, setup_archiver_tab):
-    main, tab = setup_archiver_tab()
-    tab.archiveTable.selectRow(0)
-    stdout, stderr = borg_json_output('info')
-    popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
-    mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
-
-    with qtbot.waitSignal(tab.bRefreshArchive.clicked, timeout=5000):
-        qtbot.mouseClick(tab.bRefreshArchive, QtCore.Qt.MouseButton.LeftButton)
-
-    qtbot.waitUntil(lambda: tab.mountErrors.text() == 'Refreshed archives.', **pytest._wait_defaults)
-
-
-def test_double_click(qapp, qtbot, borg_json_output, setup_archiver_tab):
-    # Currently this test just ensures the 'cellDoubleClicked' emit works as intended.
-    # functionality will be more useful when the "inline edit for archive renaming" gets merged in
-    main, tab = setup_archiver_tab()
-    # (0, 4) is the cell which contains the archive name
-    item = tab.archiveTable.item(0, 4)
-    assert item is not None
-    cell_pos = tab.archiveTable.visualItemRect(item).center()
-
-    # single click to select cell, then double click to trigger emit
-    with qtbot.waitSignal(tab.archiveTable.cellDoubleClicked, timeout=1000):
-        qtbot.mouseClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=cell_pos)
-        qtbot.mouseDClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=cell_pos)

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -221,7 +221,7 @@ def test_double_click(qapp, qtbot, borg_json_output, setup_archiver_tab):
     assert item is not None
     cell_pos = tab.archiveTable.visualItemRect(item).center()
 
-    # Through testing I found one must click the cell first, then double click to trigger emit
+    # single click to select cell, then double click to trigger emit
     with qtbot.waitSignal(tab.archiveTable.cellDoubleClicked, timeout=1000):
         qtbot.mouseClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=cell_pos)
         qtbot.mouseDClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=cell_pos)


### PR DESCRIPTION
### Description
There are some areas of opportunity in the `diff_result` module for increased test coverage of some class methods and functions. The `test_diff` module is already well parametrized and does not have a notable amount of code duplication, so here I would like to focus mainly on increasing code coverage.

### Related Issue
#1754 

### Motivation and Context
One of my Google Summer of Code projects involves cleaning up the Vorta tests, reducing duplicated code, and increasing code coverage.

### How Has This Been Tested?
Tests work locally by running pytest, and they pass the GitHub CI checks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
