### PR TITLE
Add developer name to appdata

### DIFF
--- a/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
+++ b/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
@@ -2,6 +2,7 @@
 <component type="desktop-application">
   <id>com.borgbase.Vorta</id>
   <launchable type="desktop-id">com.borgbase.Vorta.desktop</launchable>
+  <developer_name>Vorta developers</developer_name>
   <name>Vorta</name>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
+++ b/src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>com.borgbase.Vorta</id>
   <launchable type="desktop-id">com.borgbase.Vorta.desktop</launchable>
-  <developer_name>Vorta developers</developer_name>
+  <developer_name>Vorta contributors</developer_name>
   <name>Vorta</name>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
Flathub is getting more and more strict when it comes to metadata. 
I've added "Vorta developers", I can also be more specific if people prefer that.
