### PR TITLE
Update settings.py

### DIFF
--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -48,8 +48,8 @@ def get_misc_settings() -> List[Dict[str, str]]:
             'value': True,
             'type': 'checkbox',
             'group': startup,
-            'label': trans_late('settings', 'Show main window of Vorta on launch'),
-            'tooltip': trans_late(
+            'label': trans_late('settings', 'Open main window on startup'), 
+            'tooltip': trans_late('settings', 'Open main window when the application is launched'), 
                 'settings',
                 'Make Vorta appear on screen instead of minimizing to system tray',
             ),


### PR DESCRIPTION
#1763  adding setting to start vorta minimized to tray

### Editing the label and the tooltip of the setting as needed
Previously in settings.py it had 
51: 'label': trans_late('settings', 'Show main window of Vorta on launch'),
52 :           'tooltip': trans_late(
on lines 51 and 52
where in 52 line it the code wasn't fully written 
According to the suggestions I have fixed the code by changing the lines 51 and 52 to the ones mentioned in the issue
So I guess the issue is fixed.
You can merge the code 