### PR TITLE
Detect metered connections for macos when connected to an iOS Personal Hotspot

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
   pyobjc-core < 10; sys_platform == 'darwin'
   pyobjc-framework-Cocoa < 10; sys_platform == 'darwin'
   pyobjc-framework-LaunchServices < 10; sys_platform == 'darwin'
+  pyobjc-framework-CoreWLAN < 10; sys_platform == 'darwin'
 tests_require =
   pytest
   pytest-qt

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -17,10 +17,14 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
         Get current SSID or None if Wi-Fi is off.
         """
         interface: CWInterface = self._get_wifi_interface()
-        network: CWNetwork = interface.lastNetworkJoined()
-        network_name = network.ssid()
+        # If the user has Wi-Fi turned off lastNetworkJoined will return None.
+        network: [CWNetwork | None] = interface.lastNetworkJoined()
 
-        return network_name
+        if network:
+            network_name = network.ssid()
+            return network_name
+        else:
+            return None
 
     def _get_wifi_interface(self) -> CWInterface:
         interface: CWInterface = CWInterface.interface()

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -8,7 +8,7 @@ from vorta.network_status.abc import NetworkStatusMonitor, SystemWifiInfo
 
 class DarwinNetworkStatus(NetworkStatusMonitor):
     def is_network_metered(self) -> bool:
-        return any(is_network_metered(d) for d in get_network_devices())
+        return any(is_network_metered_with_android(d) for d in get_network_devices())
 
     def get_current_wifi(self) -> Optional[str]:
         """
@@ -47,7 +47,7 @@ def get_network_devices() -> Iterator[str]:
             yield line.split()[1].strip().decode('ascii')
 
 
-def is_network_metered(bsd_device) -> bool:
+def is_network_metered_with_android(bsd_device) -> bool:
     return b'ANDROID_METERED' in call_ipconfig_getpacket(bsd_device)
 
 

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -2,7 +2,7 @@ import subprocess
 from datetime import datetime as dt
 from typing import Iterator, Optional
 
-from CoreWLAN import CWInterface, CWNetwork
+from CoreWLAN import CWInterface, CWNetwork, CWWiFiClient
 
 from vorta.log import logger
 from vorta.network_status.abc import NetworkStatusMonitor, SystemWifiInfo
@@ -35,7 +35,8 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
             return None
 
     def _get_wifi_interface(self) -> CWInterface:
-        interface: CWInterface = CWInterface.interface()
+        wifi_client: CWWiFiClient = CWWiFiClient.sharedWiFiClient()
+        interface: CWInterface = wifi_client.interface()
         return interface
 
     def get_known_wifis(self):

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -1,6 +1,6 @@
 import subprocess
 from datetime import datetime as dt
-from typing import Iterator, Optional
+from typing import Iterator, Optional, List
 
 from CoreWLAN import CWInterface, CWNetwork, CWWiFiClient
 
@@ -37,7 +37,7 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
         else:
             return None
 
-    def get_known_wifis(self) -> list[SystemWifiInfo]:
+    def get_known_wifis(self) -> List[SystemWifiInfo]:
         """
         Use the program, "networksetup", to get the list of know Wi-Fi networks.
         """

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -53,7 +53,7 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
         for line in output.strip().splitlines():
             if line.strip().startswith("Preferred networks"):
                 continue
-            elif not line:
+            elif not line.strip():
                 continue
             else:
                 result.append(line.strip())

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -34,11 +34,6 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
         else:
             return None
 
