### PR TITLE
Multiselect directories

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar
 import psutil
 from PyQt6 import QtCore
 from PyQt6.QtCore import QFileInfo, QThread, pyqtSignal
-from PyQt6.QtWidgets import QApplication, QFileDialog, QSystemTrayIcon
+from PyQt6.QtWidgets import QApplication, QFileDialog, QSystemTrayIcon, QListView, QTreeView
 
 from vorta.borg._compatibility import BorgCompatibility
 from vorta.log import logger
@@ -172,6 +172,16 @@ def choose_file_dialog(parent, title, want_folder=True):
     dialog.setParent(parent, QtCore.Qt.WindowType.Sheet)
     if want_folder:
         dialog.setOption(QFileDialog.Option.ShowDirsOnly)
+        dialog.setFileMode(QFileDialog.FileMode.Directory)
+        dialog.setOption(QFileDialog.Option.DontUseNativeDialog, True)
+        list_view = dialog.findChild(QListView, "listView")
+        if list_view:
+            list_view.setSelectionMode(QListView.SelectionMode.MultiSelection)
+
+        tree_view = dialog.findChild(QTreeView)
+        if tree_view:
+            tree_view.setSelectionMode(QTreeView.SelectionMode.MultiSelection)
+
     return dialog
 
 

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -15,7 +15,13 @@ from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar
 import psutil
 from PyQt6 import QtCore
 from PyQt6.QtCore import QFileInfo, QThread, pyqtSignal
-from PyQt6.QtWidgets import QApplication, QFileDialog, QSystemTrayIcon, QListView, QTreeView
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QListView,
+    QSystemTrayIcon,
+    QTreeView,
+)
 
 from vorta.borg._compatibility import BorgCompatibility
 from vorta.log import logger

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -642,8 +642,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                     self.app.jobs_manager.add_job(job)
 
         dialog = choose_file_dialog(self, self.tr("Choose Mount Point"), want_folder=True)
-        dialog.filesSelected.connect(receive)
-        dialog.open()
+        if dialog.exec():
+            receive()
 
     def mount_result(self, result):
         if result['returncode'] == 0:
@@ -789,8 +789,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                         self._set_status(params['message'])
 
             dialog = choose_file_dialog(self, self.tr("Choose Extraction Point"), want_folder=True)
-            dialog.filesSelected.connect(receive)
-            dialog.open()
+            if dialog.exec():
+                receive()
 
         window = ExtractDialog(archive, model)
         self._toggle_all_buttons(True)

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -642,8 +642,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                     self.app.jobs_manager.add_job(job)
 
         dialog = choose_file_dialog(self, self.tr("Choose Mount Point"), want_folder=True)
-        if dialog.exec():
-            receive()
+        dialog.filesSelected.connect(receive)
+        dialog.open()
 
     def mount_result(self, result):
         if result['returncode'] == 0:
@@ -789,8 +789,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                         self._set_status(params['message'])
 
             dialog = choose_file_dialog(self, self.tr("Choose Extraction Point"), want_folder=True)
-            if dialog.exec():
-                receive()
+            dialog.filesSelected.connect(receive)
+            dialog.open()
 
         window = ExtractDialog(archive, model)
         self._toggle_all_buttons(True)

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -642,7 +642,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                     self.app.jobs_manager.add_job(job)
 
         dialog = choose_file_dialog(self, self.tr("Choose Mount Point"), want_folder=True)
-        dialog.open(receive)
+        if dialog.exec():
+            receive()
 
     def mount_result(self, result):
         if result['returncode'] == 0:
@@ -788,7 +789,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
                         self._set_status(params['message'])
 
             dialog = choose_file_dialog(self, self.tr("Choose Extraction Point"), want_folder=True)
-            dialog.open(receive)
+            if dialog.exec():
+                receive()
 
         window = ExtractDialog(archive, model)
         self._toggle_all_buttons(True)

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -72,8 +72,8 @@ class RepoWindow(AddRepoBase, AddRepoUI):
                 self.is_remote_repo = False
 
         dialog = choose_file_dialog(self, self.tr("Choose Location of Borg Repository"))
-        if dialog.exec():
-            receive()
+        dialog.filesSelected.connect(receive)
+        dialog.open()
 
     def use_remote_repo_action(self):
         self.repoURL.setText('')

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -72,8 +72,8 @@ class RepoWindow(AddRepoBase, AddRepoUI):
                 self.is_remote_repo = False
 
         dialog = choose_file_dialog(self, self.tr("Choose Location of Borg Repository"))
-        dialog.filesSelected.connect(receive)
-        dialog.open()
+        if dialog.exec():
+            receive()
 
     def use_remote_repo_action(self):
         self.repoURL.setText('')

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -72,7 +72,8 @@ class RepoWindow(AddRepoBase, AddRepoUI):
                 self.is_remote_repo = False
 
         dialog = choose_file_dialog(self, self.tr("Choose Location of Borg Repository"))
-        dialog.open(receive)
+        if dialog.exec():
+            receive()
 
     def use_remote_repo_action(self):
         self.repoURL.setText('')

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -302,8 +302,8 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
 
         msg = self.tr("Choose directory to back up") if want_folder else self.tr("Choose file(s) to back up")
         dialog = choose_file_dialog(self, msg, want_folder=want_folder)
-        dialog.filesSelected.connect(receive)
-        dialog.open()
+        if dialog.exec():
+            receive()
 
     def source_copy(self, index=None):
         """

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -302,7 +302,8 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
 
         msg = self.tr("Choose directory to back up") if want_folder else self.tr("Choose file(s) to back up")
         dialog = choose_file_dialog(self, msg, want_folder=want_folder)
-        dialog.open(receive)
+        if dialog.exec():
+            receive(dialog)
 
     def source_copy(self, index=None):
         """

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -302,8 +302,8 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
 
         msg = self.tr("Choose directory to back up") if want_folder else self.tr("Choose file(s) to back up")
         dialog = choose_file_dialog(self, msg, want_folder=want_folder)
-        if dialog.exec():
-            receive(dialog)
+        dialog.filesSelected.connect(receive)
+        dialog.open()
 
     def source_copy(self, index=None):
         """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -189,7 +189,7 @@ def choose_file_dialog(tmpdir):
 
         def open(self, func):
             func()
-        
+
         def exec(self):
             return 1
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -189,6 +189,9 @@ def choose_file_dialog(tmpdir):
 
         def open(self, func):
             func()
+        
+        def exec(self):
+            return 1
 
         def selectedFiles(self):
             if self.subdirectory:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -85,7 +85,7 @@ def choose_file_dialog(*args):
 
         def open(self, func):
             func()
-        
+
         def exec(self):
             return 1
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -85,6 +85,9 @@ def choose_file_dialog(*args):
 
         def open(self, func):
             func()
+        
+        def exec(self):
+            return 1
 
         def selectedFiles(self):
             return ['/tmp']

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -14,6 +14,9 @@ class MockFileDialog:
     def open(self, func):
         func()
 
+    def exec(self):
+        return 1
+
     def selectedFiles(self):
         return ['/tmp']
 


### PR DESCRIPTION
Multiselection of folders while selecting folders

### Description
In the source, multiple folders cant be selected, due to some limitations in QFileDialog. This pull request solves and allows multiselection of folder everywhere where folders need to be selected
Fixes #1869 

### Motivation and Context
It would be more convenient if one can select multiple directories in one go, not having to open add folder dialog window multiple time, saving previous time and clicks.

### How Has This Been Tested?
By running them locally in my system. No actual tests edited so far.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
