### PR TITLE
Prevent exception while running BorgVersionJob with unexpected lines on stderr

### DIFF
--- a/src/vorta/borg/version.py
+++ b/src/vorta/borg/version.py
@@ -22,6 +22,7 @@ class BorgVersionJob(BorgJob):
             return ret
 
         ret['cmd'] = ['borg', '--version']
+        ret['profile_name'] = 'default'
         ret['ok'] = True
         return ret
 


### PR DESCRIPTION
### Description
The borg job logic expects the `profile_name` key to be unconditionally present in the params if any data is received on stderr. This causes the BorgVersionJob (which didn’t set this param) to fail if any unexpected output – such as LD_PRELOAD warnings – in generated while running `borg --version`. This in turn causes Vorta to silently (other than an unrelated looking exception in the console output) fall back to assuming borg 1.1.0 as the borg version.

### Related Issue
Please don’t make me create an issue for this…

### Motivation and Context
Borg version detection currently silently fails in environments that have LD_PRELOAD set in a way to causes warnings to be emitted.

### How Has This Been Tested?
The change is pretty trivial, so I just tested with and without.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