-    def _get_wifi_interface(self) -> CWInterface:
-        wifi_client: CWWiFiClient = CWWiFiClient.sharedWiFiClient()
-        interface: CWInterface = wifi_client.interface()
-        return interface
-
     def get_known_wifis(self):
         """
         Use the program, "networksetup", to get the list of know Wi-Fi networks.
@@ -62,6 +57,11 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
             wifis.append(SystemWifiInfo(ssid=wifi_network_name, last_connected=dt.now()))
 
         return wifis
+
+    def _get_wifi_interface(self) -> CWInterface:
+        wifi_client: CWWiFiClient = CWWiFiClient.sharedWiFiClient()
+        interface: CWInterface = wifi_client.interface()
+        return interface
 
 
 def get_network_devices() -> Iterator[str]:

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -1,6 +1,6 @@
 import subprocess
 from datetime import datetime as dt
-from typing import Iterator, Optional, List
+from typing import Iterator, List, Optional
 
 from CoreWLAN import CWInterface, CWNetwork, CWWiFiClient
 

--- a/src/vorta/network_status/darwin.py
+++ b/src/vorta/network_status/darwin.py
@@ -24,7 +24,10 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
         """
         Get current SSID or None if Wi-Fi is off.
         """
-        interface: CWInterface = self._get_wifi_interface()
+        interface: Optional[CWInterface] = self._get_wifi_interface()
+        if not interface:
+            return None
+
         # If the user has Wi-Fi turned off lastNetworkJoined will return None.
         network: Optional[CWNetwork] = interface.lastNetworkJoined()
 
@@ -34,13 +37,16 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
         else:
             return None
 
-    def get_known_wifis(self):
+    def get_known_wifis(self) -> list[SystemWifiInfo]:
         """
         Use the program, "networksetup", to get the list of know Wi-Fi networks.
         """
 
         wifis = []
-        interface: CWInterface = self._get_wifi_interface()
+        interface: Optional[CWInterface] = self._get_wifi_interface()
+        if not interface:
+            return []
+
         interface_name = interface.name()
         output = call_networksetup_listpreferredwirelessnetworks(interface_name)
 
@@ -58,9 +64,9 @@ class DarwinNetworkStatus(NetworkStatusMonitor):
 
         return wifis
 
-    def _get_wifi_interface(self) -> CWInterface:
+    def _get_wifi_interface(self) -> Optional[CWInterface]:
         wifi_client: CWWiFiClient = CWWiFiClient.sharedWiFiClient()
-        interface: CWInterface = wifi_client.interface()
+        interface: Optional[CWInterface] = wifi_client.interface()
         return interface
 
 

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -30,6 +30,15 @@ def test_get_current_wifi_when_wifi_is_off(mocker):
     assert result is None
 
 
+def test_get_current_wifi_when_no_wifi_interface(mocker):
+    instance = darwin.DarwinNetworkStatus()
+    mocker.patch.object(instance, "_get_wifi_interface", return_value=None)
+
+    result = instance.get_current_wifi()
+
+    assert result is None
+
+
 @pytest.mark.parametrize("is_hotspot_enabled", [True, False])
 def test_network_is_metered_with_ios(mocker, is_hotspot_enabled):
     mock_interface = MagicMock()
@@ -75,7 +84,7 @@ def test_is_network_metered_with_android(getpacket_output_name, expected, monkey
     assert result == expected
 
 
-def test_get_preferred_wifi_networks(monkeypatch):
+def test_get_known_wifi_networks_when_wifi_interface_exists(monkeypatch):
     networksetup_output = """
 Preferred networks on en0:
     Home Network
@@ -93,6 +102,15 @@ Preferred networks on en0:
 
     assert len(result) == 4
     assert result[0].ssid == "Home Network"
+
+
+def test_get_known_wifi_networks_when_no_wifi_interface(mocker):
+    instance = darwin.DarwinNetworkStatus()
+    mocker.patch.object(instance, "_get_wifi_interface", return_value=None)
+
+    results = instance.get_known_wifis()
+
+    assert results == []
 
 
 def test_get_network_devices(monkeypatch):

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -30,8 +30,34 @@ def test_get_current_wifi_when_wifi_is_off(mocker):
     assert result is None
 
 
