### PR TITLE
WIP: Reopen `addrepowindow` prefilled when adding repo fails

### DIFF
--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -15,6 +15,7 @@ from .models import (
     BackupProfileModel,
     EventLogModel,
     ExclusionModel,
+    FailedRepoModel,
     RepoModel,
     RepoPassword,
     SchemaVersion,
@@ -56,6 +57,7 @@ def init_db(con=None):
             EventLogModel,
             SchemaVersion,
             ExclusionModel,
+            FailedRepoModel,
         ]
     )
 

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -268,3 +268,15 @@ class BackupProfileMixin:
 
     def profile(self):
         return BackupProfileModel.get(id=self.window().current_profile.id)
+
+
+class FailedRepoModel(BaseModel):
+    """A single failed repo with unique URL."""
+
+    url = pw.CharField(unique=True)
+    name = pw.CharField(default='')
+    extra_borg_arguments = pw.CharField(default='')
+    ssh_key = pw.CharField(default='')
+
+    class Meta:
+        database = DB

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -94,6 +94,9 @@ class RepoWindow(AddRepoBase, AddRepoUI):
         if result['returncode'] == 0:
             self.added_repo.emit(result)
             self.accept()
+            # clear FailedRepoModel if adding repo succeeds
+            FailedRepoModel.delete().execute()
+
         else:
             self.save_failed_repo(
                 self.repoURL.text(),

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -13,7 +13,7 @@ from PyQt6.QtWidgets import (
 from vorta.borg.info_repo import BorgInfoRepoJob
 from vorta.borg.init import BorgInitJob
 from vorta.keyring.abc import VortaKeyring
-from vorta.store.models import RepoModel
+from vorta.store.models import FailedRepoModel, RepoModel
 from vorta.utils import borg_compat, choose_file_dialog, get_asset, get_private_keys
 from vorta.views.partials.password_input import PasswordInput, PasswordLineEdit
 from vorta.views.utils import get_colored_icon
@@ -36,6 +36,8 @@ class RepoWindow(AddRepoBase, AddRepoUI):
 
         self.saveButton = self.buttonBox.button(QDialogButtonBox.StandardButton.Ok)
         self.saveButton.setText(self.tr("Add"))
+
+        self.populate_from_failed_repo()
 
         self.buttonBox.rejected.connect(self.close)
         self.buttonBox.accepted.connect(self.run)
@@ -93,7 +95,44 @@ class RepoWindow(AddRepoBase, AddRepoUI):
             self.added_repo.emit(result)
             self.accept()
         else:
+            self.save_failed_repo(
+                self.repoURL.text(),
+                self.repoName.text(),
+                self.extraBorgArgumentsLineEdit.text(),
+                self.sshComboBox.currentText(),
+            )
             self._set_status(self.tr('Unable to add your repository.'))
+
+    def save_failed_repo(self, url, name, extraBorgArguments, sshKey):
+        # Check if there's already a failed repository entry in the database
+        failed_repo = FailedRepoModel.get_or_none()
+        if failed_repo is not None:
+            # Update details of the existing failed repository with the new information
+            failed_repo.url = url
+            failed_repo.name = name
+            failed_repo.extra_borg_arguments = extraBorgArguments
+            failed_repo.ssh_key = sshKey
+            failed_repo.save()
+        else:
+            # Create a new entry for the failed repository
+            failed_repo = FailedRepoModel.create(
+                url=url,
+                name=name,
+                extra_borg_arguments=extraBorgArguments,
+                ssh_key=sshKey,
+            )
+        return failed_repo
+
+    def populate_from_failed_repo(self):
+        failed_repo = FailedRepoModel.get_or_none()
+
+        if failed_repo is not None:
+            self.repoName.setText(failed_repo.name)
+            self.repoURL.setText(failed_repo.url)
+            self.extraBorgArgumentsLineEdit.setText(failed_repo.extra_borg_arguments)
+            ssh_index = self.sshComboBox.findData(failed_repo.ssh_key)
+            if ssh_index != -1:
+                self.sshComboBox.setCurrentIndex(ssh_index)
 
     def init_ssh_key(self):
         keys = get_private_keys()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The addRepoWindow now opens prefilled with RepoUrl, name and extraBorgArguments if adding repo fails. 
Does not save password due to security reasons, and Encryption because last saved value might no longer be supported on next run of vorta (in case user changes Borg version).

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #1757 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add Repo Window does not retain last inputs when adding the repo fails and needs to be filled again.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by making `process_result` method of `BorgInitJob` raise an error intentionally, to mimic failure in adding repo.
### Screenshots (if appropriate):
Adding new Repo (which fails):
![Screenshot from 2024-03-13 19-23-00](https://github.com/borgbase/vorta/assets/89853707/7e22fcd1-83f5-40b8-8564-ad73491cf344)
![Screenshot from 2024-03-13 19-23-07](https://github.com/borgbase/vorta/assets/89853707/6f9bb8fd-919a-4fbe-8a40-00f26286b00a)
`AddRepoWindow` opens prefilled next time:
![Screenshot from 2024-03-13 19-23-19](https://github.com/borgbase/vorta/assets/89853707/8a1e1513-360e-4f84-9707-cdd34c8cc9e6)
![Screenshot from 2024-03-13 19-23-26](https://github.com/borgbase/vorta/assets/89853707/5053affd-6de2-4ab9-98ec-7e157ada84fd)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
