### PR TITLE
PR: `tests/unit/test_source`: cleanup, parametrize, and increase test coverage

### DIFF
--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -379,4 +379,5 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
         if len(invalidSources) != 0:  # Check if any invalid paths
             msg = QMessageBox()
             msg.setText(self.tr("Some of your sources are invalid:") + invalidSources)
+            self._msg = msg  # for testing
             msg.exec()

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 import vorta.views
 from PyQt6 import QtCore
@@ -38,10 +36,10 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, sources_setup):
     tab.source_remove()
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 1, **pytest._wait_defaults)
     assert tab.sourceFilesWidget.rowCount() == 1
+    # Wait for directory sizing to finish
     qtbot.waitUntil(lambda: len(qapp.main_window.sourceTab.updateThreads) == 0, **pytest._wait_defaults)
 
 
-@pytest.mark.skipif(sys.platform.startswith("linux"), reason="spurious test fails due to 'updateThreads'")
 @pytest.mark.parametrize(
     "path, valid",
     [
@@ -92,3 +90,5 @@ def test_sources_update(qapp, qtbot, mocker, sources_setup):
     tab.sources_update()
     assert tab.sourceFilesWidget.rowCount() == 2
     assert update_path_info_spy.call_count == 2
+    # Wait for directory sizing to finish
+    qtbot.waitUntil(lambda: len(qapp.main_window.sourceTab.updateThreads) == 0, **pytest._wait_defaults)

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -37,7 +37,7 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, source_env):
 
     # test removing a folder
     tab.sourceFilesWidget.selectRow(1)
-    tab.source_remove()
+    qtbot.mouseClick(tab.removeButton, QtCore.Qt.MouseButton.LeftButton)
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 1, **pytest._wait_defaults)
     assert tab.sourceFilesWidget.rowCount() == 1
 
@@ -75,18 +75,19 @@ def test_paste_text(qapp, qtbot, mocker, monkeypatch, source_env, path, valid):
 
 def test_sources_update(qapp, qtbot, mocker, source_env):
     main, tab = source_env
+    update_path_info_spy = mocker.spy(tab, "update_path_info")
 
     # test that `update_path_info()` has been called for each source path
-    update_path_info_spy = mocker.spy(tab, "update_path_info")
     qtbot.mouseClick(tab.updateButton, QtCore.Qt.MouseButton.LeftButton)
     assert tab.sourceFilesWidget.rowCount() == 1
     assert update_path_info_spy.call_count == 1
 
-    # add a new source and test again
+    # add a new source and reset mock
     tab.source_add(want_folder=True)
-    qtbot.mouseClick(tab.updateButton, QtCore.Qt.MouseButton.LeftButton)
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
     update_path_info_spy.reset_mock()
-    tab.sources_update()
+
+    # retest that `update_path_info()` has been called for each source path
+    qtbot.mouseClick(tab.updateButton, QtCore.Qt.MouseButton.LeftButton)
     assert tab.sourceFilesWidget.rowCount() == 2
     assert update_path_info_spy.call_count == 2

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -1,5 +1,6 @@
 import pytest
 import vorta.views
+from PyQt6 import QtCore
 from PyQt6.QtWidgets import QMessageBox
 
 
@@ -76,12 +77,13 @@ def test_sources_update(qapp, qtbot, mocker, sources_setup):
 
     # test that `update_path_info()` has been called for each source path
     update_path_info_spy = mocker.spy(tab, "update_path_info")
-    tab.sources_update()
+    qtbot.mouseClick(tab.updateButton, QtCore.Qt.MouseButton.LeftButton)
     assert tab.sourceFilesWidget.rowCount() == 1
     assert update_path_info_spy.call_count == 1
 
     # add a new source and test again
     tab.source_add(want_folder=True)
+    qtbot.mouseClick(tab.updateButton, QtCore.Qt.MouseButton.LeftButton)
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
     update_path_info_spy.reset_mock()
     tab.sources_update()

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -3,15 +3,33 @@ import vorta.views
 from PyQt6.QtWidgets import QMessageBox
 
 
