### PR TITLE
change_display_mode() in (views/ )diff_result.py and extract_result.py call to setEnabled instead of setMode

### DIFF
--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -3,7 +3,6 @@ coverage
 flake8
 macholib
 nox
-peewee
 pkgconfig
 pre-commit
 pyinstaller

--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -3,6 +3,7 @@ coverage
 flake8
 macholib
 nox
+peewee
 pkgconfig
 pre-commit
 pyinstaller

--- a/src/vorta/views/diff_result.py
+++ b/src/vorta/views/diff_result.py
@@ -201,7 +201,7 @@ class DiffResultDialog(DiffResultBase, DiffResultUI):
             SettingsModel.key == 'diff_files_display_mode'
         ).execute()
 
-        self.model.setMode(mode)
+        self.model.setEnabled(mode)
 
     def slot_sorted(self, column, order):
         """React the tree view being sorted."""

--- a/src/vorta/views/extract_dialog.py
+++ b/src/vorta/views/extract_dialog.py
@@ -187,6 +187,8 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
             mode = FileTreeModel.DisplayMode.TREE
         elif selection == 1:
             mode = FileTreeModel.DisplayMode.SIMPLIFIED_TREE
+        elif selection == 2:
+            mode = FileTreeModel.DisplayMode.FLAT
         else:
             raise Exception("Unknown item in comboBoxDisplayMode with index {}".format(selection))
 
@@ -194,7 +196,7 @@ class ExtractDialog(ExtractDialogBase, ExtractDialogUI):
             SettingsModel.key == 'extract_files_display_mode'
         ).execute()
 
-        self.model.setMode(mode)
+        self.model.setEnabled(mode)
 
     def treeview_context_menu(self, pos: QPoint):
         """Display a context menu for `treeView`."""

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -166,7 +166,7 @@ def test_archive_diff(qapp, qtbot, mocker, borg_json_output, json_mock_file, fol
 )
 def test_archive_diff_parser(line, expected):
     model = DiffTree()
-    model.setMode(model.DisplayMode.FLAT)
+    model.setEnabled(model.DisplayMode.FLAT)
     parse_diff_lines([line], model)
 
     assert model.rowCount() == 1
@@ -396,7 +396,7 @@ def test_archive_diff_parser(line, expected):
 )
 def test_archive_diff_json_parser(line, expected):
     model = DiffTree()
-    model.setMode(model.DisplayMode.FLAT)
+    model.setEnabled(model.DisplayMode.FLAT)
     parse_diff_json([line], model)
 
     assert model.rowCount() == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
A try at solving the issue #1784 
### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
