### PR TITLE
PR: `tests/unit/test_repo` - Clean up, parametrize, and increase test coverage.

### DIFF
--- a/src/vorta/views/partials/password_input.py
+++ b/src/vorta/views/partials/password_input.py
@@ -138,7 +138,7 @@ class PasswordInput(QObject):
             self.passwordLineEdit.error_state = True
             self.confirmLineEdit.error_state = True
             self.set_error_label(
-                translate('PasswordInput', "Passwords must be identical and atleast {0} characters long.").format(
+                translate('PasswordInput', "Passwords must be identical and at least {0} characters long.").format(
                     self._minimum_length
                 )
             )
@@ -148,7 +148,7 @@ class PasswordInput(QObject):
         elif not pass_long:
             self.passwordLineEdit.error_state = True
             self.set_error_label(
-                translate('PasswordInput', "Passwords must be atleast {0} characters long.").format(
+                translate('PasswordInput', "Passwords must be at least {0} characters long.").format(
                     self._minimum_length
                 )
             )

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -107,7 +107,7 @@ class RepoWindow(AddRepoBase, AddRepoUI):
             return False
 
         if len(self.values['repo_name']) > 64:
-            self._set_status(self.tr('Repository name must be less than 64 characters.'))
+            self._set_status(self.tr('Repository name must be less than 65 characters.'))
             return False
 
         if RepoModel.get_or_none(RepoModel.url == self.values['repo_url']) is not None:

--- a/tests/unit/test_password_input.py
+++ b/tests/unit/test_password_input.py
@@ -86,7 +86,7 @@ def test_password_input_validation(qapp, qtbot):
     qtbot.keyClicks(password_input.confirmLineEdit, "123456789")
 
     assert password_input.passwordLineEdit.error_state
-    assert password_input.validation_label.text() == "Passwords must be atleast 10 characters long."
+    assert password_input.validation_label.text() == "Passwords must be at least 10 characters long."
 
     password_input.clear()
     qtbot.keyClicks(password_input.passwordLineEdit, "123456789")
@@ -94,7 +94,7 @@ def test_password_input_validation(qapp, qtbot):
 
     assert password_input.passwordLineEdit.error_state
     assert password_input.confirmLineEdit.error_state
-    assert password_input.validation_label.text() == "Passwords must be identical and atleast 10 characters long."
+    assert password_input.validation_label.text() == "Passwords must be identical and at least 10 characters long."
 
     password_input.clear()
     qtbot.keyClicks(password_input.passwordLineEdit, "1234567890")
@@ -130,7 +130,7 @@ def test_password_input_validation_disabled(qapp, qtbot):
 
     assert password_input.passwordLineEdit.error_state
     assert password_input.confirmLineEdit.error_state
-    assert password_input.validation_label.text() == "Passwords must be identical and atleast 9 characters long."
+    assert password_input.validation_label.text() == "Passwords must be identical and at least 9 characters long."
 
     password_input.set_validation_enabled(False)
     assert not password_input.passwordLineEdit.error_state


### PR DESCRIPTION
### Description
The repo unit test module has some areas of opportunity for clean up, test parameterization, and additional test coverage.

I have cleaned up the tests by separating `test_repo_add_failures` into `test_new_repo_password_validation` and `test_repo_add_failures ` as these seems to be more clear indications of what was being tested. Additionally, I parametrized the password validation tests to reduce code duplication.

I added a new test for repo name behavior and parametrized it to test a few inputs. When adding this test, I noticed a typo in the `validate()` function of `RepoWindow` class that I fixed. 
 
### Related Issue
#1754 

### Motivation and Context
One of my Google Summer of Code projects involves cleaning up the Vorta tests, reducing duplicated code, and increasing code coverage.

### How Has This Been Tested?
Tests work locally by running pytest, and they pass the GitHub CI checks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