-def test_source_add_remove(qapp, qtbot, monkeypatch, choose_file_dialog):
-    monkeypatch.setattr(vorta.views.source_tab, "choose_file_dialog", choose_file_dialog)
-    main = qapp.main_window
-    main.tabWidget.setCurrentIndex(1)
-    tab = main.sourceTab
+@pytest.fixture()
+def sources_setup(qapp, qtbot, monkeypatch, choose_file_dialog):
+    def setup():
+        monkeypatch.setattr(vorta.views.source_tab, "choose_file_dialog", choose_file_dialog)
+        main = qapp.main_window
+        main.tabWidget.setCurrentIndex(1)
+        tab = main.sourceTab
+        qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 1, **pytest._wait_defaults)
+        return main, tab
 
-    # test adding a folder
+    return setup
+
+
+def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, sources_setup):
+    main, tab = sources_setup()
+
+    # test adding a folder with os access
+    mocker.patch('os.access', return_value=True)
     tab.source_add(want_folder=True)
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
+    assert tab.sourceFilesWidget.rowCount() == 2
+
+    # test adding a folder without os access
+    mocker.patch('os.access', return_value=False)
+    monkeypatch.setattr(QMessageBox, "exec", lambda *args: True)  # prevent QMessageBox from stopping test
+    tab.source_add(want_folder=True)
+    assert tab.sourceFilesWidget.rowCount() == 2
 
     # test removing a folder
     tab.sourceFilesWidget.selectRow(1)
@@ -30,22 +48,42 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, choose_file_dialog):
         (f"file://{__file__}{__file__}", False),  # invalid - no new line separating file names
     ],
 )
-def test_paste_text(qapp, qtbot, mocker, monkeypatch, choose_file_dialog, path, valid):
-    monkeypatch.setattr(vorta.views.source_tab, "choose_file_dialog", choose_file_dialog)
-    main = qapp.main_window
-    main.tabWidget.setCurrentIndex(1)
-    tab = main.sourceTab
-
+def test_paste_text(qapp, qtbot, mocker, monkeypatch, sources_setup, path, valid):
+    main, tab = sources_setup()
     mock_clipboard = mocker.Mock()
     mock_clipboard.text.return_value = path
+
     mocker.patch.object(vorta.views.source_tab.QApplication, 'clipboard', return_value=mock_clipboard)
-    monkeypatch.setattr(QMessageBox, "exec", lambda *args: True)
+    monkeypatch.setattr(QMessageBox, "exec", lambda *args: True)  # prevent QMessageBox from stopping test
     tab.paste_text()
+
     if valid:
+        # valid paths will be added as a source
         assert not hasattr(tab, '_msg')
         qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
+        assert tab.sourceFilesWidget.rowCount() == 2
         # Wait for directory sizing to finish
         qtbot.waitUntil(lambda: len(qapp.main_window.sourceTab.updateThreads) == 0, **pytest._wait_defaults)
     else:
+        # invalid paths will trigger an alert and not be added as a source
         qtbot.waitUntil(lambda: hasattr(tab, "_msg"), **pytest._wait_defaults)
         assert tab._msg.text().startswith("Some of your sources are invalid")
+        assert tab.sourceFilesWidget.rowCount() == 1
+
+
+def test_sources_update(qapp, qtbot, mocker, sources_setup):
+    main, tab = sources_setup()
+
+    # test that `update_path_info()` has been called for each source path
+    update_path_info_spy = mocker.spy(tab, "update_path_info")
+    tab.sources_update()
+    assert tab.sourceFilesWidget.rowCount() == 1
+    assert update_path_info_spy.call_count == 1
+
+    # add a new source and test again
+    tab.source_add(want_folder=True)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
+    update_path_info_spy.reset_mock()
+    tab.sources_update()
+    assert tab.sourceFilesWidget.rowCount() == 2
+    assert update_path_info_spy.call_count == 2

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import vorta.views
 from PyQt6 import QtCore
@@ -39,6 +41,7 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, sources_setup):
     assert tab.sourceFilesWidget.rowCount() == 1
 
 
