### PR TITLE
Invalidate `smb://` URLs #1631

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -530,3 +530,190 @@ def search(key, iterable: Iterable, func: Callable = None) -> Tuple[int, Any]:
             return i, item
 
     return None
+
+
+class Location:
+    """Object representing a repository location"""
+
+    # user must not contain "@", ":" or "/".
+    # Quoting adduser error message:
+    # "To avoid problems, the username should consist only of letters, digits,
+    # underscores, periods, at signs and dashes, and not start with a dash
+    # (as defined by IEEE Std 1003.1-2001)."
+    # We use "@" as separator between username and hostname, so we must
+    # disallow it within the pure username part.
+    optional_user_re = r"""
+        (?:(?P<user>[^@:/]+)@)?
+    """
+
+    # path must not contain :: (it ends at :: or string end), but may contain single colons.
+    # to avoid ambiguities with other regexes, it must also not start with ":" nor with "//" nor with "ssh://".
+    local_path_re = r"""
+        (?!(:|//|ssh://|socket://|smb://))                         # not starting with ":" or // or ssh:// or socket://
+        (?P<path>([^:]|(:(?!:)))+)                          # any chars, but no "::"
+        """
+
+    # file_path must not contain :: (it ends at :: or string end), but may contain single colons.
+    # it must start with a / and that slash is part of the path.
+    file_path_re = r"""
+        (?P<path>(([^/]*)/([^:]|(:(?!:)))+))                # start opt. servername, then /, then any chars, but no "::"
+        """
+
+    # abs_path must not contain :: (it ends at :: or string end), but may contain single colons.
+    # it must start with a / and that slash is part of the path.
+    abs_path_re = r"""
+        (?P<path>(/([^:]|(:(?!:)))+))                       # start with /, then any chars, but no "::"
+        """
+
+    # host NAME, or host IP ADDRESS (v4 or v6, v6 must be in square brackets)
+    host_re = r"""
+        (?P<host>(
+            (?!\[)[^:/]+(?<!\])     # hostname or v4 addr, not containing : or / (does not match v6 addr: no brackets!)
+            |
+            \[[0-9a-fA-F:.]+\])     # ipv6 address in brackets
+        )
+    """
+
+    # regexes for misc. kinds of supported location specifiers:
+    ssh_re = re.compile(
+        r"""
+        (?P<proto>ssh)://                                       # ssh://
+        """
+        + optional_user_re
+        + host_re
+        + r"""                 # user@  (optional), host name or address
+        (?::(?P<port>\d+))?                                     # :port (optional)
+        """
+        + abs_path_re,
+        re.VERBOSE,
+    )  # path
+
+    socket_re = re.compile(
+        r"""
+        (?P<proto>socket)://                                    # socket://
+        """
+        + abs_path_re,
+        re.VERBOSE,
+    )  # path
+
+    file_re = re.compile(
+        r"""
+        (?P<proto>file)://                                      # file://
+        """
+        + file_path_re,
+        re.VERBOSE,
+    )  # servername/path or path
+
+    local_re = re.compile(local_path_re, re.VERBOSE)  # local path
+
+    win_file_re = re.compile(
+        r"""
+        (?:file://)?                                        # optional file protocol
+        (?P<path>
+            (?:[a-zA-Z]:)?                                  # Drive letter followed by a colon (optional)
+            (?:[^:]+)                                       # Anything which does not contain a :, at least one char
+        )
+        """,
+        re.VERBOSE,
+    )
+
+    def __init__(self, text="", overrides={}, other=False):
+        self.repo_env_var = "BORG_OTHER_REPO" if other else "BORG_REPO"
+        self.valid = False
+        self.proto = None
+        self.user = None
+        self._host = None
+        self.port = None
+        self.path = None
+        self.raw = None
+        self.processed = None
+        self.parse(text, overrides)
+
+    def parse(self, text, overrides={}):
+        if not text:
+            # we did not get a text to parse, so we try to fetch from the environment
+            text = os.environ.get(self.repo_env_var)
+            if text is None:
+                return
+
+        self.raw = text  # as given by user, might contain placeholders
+        # self.processed = replace_placeholders(self.raw, overrides)  # after placeholder replacement
+        valid = self._parse(text)
+        if valid:
+            self.valid = True
+        else:
+            self.valid = False
+
+    def _parse(self, text):
+        def normpath_special(p):
+            # avoid that normpath strips away our relative path hack and even makes p absolute
+            relative = p.startswith("/./")
+            p = os.path.normpath(p)
+            return ("/." + p) if relative else p
+
+        m = self.ssh_re.match(text)
+        if m:
+            self.proto = m.group("proto")
+            self.user = m.group("user")
+            self._host = m.group("host")
+            self.port = m.group("port") and int(m.group("port")) or None
+            self.path = normpath_special(m.group("path"))
+            return True
+        m = self.file_re.match(text)
+        if m:
+            self.proto = m.group("proto")
+            self.path = normpath_special(m.group("path"))
+            return True
+        m = self.socket_re.match(text)
+        if m:
+            self.proto = m.group("proto")
+            self.path = normpath_special(m.group("path"))
+            return True
+        m = self.local_re.match(text)
+        if m:
+            self.proto = "file"
+            self.path = normpath_special(m.group("path"))
+            return True
+
+        return False
+
+    def __str__(self):
+        items = [
+            "proto=%r" % self.proto,
+            "user=%r" % self.user,
+            "host=%r" % self.host,
+            "port=%r" % self.port,
+            "path=%r" % self.path,
+        ]
+        return ", ".join(items)
+
+    def __repr__(self):
+        return "Location(%s)" % self
+
+    @property
+    def host(self):
+        # strip square brackets used for IPv6 addrs
+        if self._host is not None:
+            return self._host.lstrip("[").rstrip("]")
+
+    def canonical_path(self):
+        if self.proto in ("file", "socket"):
+            return self.path
+        else:
+            if self.path and self.path.startswith("~"):
+                path = "/" + self.path  # /~/x = path x relative to home dir
+            elif self.path and not self.path.startswith("/"):
+                path = "/./" + self.path  # /./x = path x relative to cwd
+            else:
+                path = self.path
+            return "ssh://{}{}{}{}".format(
+                f"{self.user}@" if self.user else "",
+                self._host,  # needed for ipv6 addrs
+                f":{self.port}" if self.port else "",
+                path,
+            )
+
+
+def is_valid_url(url):
+    location = Location(url)
+    return True if location.valid else False

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -14,7 +14,13 @@ from vorta.borg.info_repo import BorgInfoRepoJob
 from vorta.borg.init import BorgInitJob
 from vorta.keyring.abc import VortaKeyring
 from vorta.store.models import RepoModel
