### PR TITLE
Loosen platformdirs dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,8 @@ package_dir =
 include_package_data = true
 python_requires = >=3.8
 install_requires =
-  platformdirs >=3.0.0, <4.0.0; sys_platform == 'darwin'  # for macOS: breaking changes in 3.0.0,
-  platformdirs >=2.6.0, <4.0.0; sys_platform != 'darwin'  # for others: 2.6+ works consistently.
+  platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'  # for macOS: breaking changes in 3.0.0,
+  platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'  # for others: 2.6+ works consistently.
   pyqt6
   peewee
   psutil


### PR DESCRIPTION
4.x is backwards compatible with 3.x except that site_cache_dir has moved to /var/cache. Vorta doesn't use this.

https://github.com/platformdirs/platformdirs/releases/tag/4.0.0

### Related Issue
N/A

### Motivation and Context
Debian is applying this patch so it can carry platformdirs 4.

### How Has This Been Tested?
Ran the test suite as part of a Debian build.

### Screenshots (if appropriate):
N/A

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/