### PR TITLE
Update appdata.xml

### DIFF
--- a/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
+++ b/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>com.borgbase.Vorta</id>
+  <launchable type="desktop-id">com.borgbase.Vorta.desktop</launchable>
   <name>Vorta</name>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
@@ -40,25 +41,13 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="v0.9.1-beta3" date="2023-11-30" urgency="low">
-      <description>
-        <ul>
-          <li>Exclude GUI. By @diivi (#1846)</li>
-          <li>Backup settings.db before migrations. By @AdwaitSalankar (#1848)</li>
-          <li>Loosen platformdirs dependency (#1843)</li>
-        </ul>
-      </description>
-    </release>
     <release version="v0.9.1" date="2024-01-10" urgency="low">
       <description>
         <ul>
           <li>First production 0.9 release</li>
-        </ul>
-      </description>
-    </release>
-    <release version="v0.9.1-beta2" date="2023-10-27" urgency="low">
-      <description>
-        <ul>
+          <li>Exclude GUI. By @diivi (#1846)</li>
+          <li>Backup settings.db before migrations. By @AdwaitSalankar (#1848)</li>
+          <li>Loosen platformdirs dependency (#1843)</li>
           <li>Unit test improvements and coverage increase. By @bigtedde (#1787)</li>
           <li>Profile sidebar and new setting interface. By @bigtedde (#1809)</li>
           <li>Update macOS notarization for use with notarytool (#1831)</li>


### PR DESCRIPTION
The appdata.xml doesn't pass validation of flathub

1. The `launchable` tag is nowadays required
2. Flatpak doesn't like the beta releases. In the end, it only made sense to remove them from the xml

I have a PR open that patches the xml: https://github.com/flathub/com.borgbase.Vorta/pull/150#issuecomment-1885331084
It would still be good to get a patch release out, if possible :)