-from vorta.utils import borg_compat, choose_file_dialog, get_asset, get_private_keys
+from vorta.utils import (
+    borg_compat,
+    choose_file_dialog,
+    get_asset,
+    get_private_keys,
+    is_valid_url,
+)
 from vorta.views.partials.password_input import PasswordInput, PasswordLineEdit
 from vorta.views.utils import get_colored_icon
 
@@ -102,6 +108,10 @@ class RepoWindow(AddRepoBase, AddRepoUI):
 
     def validate(self):
         """Pre-flight check for valid input and borg binary."""
+        if not is_valid_url(self.values['repo_url']):
+            self._set_status(self.tr('Please use a supported URL format.'))
+            return False
+
         if self.is_remote_repo and not re.match(r'.+:.+', self.values['repo_url']):
             self._set_status(self.tr('Please enter a valid repo URL or select a local path.'))
             return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Added logic from borg that validates the url against certain regex patterns. Borg code wont invalidate `smb://` urls, so introduced  change to one of the regex patterns
### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1631 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Additional check for Repository URL, as using `smb://` format resulted in crashes as per #1628 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
using `smb://` repository URLs gave an error like other unsupported ones

### Screenshots (if appropriate):
![a](https://github.com/borgbase/vorta/assets/72215253/97073910-70b4-4e28-b602-98b2275e5c46)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