+@pytest.mark.skipif(platform=sys.platform.startswith("linux"), reason="spurious test fails due to 'updateThreads'")
 @pytest.mark.parametrize(
     "path, valid",
     [

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -1,22 +1,51 @@
 import pytest
 import vorta.views
+from PyQt6.QtWidgets import QMessageBox
 
 
-def test_add_folder(qapp, qtbot, mocker, monkeypatch, choose_file_dialog):
+def test_source_add_remove(qapp, qtbot, monkeypatch, choose_file_dialog):
     monkeypatch.setattr(vorta.views.source_tab, "choose_file_dialog", choose_file_dialog)
     main = qapp.main_window
     main.tabWidget.setCurrentIndex(1)
     tab = main.sourceTab
 
+    # test adding a folder
     tab.source_add(want_folder=True)
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
 
-    # Test paste button with mocked clipboard
-    mock_clipboard = mocker.Mock()
-    mock_clipboard.text.return_value = __file__
-    mocker.patch.object(vorta.views.source_tab.QApplication, 'clipboard', return_value=mock_clipboard)
-    tab.paste_text()
-    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 3, **pytest._wait_defaults)
+    # test removing a folder
+    tab.sourceFilesWidget.selectRow(1)
+    tab.source_remove()
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 1, **pytest._wait_defaults)
+    assert tab.sourceFilesWidget.rowCount() == 1
 
-    # Wait for directory sizing to finish
-    qtbot.waitUntil(lambda: len(qapp.main_window.sourceTab.updateThreads) == 0, **pytest._wait_defaults)
+
+@pytest.mark.parametrize(
+    "path, valid",
+    [
+        (__file__, True),  # valid path
+        ("test", False),  # invalid path
+        (f"file://{__file__}", True),  # valid - normal path with prefix that will be stripped
+        (f"file://{__file__}\n{__file__}", True),  # valid - two files separated by new line
+        (f"file://{__file__}{__file__}", False),  # invalid - no new line separating file names
+    ],
+)
+def test_paste_text(qapp, qtbot, mocker, monkeypatch, choose_file_dialog, path, valid):
+    monkeypatch.setattr(vorta.views.source_tab, "choose_file_dialog", choose_file_dialog)
+    main = qapp.main_window
+    main.tabWidget.setCurrentIndex(1)
+    tab = main.sourceTab
+
+    mock_clipboard = mocker.Mock()
+    mock_clipboard.text.return_value = path
+    mocker.patch.object(vorta.views.source_tab.QApplication, 'clipboard', return_value=mock_clipboard)
+    monkeypatch.setattr(QMessageBox, "exec", lambda *args: True)
+    tab.paste_text()
+    if valid:
+        assert not hasattr(tab, '_msg')
+        qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
+        # Wait for directory sizing to finish
+        qtbot.waitUntil(lambda: len(qapp.main_window.sourceTab.updateThreads) == 0, **pytest._wait_defaults)
+    else:
+        qtbot.waitUntil(lambda: hasattr(tab, "_msg"), **pytest._wait_defaults)
+        assert tab._msg.text().startswith("Some of your sources are invalid")

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -23,6 +23,8 @@ def source_env(qapp, qtbot, monkeypatch, choose_file_dialog):
 
 def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, source_env):
     main, tab = source_env
+    mocker.patch.object(QMessageBox, "exec")  # prevent QMessageBox from stopping test
+
     # test adding a folder with os access
     mocker.patch('os.access', return_value=True)
     tab.source_add(want_folder=True)
@@ -31,7 +33,6 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, source_env):
 
     # test adding a folder without os access
     mocker.patch('os.access', return_value=False)
-    monkeypatch.setattr(QMessageBox, "exec", lambda *args: True)  # prevent QMessageBox from stopping test
     tab.source_add(want_folder=True)
     assert tab.sourceFilesWidget.rowCount() == 2
 
@@ -52,13 +53,13 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, source_env):
         (f"file://{__file__}{__file__}", False),  # invalid - no new line separating file names
     ],
 )
-def test_paste_text(qapp, qtbot, mocker, monkeypatch, source_env, path, valid):
+def test_paste_text(qapp, qtbot, mocker, source_env, path, valid):
     main, tab = source_env
     mock_clipboard = mocker.Mock()
     mock_clipboard.text.return_value = path
 
     mocker.patch.object(vorta.views.source_tab.QApplication, 'clipboard', return_value=mock_clipboard)
-    monkeypatch.setattr(QMessageBox, "exec", lambda *args: True)  # prevent QMessageBox from stopping test
+    mocker.patch.object(QMessageBox, "exec")  # prevent QMessageBox from stopping test
     tab.paste_text()
 
     if valid:

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -21,7 +21,6 @@ def sources_setup(qapp, qtbot, monkeypatch, choose_file_dialog):
 
 def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, sources_setup):
     main, tab = sources_setup()
