### PR TITLE
'Add SSH Key' Improvements

### DIFF
--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -199,7 +199,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         self._window = ssh_add_window  # For tests
         ssh_add_window.setParent(self, QtCore.Qt.WindowType.Sheet)
         ssh_add_window.rejected.connect(self.init_ssh)
-        ssh_add_window.create_ssh_key_failure.connect(self.create_ssh_key_failure)
+        ssh_add_window.failure.connect(self.create_ssh_key_failure)
         ssh_add_window.open()
 
     def create_ssh_key_failure(self, exit_code):

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -198,9 +198,19 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         ssh_add_window = SSHAddWindow()
         self._window = ssh_add_window  # For tests
         ssh_add_window.setParent(self, QtCore.Qt.WindowType.Sheet)
-        ssh_add_window.accepted.connect(self.init_ssh)
-        # ssh_add_window.rejected.connect(lambda: self.sshComboBox.setCurrentIndex(0))
+        ssh_add_window.create_ssh_key_message.connect(self.init_ssh)
+        ssh_add_window.create_ssh_key_message.connect(self.create_ssh_key_message)
         ssh_add_window.open()
+
+    def create_ssh_key_message(self, exitCode: int, output_file: str):
+        msg = QMessageBox()
+        msg.setStandardButtons(QMessageBox.StandardButton.Ok)
+        msg.setParent(self, QtCore.Qt.WindowType.Sheet)
+        if exitCode == 0:
+            msg.setText(self.tr(f"New key was copied to clipboard, and written to:\n{output_file}"))
+        else:
+            msg.setText(self.tr('Error during key generation.'))
+        msg.show()
 
     def ssh_copy_to_clipboard_action(self):
         msg = QMessageBox()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -198,7 +198,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         ssh_add_window = SSHAddWindow()
         self._window = ssh_add_window  # For tests
         ssh_add_window.setParent(self, QtCore.Qt.WindowType.Sheet)
-        ssh_add_window.reject.connect(self.init_ssh)
+        ssh_add_window.rejected.connect(self.init_ssh)
         ssh_add_window.create_ssh_key_failure.connect(self.create_ssh_key_failure)
         ssh_add_window.open()
 

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -198,18 +198,15 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         ssh_add_window = SSHAddWindow()
         self._window = ssh_add_window  # For tests
         ssh_add_window.setParent(self, QtCore.Qt.WindowType.Sheet)
-        ssh_add_window.create_ssh_key_message.connect(self.init_ssh)
-        ssh_add_window.create_ssh_key_message.connect(self.create_ssh_key_message)
+        ssh_add_window.reject.connect(self.init_ssh)
+        ssh_add_window.create_ssh_key_failure.connect(self.create_ssh_key_failure)
         ssh_add_window.open()
 
-    def create_ssh_key_message(self, exitCode: int, output_file: str):
+    def create_ssh_key_failure(self, exit_code):
         msg = QMessageBox()
         msg.setStandardButtons(QMessageBox.StandardButton.Ok)
         msg.setParent(self, QtCore.Qt.WindowType.Sheet)
-        if exitCode == 0:
-            msg.setText(self.tr(f"New key was copied to clipboard, and written to:\n{output_file}"))
-        else:
-            msg.setText(self.tr('Error during key generation.'))
+        msg.setText(self.tr(f'Error during key generation. Exited with code {exit_code}.'))
         msg.show()
 
     def ssh_copy_to_clipboard_action(self):
@@ -233,7 +230,6 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
                         "Use it to set up remote repo permissions."
                     )
                 )
-
             else:
                 msg.setText(self.tr("Could not find public key."))
         else:

--- a/src/vorta/views/ssh_dialog.py
+++ b/src/vorta/views/ssh_dialog.py
@@ -1,6 +1,6 @@
 import os
 
-from PyQt6 import uic
+from PyQt6 import QtCore, uic
 from PyQt6.QtCore import QProcess, Qt
 from PyQt6.QtWidgets import QApplication, QDialogButtonBox
 
@@ -11,6 +11,8 @@ SSHAddUI, SSHAddBase = uic.loadUiType(uifile)
 
 
 class SSHAddWindow(SSHAddBase, SSHAddUI):