-def test_get_network_metered_with_ios(mocker):
-    pass
+@pytest.mark.parametrize(
+    "is_hotspot_enabled",
+    [True, False]
+)
+def test_network_is_metered_with_ios(mocker, is_hotspot_enabled):
+    mock_interface = MagicMock()
+    mock_network = MagicMock()
+    mock_interface.lastNetworkJoined.return_value = mock_network
+    mock_network.isPersonalHotspot.return_value = is_hotspot_enabled
+
+    instance = darwin.DarwinNetworkStatus()
+    mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
+
+    result = instance.is_network_metered()
+
+    assert result == is_hotspot_enabled
+
+
+def test_network_is_metered_when_wifi_is_off(mocker):
+    mock_interface = MagicMock()
+    mock_interface.lastNetworkJoined.return_value = None
+
+    instance = darwin.DarwinNetworkStatus()
+    mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
+
+    result = instance.is_network_metered()
+
+    assert result is False
 
 
 @pytest.mark.parametrize(

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -1,6 +1,25 @@
+from unittest.mock import MagicMock
+
 import pytest
 from vorta.network_status import darwin
 
+
+def test_get_current_wifis_when_wifi_is_on(mocker):
+    mock_interface = MagicMock()
+    mock_network = MagicMock()
+    mock_interface.lastNetworkJoined.return_value = mock_network
+    mock_network.ssid.return_value = "Coffee Shop Wifi"
+
+    instance = darwin.DarwinNetworkStatus()
+    mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
+
+    result = instance.get_current_wifi()
+
+    assert result == "Coffee Shop Wifi"
+
+
+def test_get_network_metered_with_ios(mocker):
+    pass
 
 @pytest.mark.parametrize(
     'getpacket_output_name, expected',

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -6,17 +6,17 @@ from vorta.network_status import darwin
     'getpacket_output_name, expected',
     [
         ('normal_router', False),
-        ('phone', True),
+        ('android_phone', True),
     ],
 )
-def test_is_network_metered(getpacket_output_name, expected, monkeypatch):
+def test_is_network_metered_with_android(getpacket_output_name, expected, monkeypatch):
     def mock_getpacket(device):
         assert device == 'en0'
         return GETPACKET_OUTPUTS[getpacket_output_name]
 
     monkeypatch.setattr(darwin, 'call_ipconfig_getpacket', mock_getpacket)
 
-    result = darwin.is_network_metered('en0')
+    result = darwin.is_network_metered_with_android('en0')
     assert result == expected
 
 
@@ -55,7 +55,7 @@ interface_mtu (uint16): 0x5dc
 server_identifier (ip): 172.16.12.1
 end (none):
 """,
-    'phone': b"""\
+    'android_phone': b"""\
 op = BOOTREPLY
 htype = 1
 flags = 0

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -4,7 +4,7 @@ import pytest
 from vorta.network_status import darwin
 
 
-def test_get_current_wifis_when_wifi_is_on(mocker):
+def test_get_current_wifi_when_wifi_is_on(mocker):
     mock_interface = MagicMock()
     mock_network = MagicMock()
     mock_interface.lastNetworkJoined.return_value = mock_network
@@ -16,6 +16,18 @@ def test_get_current_wifis_when_wifi_is_on(mocker):
     result = instance.get_current_wifi()
 
     assert result == "Coffee Shop Wifi"
+
+
+def test_get_current_wifi_when_wifi_is_off(mocker):
+    mock_interface = MagicMock()
+    mock_interface.lastNetworkJoined.return_value = None
+
+    instance = darwin.DarwinNetworkStatus()
+    mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
+
+    result = instance.get_current_wifi()
+
+    assert result is None
 
 
 def test_get_network_metered_with_ios(mocker):

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -21,6 +21,7 @@ def test_get_current_wifis_when_wifi_is_on(mocker):
 def test_get_network_metered_with_ios(mocker):
     pass
 
+
 @pytest.mark.parametrize(
     'getpacket_output_name, expected',
     [
@@ -37,6 +38,27 @@ def test_is_network_metered_with_android(getpacket_output_name, expected, monkey
 
     result = darwin.is_network_metered_with_android('en0')
     assert result == expected
+
+
+def test_get_preferred_wifi_networks(monkeypatch):
+    networksetup_output = """
+Preferred networks on en0:
+    Home Network
+    Coffee Shop Wifi
+    iPhone
+    Office Wifi
+    """
+    monkeypatch.setattr(
+        darwin,
+        "call_networksetup_listpreferredwirelessnetworks",
+        lambda interface_name: networksetup_output
+    )
+
+    network_status = darwin.DarwinNetworkStatus()
+    result = network_status.get_known_wifis()
+
+    assert len(result) == 4
+    assert result[0].ssid == "Home Network"
 
 
 def test_get_network_devices(monkeypatch):

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -30,10 +30,7 @@ def test_get_current_wifi_when_wifi_is_off(mocker):
     assert result is None
 
 
-@pytest.mark.parametrize(
-    "is_hotspot_enabled",
-    [True, False]
-)
+@pytest.mark.parametrize("is_hotspot_enabled", [True, False])
 def test_network_is_metered_with_ios(mocker, is_hotspot_enabled):
     mock_interface = MagicMock()
     mock_network = MagicMock()
@@ -84,12 +81,11 @@ Preferred networks on en0:
     Home Network
     Coffee Shop Wifi
     iPhone
+
     Office Wifi
     """
     monkeypatch.setattr(
-        darwin,
-        "call_networksetup_listpreferredwirelessnetworks",
-        lambda interface_name: networksetup_output
+        darwin, "call_networksetup_listpreferredwirelessnetworks", lambda interface_name: networksetup_output
     )
 
     network_status = darwin.DarwinNetworkStatus()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

This change addresses #1884 by adding support for Vorta to detect when macOS is connected to a Wi-Fi network presented by an iOS Personal Hotspot.

I changed how the `darwin` module gets its information about Wi-Fi networks to use ObjC instead of running command line tools.  The benefits of using the ObjC Cocoa APIs is that we get richer information about Wi-Fi networks. There is an explicit API in Cocoa for checking whether a connected Wi-Fi network is an iOS Personal Hotspot. 

I left the existing implementation in place, and added a new check for iOS since it seems like the previous implementation was working when tethered with an Android device.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

* #1884 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I updated this part of the code base because while I was working through an home Internet outage recently, a Vorta backup running in the background used up all of my allotted data on my mobile phone plan.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Automated tests were added and improved in the `network_manager.darwin` module.
* I ran a manual tests against a remote SSH repository.  I connected to a Personal Hotspot Wi-Fi, then tried to run a backup.  Vorta successfully detected the Hotspot connection and suppressed the backup with a status message for the user.

### Screenshots (if appropriate):

![Vorta Success Screenshot Redacted](https://github.com/borgbase/vorta/assets/68455/6395df35-56c8-4e92-a730-4e627fbc5135)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