-
     # test adding a folder with os access
     mocker.patch('os.access', return_value=True)
     tab.source_add(want_folder=True)
@@ -39,9 +38,10 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, sources_setup):
     tab.source_remove()
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 1, **pytest._wait_defaults)
     assert tab.sourceFilesWidget.rowCount() == 1
+    qtbot.waitUntil(lambda: len(qapp.main_window.sourceTab.updateThreads) == 0, **pytest._wait_defaults)
 
 
-@pytest.mark.skipif(platform=sys.platform.startswith("linux"), reason="spurious test fails due to 'updateThreads'")
+@pytest.mark.skipif(sys.platform.startswith("linux"), reason="spurious test fails due to 'updateThreads'")
 @pytest.mark.parametrize(
     "path, valid",
     [

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -6,15 +6,15 @@ from PyQt6.QtWidgets import QMessageBox
 
 @pytest.fixture()
 def source_env(qapp, qtbot, monkeypatch, choose_file_dialog):
-    def setup():
-        monkeypatch.setattr(vorta.views.source_tab, "choose_file_dialog", choose_file_dialog)
-        main = qapp.main_window
-        main.tabWidget.setCurrentIndex(1)
-        tab = main.sourceTab
-        qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 1, timeout=2000)
-        return main, tab
+    """
+    Handles common setup and teardown for unit tests involving the source tab.
+    """
+    monkeypatch.setattr(vorta.views.source_tab, "choose_file_dialog", choose_file_dialog)
+    main = qapp.main_window
+    main.tabWidget.setCurrentIndex(1)
+    tab = main.sourceTab
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 1, timeout=2000)
 
-    main, tab = setup()
     yield main, tab
 
     # Wait for directory sizing to finish
@@ -22,6 +22,9 @@ def source_env(qapp, qtbot, monkeypatch, choose_file_dialog):
 
 
 def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, source_env):
+    """
+    Tests adding and removing source to ensure expected behavior.
+    """
     main, tab = source_env
     mocker.patch.object(QMessageBox, "exec")  # prevent QMessageBox from stopping test
 
@@ -53,7 +56,11 @@ def test_source_add_remove(qapp, qtbot, monkeypatch, mocker, source_env):
         (f"file://{__file__}{__file__}", False),  # invalid - no new line separating file names
     ],
 )
-def test_paste_text(qapp, qtbot, mocker, source_env, path, valid):
+def test_valid_and_invalid_source_paths(qapp, qtbot, mocker, source_env, path, valid):
+    """
+    Valid paths will be added as a source.
+    Invalid paths will trigger an alert and not be added as a source.
+    """
     main, tab = source_env
     mock_clipboard = mocker.Mock()
     mock_clipboard.text.return_value = path
@@ -63,18 +70,19 @@ def test_paste_text(qapp, qtbot, mocker, source_env, path, valid):
     tab.paste_text()
 
     if valid:
-        # valid paths will be added as a source
         assert not hasattr(tab, '_msg')
         qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
         assert tab.sourceFilesWidget.rowCount() == 2
     else:
-        # invalid paths will trigger an alert and not be added as a source
         qtbot.waitUntil(lambda: hasattr(tab, "_msg"), **pytest._wait_defaults)
         assert tab._msg.text().startswith("Some of your sources are invalid")
         assert tab.sourceFilesWidget.rowCount() == 1
 
 
 def test_sources_update(qapp, qtbot, mocker, source_env):
+    """
+    Tests the source update button in the source tab
+    """
     main, tab = source_env
     update_path_info_spy = mocker.spy(tab, "update_path_info")
 


### PR DESCRIPTION
### Description
In this PR, I cleaned up the `test_source` module by splitting the `paste_text()` testing into its own separate test. I then parametrized `test_paste_text()` to cover more use/edge cases. Finally, I added in tests for removing a source from the sources table, as well as testing the source update button.

### Related Issue
#1754 

### Motivation and Context
One of my Google Summer of Code projects involves cleaning up the Vorta tests, reducing duplicated code, and increasing code coverage.

### How Has This Been Tested?
Tests work locally by running `pytest`, and they pass the GitHub CI checks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