+    create_ssh_key_message = QtCore.pyqtSignal(int, str)
+
     def __init__(self):
         super().__init__()
         self.setupUi(self)
@@ -68,15 +70,17 @@ class SSHAddWindow(SSHAddBase, SSHAddUI):
             self.sshproc.finished.connect(self.generate_key_result)
             self.sshproc.start('ssh-keygen', ['-t', format, '-b', length, '-f', output_path, '-N', ''])
 
-    def generate_key_result(self, exitCode, exitStatus):
+    def generate_key_result(self, exitCode):
         if exitCode == 0:
             output_path = os.path.expanduser(self.outputFileTextBox.text())
             pub_key = open(output_path + '.pub').read().strip()
             clipboard = QApplication.clipboard()
             clipboard.setText(pub_key)
-            self.errors.setText(self.tr('New key was copied to clipboard and written to %s.') % output_path)
+            self.reject()
+            self.create_ssh_key_message.emit(exitCode, output_path)
         else:
-            self.errors.setText(self.tr('Error during key generation.'))
+            self.reject()
+            self.create_ssh_key_message.emit(exitCode, "")
 
     def get_values(self):
         return {

--- a/src/vorta/views/ssh_dialog.py
+++ b/src/vorta/views/ssh_dialog.py
@@ -11,7 +11,8 @@ SSHAddUI, SSHAddBase = uic.loadUiType(uifile)
 
 
 class SSHAddWindow(SSHAddBase, SSHAddUI):
-    create_ssh_key_message = QtCore.pyqtSignal(int, str)
+    create_ssh_key_success = QtCore.pyqtSignal()
+    create_ssh_key_failure = QtCore.pyqtSignal(int)
 
     def __init__(self):
         super().__init__()
@@ -70,17 +71,16 @@ class SSHAddWindow(SSHAddBase, SSHAddUI):
             self.sshproc.finished.connect(self.generate_key_result)
             self.sshproc.start('ssh-keygen', ['-t', format, '-b', length, '-f', output_path, '-N', ''])
 
-    def generate_key_result(self, exitCode):
-        if exitCode == 0:
+    def generate_key_result(self, exit_code):
+        if exit_code == 0:
             output_path = os.path.expanduser(self.outputFileTextBox.text())
             pub_key = open(output_path + '.pub').read().strip()
             clipboard = QApplication.clipboard()
             clipboard.setText(pub_key)
             self.reject()
-            self.create_ssh_key_message.emit(exitCode, output_path)
         else:
             self.reject()
-            self.create_ssh_key_message.emit(exitCode, "")
+            self.create_ssh_key_failure.emit(exit_code)
 
     def get_values(self):
         return {

--- a/src/vorta/views/ssh_dialog.py
+++ b/src/vorta/views/ssh_dialog.py
@@ -11,7 +11,6 @@ SSHAddUI, SSHAddBase = uic.loadUiType(uifile)
 
 
 class SSHAddWindow(SSHAddBase, SSHAddUI):
-    create_ssh_key_success = QtCore.pyqtSignal()
     create_ssh_key_failure = QtCore.pyqtSignal(int)
 
     def __init__(self):

--- a/src/vorta/views/ssh_dialog.py
+++ b/src/vorta/views/ssh_dialog.py
@@ -1,7 +1,7 @@
 import os
 
 from PyQt6 import QtCore, uic
-from PyQt6.QtCore import QProcess, Qt
+from PyQt6.QtCore import QProcess, Qt, pyqtSlot
 from PyQt6.QtWidgets import QApplication, QDialogButtonBox
 
 from ..utils import get_asset
@@ -11,7 +11,7 @@ SSHAddUI, SSHAddBase = uic.loadUiType(uifile)
 
 
 class SSHAddWindow(SSHAddBase, SSHAddUI):
-    create_ssh_key_failure = QtCore.pyqtSignal(int)
+    failure = QtCore.pyqtSignal(int)
 
     def __init__(self):
         super().__init__()
@@ -70,6 +70,7 @@ class SSHAddWindow(SSHAddBase, SSHAddUI):
             self.sshproc.finished.connect(self.generate_key_result)
             self.sshproc.start('ssh-keygen', ['-t', format, '-b', length, '-f', output_path, '-N', ''])
 
+    @pyqtSlot(int)
     def generate_key_result(self, exit_code):
         if exit_code == 0:
             output_path = os.path.expanduser(self.outputFileTextBox.text())
@@ -79,7 +80,7 @@ class SSHAddWindow(SSHAddBase, SSHAddUI):
             self.reject()
         else:
             self.reject()
-            self.create_ssh_key_failure.emit(exit_code)
+            self.failure.emit(exit_code)
 
     def get_values(self):
         return {

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -1,4 +1,4 @@
-import os
+# import os
 import uuid
 
 import pytest
@@ -131,32 +131,32 @@ def test_repo_add_success(qapp, qtbot, mocker, borg_json_output):
     assert tab.repoSelector.currentText() == f"{test_repo_name} - {test_repo_url}"
 
 
-def test_ssh_dialog(qapp, qtbot, tmpdir):
-    main = qapp.main_window
-    tab = main.repoTab
-
-    qtbot.mouseClick(tab.bAddSSHKey, QtCore.Qt.MouseButton.LeftButton)
-    ssh_dialog = tab._window
-
-    ssh_dir = tmpdir
-    key_tmpfile = ssh_dir.join("id_rsa-test")
-    pub_tmpfile = ssh_dir.join("id_rsa-test.pub")
-    key_tmpfile_full = os.path.join(key_tmpfile.dirname, key_tmpfile.basename)
-    ssh_dialog.outputFileTextBox.setText(key_tmpfile_full)
-    ssh_dialog.generate_key()
-
-    # Ensure new key files exist
-    qtbot.waitUntil(lambda: ssh_dialog.errors.text().startswith('New key was copied'), **pytest._wait_defaults)
-    assert len(ssh_dir.listdir()) == 2
-
-    # Ensure valid keys were created
-    key_tmpfile_content = key_tmpfile.read()
-    assert key_tmpfile_content.startswith('-----BEGIN OPENSSH PRIVATE KEY-----')
-    pub_tmpfile_content = pub_tmpfile.read()
-    assert pub_tmpfile_content.startswith('ssh-ed25519')
-
-    ssh_dialog.generate_key()
-    qtbot.waitUntil(lambda: ssh_dialog.errors.text().startswith('Key file already'), **pytest._wait_defaults)
+# def test_ssh_dialog(qapp, qtbot, tmpdir):
+#     main = qapp.main_window
+#     tab = main.repoTab
+#
+#     qtbot.mouseClick(tab.bAddSSHKey, QtCore.Qt.MouseButton.LeftButton)
+#     ssh_dialog = tab._window
+#
+#     ssh_dir = tmpdir
+#     key_tmpfile = ssh_dir.join("id_rsa-test")
+#     pub_tmpfile = ssh_dir.join("id_rsa-test.pub")
+#     key_tmpfile_full = os.path.join(key_tmpfile.dirname, key_tmpfile.basename)
+#     ssh_dialog.outputFileTextBox.setText(key_tmpfile_full)
+#     ssh_dialog.generate_key()
+#
+#     # Ensure new key files exist
+#     qtbot.waitUntil(lambda: ssh_dialog.errors.text().startswith('New key was copied'), **pytest._wait_defaults)
+#     assert len(ssh_dir.listdir()) == 2
+#
+#     # Ensure valid keys were created
+#     key_tmpfile_content = key_tmpfile.read()
+#     assert key_tmpfile_content.startswith('-----BEGIN OPENSSH PRIVATE KEY-----')
+#     pub_tmpfile_content = pub_tmpfile.read()
+#     assert pub_tmpfile_content.startswith('ssh-ed25519')
+#
+#     ssh_dialog.generate_key()
+#     qtbot.waitUntil(lambda: ssh_dialog.errors.text().startswith('Key file already'), **pytest._wait_defaults)
 
 
 def test_create(qapp, borg_json_output, mocker, qtbot):

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -149,7 +149,7 @@ def test_ssh_dialog_success(qapp, qtbot, mocker, tmpdir):
     qtbot.waitUntil(lambda: ssh_dialog_closed.called, **pytest._wait_defaults)
     assert len(ssh_dir.listdir()) == 2
 
-    # Ensure it populated in SSH combobox
+    # Ensure new key is populated in SSH combobox
     mocker.patch('os.path.expanduser', return_value=str(tmpdir))
     tab.init_ssh()
     assert tab.sshComboBox.count() == 2

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -1,4 +1,4 @@
-# import os
+import os
 import uuid
 
 import pytest
@@ -131,32 +131,36 @@ def test_repo_add_success(qapp, qtbot, mocker, borg_json_output):
     assert tab.repoSelector.currentText() == f"{test_repo_name} - {test_repo_url}"
 
 
-# def test_ssh_dialog(qapp, qtbot, tmpdir):
-#     main = qapp.main_window
-#     tab = main.repoTab
-#
-#     qtbot.mouseClick(tab.bAddSSHKey, QtCore.Qt.MouseButton.LeftButton)
-#     ssh_dialog = tab._window
-#
-#     ssh_dir = tmpdir
-#     key_tmpfile = ssh_dir.join("id_rsa-test")
-#     pub_tmpfile = ssh_dir.join("id_rsa-test.pub")
-#     key_tmpfile_full = os.path.join(key_tmpfile.dirname, key_tmpfile.basename)
-#     ssh_dialog.outputFileTextBox.setText(key_tmpfile_full)
-#     ssh_dialog.generate_key()
-#
-#     # Ensure new key files exist
-#     qtbot.waitUntil(lambda: ssh_dialog.errors.text().startswith('New key was copied'), **pytest._wait_defaults)
-#     assert len(ssh_dir.listdir()) == 2
-#
-#     # Ensure valid keys were created
-#     key_tmpfile_content = key_tmpfile.read()
-#     assert key_tmpfile_content.startswith('-----BEGIN OPENSSH PRIVATE KEY-----')
-#     pub_tmpfile_content = pub_tmpfile.read()
-#     assert pub_tmpfile_content.startswith('ssh-ed25519')
-#
-#     ssh_dialog.generate_key()
-#     qtbot.waitUntil(lambda: ssh_dialog.errors.text().startswith('Key file already'), **pytest._wait_defaults)
+def test_ssh_dialog(qapp, qtbot, mocker, tmpdir):
+    main = qapp.main_window
+    tab = main.repoTab
+
+    qtbot.mouseClick(tab.bAddSSHKey, QtCore.Qt.MouseButton.LeftButton)
+    ssh_dialog = tab._window
+
+    spy = mocker.spy(ssh_dialog, 'reject')
+
+    ssh_dir = tmpdir
+    key_tmpfile = ssh_dir.join("id_rsa-test")
+    pub_tmpfile = ssh_dir.join("id_rsa-test.pub")
+    key_tmpfile_full = os.path.join(key_tmpfile.dirname, key_tmpfile.basename)
+    ssh_dialog.outputFileTextBox.setText(key_tmpfile_full)
+    ssh_dialog.generate_key()
+
+    # Ensure new key files exist
+    qtbot.waitUntil(lambda: spy.called, **pytest._wait_defaults)
+    assert len(ssh_dir.listdir()) == 2
+
+    # Ensure it populates in SSH combobox
+    mocker.patch('os.path.expanduser', return_value=str(tmpdir))
+    tab.init_ssh()
+    assert tab.sshComboBox.count() == 2
+
+    # Ensure valid keys were created
+    key_tmpfile_content = key_tmpfile.read()
+    assert key_tmpfile_content.startswith('-----BEGIN OPENSSH PRIVATE KEY-----')
+    pub_tmpfile_content = pub_tmpfile.read()
+    assert pub_tmpfile_content.startswith('ssh-ed25519')
 
 
 def test_create(qapp, borg_json_output, mocker, qtbot):


### PR DESCRIPTION
### Description
Issue described here: #1801 

In addition to fixing the issue of adding keys to the dropdown right away, I tweaked the process for adding a key such that now when the user adds a new key, they receive a QMessageBox alert informing them and the SSH dialogue box closes. Previously, the SSH dialogue box would not close unless the user clicked 'cancel', which seems counterintuitive. Here is a demo of the changes:

![ssh](https://github.com/borgbase/vorta/assets/13988300/dfc8bd69-0abb-40c7-800d-32656f27ebb3)


### Related Issue
#1801 

### Motivation and Context
Greater consistency and (hopefully) improved user experience.

### How Has This Been Tested?
Locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
