### PR TITLE
Notify after post_backup_tasks #1632

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -430,16 +430,32 @@ class VortaScheduler(QtCore.QObject):
         profile_id = result['params']['profile'].id
 
         if result['returncode'] in [0, 1]:
-            notifier.deliver(
-                self.tr('Vorta Backup'),
-                self.tr('Backup successful for %s.') % profile_name,
-                level='info',
-            )
-            logger.info('Backup creation successful.')
-            # unpause scheduler
-            self.unpause(result['params']['profile_id'])
+            try:
+                notifier.deliver(
+                    self.tr('Vorta Backup'),
+                    self.tr('Backup successful for %s.') % profile_name,
+                    level='info',
+                )
+                logger.info('Backup creation successful.')
+                # unpause scheduler
+                self.unpause(result['params']['profile_id'])
 
-            self.post_backup_tasks(profile_id)
+                self.post_backup_tasks(profile_id)
+                # Notify after successful post_backup_tasks
+                notifier.deliver(
+                    self.tr('Vorta Backup'),
+                    self.tr('Post Backup Tasks successful for %s' % profile_id),
+                    level='info',
+                )
+                logger.info('Post Backup Tasks successful for %s' % profile_id)
+            
+            except Exception as e:
+                # Handle exceptions if post_backup_tasks fails
+                notifier.deliver(
+                    self.tr('Vorta Backup'),
+                    self.tr('Error during post backup tasks for %s.') % profile_name,
+                    level='error',
+                )
         else:
             notifier.deliver(
                 self.tr('Vorta Backup'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Made changes to notify function to deliver notifications based on the status of post_backup_tasks. Post Backup Tasks include pruning as well as BorgCheckJob(data consistency check)  as referred to in the issue.  This way user isnt spammed with different notifications and still notified for post backup jobs
### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1632 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A notification for when post backup jobs were completed, earlier only a log for completion of these jobs was delivered. Now a status based notification is delivered
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Backups were scheduled and after completion of post_backup_jobs expected notifications were delivered. 

### Screenshots (if appropriate):
![WhatsApp Image 2024-02-22 at 00 31 18](https://github.com/borgbase/vorta/assets/72215253/325f9cce-a338-4713-bf64-4663880c1167)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
