### PR TITLE
Bound archive buttons enable/disable to context menu actions

### DIFF
--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -221,23 +221,23 @@
               </item>
               <item>
                <widget class="QToolButton" name="bDiff">
-               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-               </sizepolicy>
-               </property>
-               <property name="toolTip">
-               <string>Compare two archives</string>
-               </property>
-               <property name="text">
-               <string>Diff</string>
-               </property>
-               <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextBesideIcon</enum>
-               </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Compare two archives</string>
+                </property>
+                <property name="text">
+                 <string>Diff</string>
+                </property>
+                <property name="toolButtonStyle">
+                 <enum>Qt::ToolButtonTextBesideIcon</enum>
+                </property>
                </widget>
-               </item>
+              </item>
               <item>
                <widget class="QToolButton" name="bMountArchive">
                 <property name="sizePolicy">
@@ -295,25 +295,25 @@
                 </property>
                </widget>
               </item>
-               <item>
+              <item>
                <widget class="QToolButton" name="bDelete">
-               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-               </sizepolicy>
-               </property>
-               <property name="toolTip">
-               <string>Delete selected archive(s)</string>
-               </property>
-               <property name="text">
-               <string>Delete</string>
-               </property>
-               <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextBesideIcon</enum>
-               </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Delete selected archive(s)</string>
+                </property>
+                <property name="text">
+                 <string>Delete</string>
+                </property>
+                <property name="toolButtonStyle">
+                 <enum>Qt::ToolButtonTextBesideIcon</enum>
+                </property>
                </widget>
-               </item>
+              </item>
              </layout>
             </widget>
            </item>

--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -220,6 +220,25 @@
                </widget>
               </item>
               <item>
+               <widget class="QToolButton" name="bDiff">
+               <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+               </sizepolicy>
+               </property>
+               <property name="toolTip">
+               <string>Compare two archives</string>
+               </property>
+               <property name="text">
+               <string>Diff</string>
+               </property>
+               <property name="toolButtonStyle">
+               <enum>Qt::ToolButtonTextBesideIcon</enum>
+               </property>
+               </widget>
+               </item>
+              <item>
                <widget class="QToolButton" name="bMountArchive">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -276,58 +295,26 @@
                 </property>
                </widget>
               </item>
+               <item>
+               <widget class="QToolButton" name="bDelete">
+               <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+               </sizepolicy>
+               </property>
+               <property name="toolTip">
+               <string>Delete selected archive(s)</string>
+               </property>
+               <property name="text">
+               <string>Delete</string>
+               </property>
+               <property name="toolButtonStyle">
+               <enum>Qt::ToolButtonTextBesideIcon</enum>
+               </property>
+               </widget>
+               </item>
              </layout>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QToolButton" name="bDiff">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Compare two archives</string>
-             </property>
-             <property name="text">
-              <string>Diff</string>
-             </property>
-             <property name="toolButtonStyle">
-              <enum>Qt::ToolButtonTextBesideIcon</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QToolButton" name="bDelete">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Delete selected archive(s)</string>
-             </property>
-             <property name="text">
-              <string>Delete</string>
-             </property>
-             <property name="toolButtonStyle">
-              <enum>Qt::ToolButtonTextBesideIcon</enum>
-             </property>
             </widget>
            </item>
           </layout>

--- a/src/vorta/assets/UI/archivetab.ui
+++ b/src/vorta/assets/UI/archivetab.ui
@@ -314,6 +314,19 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <spacer name="verticalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
              </layout>
             </widget>
            </item>

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -382,7 +382,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
 
             for index in range(layout.count()):
                 widget = layout.itemAt(index).widget()
-                widget.setToolTip(self.tooltip_dict.get(widget, ""))
+                if widget is not None:
+                    widget.setToolTip(self.tooltip_dict.get(widget, ""))
 
             # refresh bMountArchive for the selected archive
             self.bmountarchive_refresh()

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -154,7 +154,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.app.paletteChanged.connect(lambda p: self.set_icons())
 
     def set_icons(self):
