### PR TITLE
Prevent in-line archive rename during ongoing operation

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -825,6 +825,9 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self._toggle_all_buttons(True)
 
     def cell_double_clicked(self, row=None, column=None):
+        if not self.bRename.isEnabled():
+            return
+
         if not row or not column:
             row = self.archiveTable.currentRow()
             column = self.archiveTable.currentColumn()

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -179,7 +179,10 @@ def test_refresh_archive_info(qapp, qtbot, mocker, borg_json_output, archive_env
     qtbot.waitUntil(lambda: tab.mountErrors.text() == 'Refreshed archives.', **pytest._wait_defaults)
 
 
-def test_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_env):
+def test_inline_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_env):
+    """
+    Tests the functionality of in-line renaming an archive by double-clicking its name.
+    """
     main, tab = archive_env
 
     tab.archiveTable.selectRow(0)
@@ -190,9 +193,12 @@ def test_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_env):
 
     pos = tab.archiveTable.visualRect(tab.archiveTable.model().index(0, 4)).center()
     qtbot.mouseClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=pos)
+    assert tab.bRename.isEnabled()
     qtbot.mouseDClick(tab.archiveTable.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=pos)
+    tab.archiveTable.viewport().focusWidget().setText("")
     qtbot.keyClicks(tab.archiveTable.viewport().focusWidget(), new_archive_name)
     qtbot.keyClick(tab.archiveTable.viewport().focusWidget(), QtCore.Qt.Key.Key_Return)
 
     # Successful rename case
     qtbot.waitUntil(lambda: tab.archiveTable.model().index(0, 4).data() == new_archive_name, **pytest._wait_defaults)
+    assert tab.archiveTable.model().index(0, 4).data() == new_archive_name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes #1790 

### Motivation and Context
Improved stability during background operations.

### How Has This Been Tested?
I edited the current archive rename unit test to ensure it asserts the rename button is enabled before attempting the rename.
Passes tests locally and on GitHub workflow.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