-        "Used when changing between light- and dark mode"
+        """Used when changing between light- and dark mode"""
         self.bCheck.setIcon(get_colored_icon('check-circle'))
         self.bDiff.setIcon(get_colored_icon('stream-solid'))
         self.bPrune.setIcon(get_colored_icon('cut'))
@@ -189,11 +189,11 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         # archive actions
         button_connection_pairs = [
             (self.bRefreshArchive, self.refresh_archive_info),
+            (self.bDiff, self.diff_action),
             (self.bMountArchive, self.bmountarchive_clicked),
             (self.bExtract, self.extract_action),
             (self.bRename, self.cell_double_clicked),
             (self.bDelete, self.delete_action),
-            (self.bDiff, self.diff_action),
         ]
 
         for button, connection in button_connection_pairs:

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 from PyQt6 import QtCore, uic
 from PyQt6.QtCore import QItemSelectionModel, QMimeData, QPoint, Qt, pyqtSlot
-from PyQt6.QtGui import QAction, QDesktopServices, QKeySequence, QShortcut
+from PyQt6.QtGui import QDesktopServices, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QApplication,
@@ -183,46 +183,22 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             return  # popup only for selected items
 
         menu = QMenu(self.archiveTable)
-        menu.addAction(
-            get_colored_icon('copy'),
-            self.tr("Copy"),
-            lambda: self.archive_copy(index=index),
-        )
+        menu.addAction(get_colored_icon('copy'), self.tr("Copy"), lambda: self.archive_copy(index=index))
         menu.addSeparator()
 
         # archive actions
-        archive_actions = []
-        archive_actions.append(
-            menu.addAction(
-                self.bRefreshArchive.icon(),
-                self.bRefreshArchive.text(),
-                self.refresh_archive_info,
-            )
-        )
-        archive_actions.append(
-            menu.addAction(
-                self.bMountArchive.icon(),
-                self.bMountArchive.text(),
-                self.bmountarchive_clicked,
-            )
-        )
-        archive_actions.append(menu.addAction(self.bExtract.icon(), self.bExtract.text(), self.extract_action))
-        archive_actions.append(menu.addAction(self.bRename.icon(), self.bRename.text(), self.cell_double_clicked))
-        # deletion possible with one but also multiple archives
-        menu.addAction(self.bDelete.icon(), self.bDelete.text(), self.delete_action)
+        button_connection_pairs = [
+            (self.bRefreshArchive, self.refresh_archive_info),
+            (self.bMountArchive, self.bmountarchive_clicked),
+            (self.bExtract, self.extract_action),
+            (self.bRename, self.cell_double_clicked),
+            (self.bDelete, self.delete_action),
+            (self.bDiff, self.diff_action),
+        ]
 
-        if not (self.repoactions_enabled and len(selected_rows) <= 1):
-            for action in archive_actions:
-                action.setEnabled(False)
-
-        # diff action
-        menu.addSeparator()
-        diff_action = QAction(self.bDiff.icon(), self.bDiff.text(), menu)
-        diff_action.triggered.connect(self.diff_action)
-        menu.addAction(diff_action)
-
-        selected_rows = self.archiveTable.selectionModel().selectedRows(index.column())
-        diff_action.setEnabled(self.repoactions_enabled and len(selected_rows) == 2)
+        for button, connection in button_connection_pairs:
+            action = menu.addAction(button.icon(), button.text(), connection)
+            action.setEnabled(button.isEnabled())
 
         menu.popup(self.archiveTable.viewport().mapToGlobal(pos))
 


### PR DESCRIPTION
### Description
The context menu that appears when you right click on an archive has its own rules for when actions are enabled or disabled, separate from the rules for the buttons in the archive tab, even though they perform the same actions. I do not believe there is a reason for these buttons to ever be enabled in the context menu and disabled on the archive tab or vise versa.

In this PR, I have bound the "enabled" or "disabled" state of the actions in the archive right-click context menu to the state of their button equivalent in the archive tab. This will improve consistency, and prevent issues like the one I encountered [here](https://github.com/borgbase/vorta/issues/1792).

### Related Issue
#1792 

### Motivation and Context
Improve consistency and prevent errors

### How Has This Been Tested?
Tested locally, and passes Github test workflow

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
