### PR TITLE
Replacement of flake8 with Ruff

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@ b6a24debb78b953117a3f637db18942f370a4b85
 
 # Run pre-commit after adding ruff
 24e1dd5c561bc3da972e41e6fd61961f12a2fc9f
+
+# Apply ruff sort settings
+ba9f1bd3d77dbd0b9efeb1f2f91c743b97ec558e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: 3.11
           pre-commit: true
 
-      - name: Test formatting with Flake8, ruff and Black
+      - name: Test formatting with ruff and Black
         shell: bash
         run: make lint
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
           python-version: 3.11
           pre-commit: true
 
-      - name: Test formatting with ruff and Black
+      - name: Test formatting with ruff
         shell: bash
-        run: make lint
+        run: pre-commit run --all-files --show-diff-on-failure
 
   prepare-matrix:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,12 +56,6 @@ repos:
   #           py39,
   #         ]
 
-  # check pep8 conformity using flake8
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-
 # configuration for the pre-commit.ci bot
 # only relevant when actually using the bot
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,17 +29,19 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.257"
+    rev: v0.7.0
     hooks:
+      # Run the linter.
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+      # Run the formatter.
+      - id: ruff-format
 
   # format python files
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black
-        files: ^(src/vorta/|tests)
+  # - repo: https://github.com/psf/black
+  #   rev: 22.12.0
+  #   hooks:
+  #     - id: black
+  #       files: ^(src/vorta/|tests)
 
   # # run black on code embedded in docstrings
   # - repo: https://github.com/asottile/blacken-docs

--- a/package/fix_app_qt_folder_names_for_codesign.py
+++ b/package/fix_app_qt_folder_names_for_codesign.py
@@ -11,6 +11,7 @@ import shutil
 import sys
 from pathlib import Path
 from typing import Generator, List, Optional
+
 from macholib.MachO import MachO
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 select = ["T", "I"]
-exclude = ["package"]
 fixable = ["I"]
+line-length = 120
+exclude = ["package", "build", "dist", ".git", ".idea", ".cache", ".tox", ".eggs", "./src/vorta/__init__.py", ".direnv", "env"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,23 @@
-[tool.black]
-line-length = 120
-skip-string-normalization = true
-target-version = ['py39']
-include = "(src/vorta/|tests).*.py$"
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-select = ["T", "I"]
-fixable = ["I"]
 line-length = 120
-exclude = ["package", "build", "dist", ".git", ".idea", ".cache", ".tox", ".eggs", "./src/vorta/__init__.py", ".direnv", "env"]
+# exclude = ["package", "build", "dist", ".git", ".idea", ".cache", ".tox", ".eggs", "./src/vorta/__init__.py", ".direnv", "env"]
+include = ["src/**/*.py", "tests/**/*.py"]
+
+[tool.ruff.lint]
+select = [
+    "E",  # Error
+    "F",  # pyflakes
+    "I",  # isort
+    "W",  # Warning
+    "YTT", # flake8-2020
+]
+ignore = [
+    "F401",
+]
+
+[tool.ruff.format]
+quote-style = "preserve"

--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -1,6 +1,5 @@
 black==22.*
 coverage
-flake8
 macholib
 nox
 pkgconfig

--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -3,7 +3,6 @@ coverage
 flake8
 macholib
 nox
-peewee
 pkgconfig
 pre-commit
 pyinstaller

--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -3,6 +3,7 @@ coverage
 flake8
 macholib
 nox
+peewee
 pkgconfig
 pre-commit
 pyinstaller

--- a/requirements.d/dev.txt
+++ b/requirements.d/dev.txt
@@ -1,4 +1,3 @@
-black==22.*
 coverage
 macholib
 nox

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,0 @@
-line-length = 120
-exclude = ["build", "dist", ".git", ".idea", ".cache", ".tox", ".eggs", "./src/vorta/__init__.py", ".direnv", "env"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+line-length = 120
+exclude = ["build", "dist", ".git", ".idea", ".cache", ".tox", ".eggs", "./src/vorta/__init__.py", ".direnv", "env"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,16 +72,8 @@ source = vorta
 omit = tests/*
 relative_files = true
 
-[flake8]
-ignore =
-max-line-length = 120
-extend-ignore = E203,E121,E123,E126,E226,E24,E704,W503,W504
-exclude =
-    build,dist,.git,.idea,.cache,.tox,.eggs,
-    ./src/vorta/__init__.py,.direnv,env
-
 [tox:tox]
-envlist = py36,py37,py38,flake8
+envlist = py36,py37,py38,ruff
 skip_missing_interpreters = true
 
 [testenv]
@@ -92,10 +84,10 @@ deps =
 commands=pytest
 passenv = DISPLAY
 
-[testenv:flake8]
+[testenv:ruff]
 deps =
-    flake8
-commands=flake8 src tests
+    ruff
+commands=ruff check src tests
 
 [pycodestyle]
 max_line_length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ omit = tests/*
 relative_files = true
 
 [tox:tox]
-envlist = py36,py37,py38,ruff
+envlist = py36,py37,py38
 skip_missing_interpreters = true
 
 [testenv]

--- a/src/vorta/assets/exclusion_presets/browsers.json
+++ b/src/vorta/assets/exclusion_presets/browsers.json
@@ -135,7 +135,7 @@
         ],
         "tags": ["application:firefox", "type:browser", "os:linux"],
         "author": "Divi, Renner0E"
-    }
+    },
     {
         "name": "Mozilla Firefox Snap cache and config files",
         "slug": "firefox-snap-cache",

--- a/src/vorta/autostart.py
+++ b/src/vorta/autostart.py
@@ -31,7 +31,6 @@ def open_app_at_startup(enabled=True):
     while on Linux it adds a .desktop file at ~/.config/autostart
     """
     if sys.platform == 'darwin':
-
         url = NSURL.alloc().initFileURLWithPath_(APP_PATH)
         login_items = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, None)
         props = NSDictionary.dictionaryWithObject_forKey_(True, kLSSharedFileListItemHidden)

--- a/src/vorta/borg/init.py
+++ b/src/vorta/borg/init.py
@@ -10,7 +10,6 @@ class BorgInitJob(BorgJob):
 
     @classmethod
     def prepare(cls, params):
-
         # Build fake profile because we don't have it in the DB yet.
         profile = FakeProfile(
             999,

--- a/src/vorta/i18n/__init__.py
+++ b/src/vorta/i18n/__init__.py
@@ -1,6 +1,7 @@
 """
 internationalisation (i18n) support code
 """
+
 import logging
 import os
 

--- a/src/vorta/keyring/darwin.py
+++ b/src/vorta/keyring/darwin.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 """
 A dirty objc implementation to access the macOS Keychain. Because the
@@ -10,8 +10,10 @@ Adapted from https://gist.github.com/apettinen/5dc7bf1f6a07d148b2075725db6b1950
 import logging
 import sys
 from ctypes import c_char
+
 import objc
 from Foundation import NSBundle
+
 from .abc import VortaKeyring
 
 logger = logging.getLogger(__name__)
@@ -47,14 +49,14 @@ class VortaDarwinKeyring(VortaKeyring):
 
         objc.loadBundleFunctions(Security, globals(), S_functions)
 
-        SecKeychainRef = objc.registerCFSignature('SecKeychainRef', b'^{OpaqueSecKeychainRef=}', SecKeychainGetTypeID())
-        SecKeychainItemRef = objc.registerCFSignature(
+        objc.registerCFSignature('SecKeychainRef', b'^{OpaqueSecKeychainRef=}', SecKeychainGetTypeID())
+        objc.registerCFSignature(
             'SecKeychainItemRef',
             b'^{OpaqueSecKeychainItemRef=}',
             SecKeychainItemGetTypeID(),
         )
 
-        PassBuffRef = objc.createOpaquePointerType('PassBuffRef', b'^{OpaquePassBuff=}', None)
+        objc.createOpaquePointerType('PassBuffRef', b'^{OpaquePassBuff=}', None)
 
         # Get the login keychain
         result, login_keychain = SecKeychainOpen(b'login.keychain', None)

--- a/src/vorta/keyring/darwin.py
+++ b/src/vorta/keyring/darwin.py
@@ -7,6 +7,7 @@ objc modules.
 
 Adapted from https://gist.github.com/apettinen/5dc7bf1f6a07d148b2075725db6b1950
 """
+
 import logging
 import sys
 from ctypes import c_char
@@ -83,7 +84,12 @@ class VortaDarwinKeyring(VortaKeyring):
         if not self.login_keychain:
             self._set_keychain()
 
-        (result, password_length, password_buffer, keychain_item,) = SecKeychainFindGenericPassword(
+        (
+            result,
+            password_length,
+            password_buffer,
+            keychain_item,
+        ) = SecKeychainFindGenericPassword(
             self.login_keychain,
             len(service),
             service.encode(),

--- a/src/vorta/qt_single_application.py
+++ b/src/vorta/qt_single_application.py
@@ -40,7 +40,6 @@ class QtSingleApplication(QApplication):
     message_received_event = pyqtSignal(str)
 
     def __init__(self, id, *argv):
-
         super().__init__(*argv)
         self._id = id
 

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -469,7 +469,6 @@ def extract_mount_points_v1(proc, repo_url):
 
     for idx, parameter in enumerate(proc.cmdline()):
         if parameter.startswith(repo_url):
-
             if len(proc.cmdline()) > idx + 1:
                 mount_point = proc.cmdline()[idx + 1]
 

--- a/src/vorta/views/exclude_dialog.py
+++ b/src/vorta/views/exclude_dialog.py
@@ -154,7 +154,7 @@ class ExcludeDialog(ExcludeDialogBase, ExcludeDialogUi):
             .order_by(ExclusionModel.name)
         }
 
-        for (exclude, enabled) in user_excluded_patterns.items():
+        for exclude, enabled in user_excluded_patterns.items():
             item = QStandardItem(exclude)
             item.setCheckable(True)
             item.setCheckState(Qt.CheckState.Checked if enabled else Qt.CheckState.Unchecked)

--- a/src/vorta/views/partials/treemodel.py
+++ b/src/vorta/views/partials/treemodel.py
@@ -909,12 +909,10 @@ class FileTreeSortProxyModel(QSortFilterProxyModel):
         self.folders_on_top = False
 
     @overload
-    def keepFoldersOnTop(self) -> bool:
-        ...
+    def keepFoldersOnTop(self) -> bool: ...
 
     @overload
-    def keepFoldersOnTop(self, value: bool) -> bool:
-        ...
+    def keepFoldersOnTop(self, value: bool) -> bool: ...
 
     def keepFoldersOnTop(self, value=None) -> bool:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,11 @@ import os
 import sys
 
 import pytest
+from peewee import SqliteDatabase
+
 import vorta
 import vorta.application
 import vorta.borg.jobs_manager
-from peewee import SqliteDatabase
 
 
 def pytest_configure(config):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,11 +2,12 @@ import os
 import subprocess
 
 import pytest
+from peewee import SqliteDatabase
+from pkg_resources import parse_version
+
 import vorta
 import vorta.application
 import vorta.borg.jobs_manager
-from peewee import SqliteDatabase
-from pkg_resources import parse_version
 from vorta.store.models import (
     ArchiveModel,
     BackupProfileModel,

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -7,10 +7,11 @@ from collections import namedtuple
 
 import psutil
 import pytest
+from PyQt6 import QtCore
+
 import vorta.borg
 import vorta.utils
 import vorta.views.archive_tab
-from PyQt6 import QtCore
 from vorta.store.models import ArchiveModel
 
 

--- a/tests/integration/test_borg.py
+++ b/tests/integration/test_borg.py
@@ -5,6 +5,7 @@ This file contains tests that directly call borg commands and verify the exit co
 from pathlib import Path
 
 import pytest
+
 import vorta.borg
 import vorta.store.models
 from vorta.borg.info_archive import BorgInfoArchiveJob

--- a/tests/integration/test_diff.py
+++ b/tests/integration/test_diff.py
@@ -3,10 +3,11 @@ These tests compare the output of the diff command with the expected output.
 """
 
 import pytest
+from pkg_resources import parse_version
+
 import vorta.borg
 import vorta.utils
 import vorta.views.archive_tab
-from pkg_resources import parse_version
 from vorta.borg.diff import BorgDiffJob
 from vorta.views.diff_result import (
     ChangeType,

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -6,11 +6,12 @@ import os
 from pathlib import PurePath
 
 import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QMessageBox
+
 import vorta.borg
 import vorta.utils
 import vorta.views.repo_add_dialog
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QMessageBox
 
 LONG_PASSWORD = 'long-password-long'
 TEST_REPO_NAME = 'TEST - REPONAME'

--- a/tests/integration/test_repo.py
+++ b/tests/integration/test_repo.py
@@ -4,6 +4,7 @@ Test backup creation
 
 import pytest
 from PyQt6 import QtCore
+
 from vorta.store.models import ArchiveModel, EventLogModel
 
 

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from vorta.network_status import darwin
 
 

--- a/tests/network_manager/test_network_manager.py
+++ b/tests/network_manager/test_network_manager.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
+
 from vorta.network_status.abc import SystemWifiInfo
 from vorta.network_status.network_manager import (
     ActiveConnectionInfo,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,10 +2,11 @@ import os
 from datetime import datetime as dt
 
 import pytest
+from peewee import SqliteDatabase
+
 import vorta
 import vorta.application
 import vorta.borg.jobs_manager
-from peewee import SqliteDatabase
 from vorta.store.models import (
     ArchiveModel,
     BackupProfileModel,

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -2,11 +2,12 @@ from collections import namedtuple
 
 import psutil
 import pytest
+from PyQt6 import QtCore
+from PyQt6.QtWidgets import QMenu
+
 import vorta.borg
 import vorta.utils
 import vorta.views.archive_tab
-from PyQt6 import QtCore
-from PyQt6.QtWidgets import QMenu
 from vorta.store.models import ArchiveModel, BackupProfileModel
 
 

--- a/tests/unit/test_borg.py
+++ b/tests/unit/test_borg.py
@@ -1,4 +1,5 @@
 import pytest
+
 import vorta.borg
 import vorta.store.models
 from vorta.borg.prune import BorgPruneJob

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -1,11 +1,12 @@
 from pathlib import PurePath
 
 import pytest
+from PyQt6.QtCore import QDateTime, QItemSelectionModel, Qt
+from PyQt6.QtWidgets import QMenu
+
 import vorta.borg
 import vorta.utils
 import vorta.views.archive_tab
-from PyQt6.QtCore import QDateTime, QItemSelectionModel, Qt
-from PyQt6.QtWidgets import QMenu
 from vorta.store.models import ArchiveModel
 from vorta.views.diff_result import (
     ChangeType,

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -1,6 +1,7 @@
 import pytest
-import vorta.borg
 from PyQt6.QtCore import QModelIndex, Qt
+
+import vorta.borg
 from vorta.store.models import ArchiveModel
 from vorta.views.extract_dialog import (
     ExtractDialog,

--- a/tests/unit/test_import_export.py
+++ b/tests/unit/test_import_export.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import QDialogButtonBox, QFileDialog, QMessageBox
+
 from vorta.profile_export import VersionException
 from vorta.store.models import BackupProfileModel, SourceFileModel
 from vorta.views.import_window import ImportWindow

--- a/tests/unit/test_lock.py
+++ b/tests/unit/test_lock.py
@@ -1,7 +1,8 @@
 import pytest
+from PyQt6 import QtCore
+
 import vorta.application
 import vorta.borg.borg_job
-from PyQt6 import QtCore
 
 
 def test_create_perm_error(qapp, borg_json_output, mocker, qtbot):

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -4,10 +4,11 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-import vorta.store.models
 from PyQt6 import QtCore
 from PyQt6.QtGui import QCloseEvent
 from PyQt6.QtWidgets import QCheckBox, QFormLayout, QMessageBox
+
+import vorta.store.models
 from vorta.store.models import SettingsModel
 
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,9 +1,10 @@
 import sys
 
 import pytest
+from PyQt6 import QtDBus
+
 import vorta.borg
 import vorta.notifications
-from PyQt6 import QtDBus
 
 
 @pytest.mark.skipif(sys.platform != 'linux', reason="DBus notifications only on Linux")

--- a/tests/unit/test_password_input.py
+++ b/tests/unit/test_password_input.py
@@ -1,5 +1,6 @@
 import pytest
 from PyQt6.QtWidgets import QFormLayout, QWidget
+
 from vorta.views.partials.password_input import PasswordInput, PasswordLineEdit
 
 

--- a/tests/unit/test_profile.py
+++ b/tests/unit/test_profile.py
@@ -2,6 +2,7 @@ import tempfile
 
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import QDialogButtonBox, QFileDialog, QMessageBox, QToolTip
+
 from vorta.store.models import BackupProfileModel, SourceFileModel
 from vorta.views.export_window import ExportWindow
 

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -3,9 +3,10 @@ import uuid
 from typing import Any, Dict
 
 import pytest
-import vorta.borg.borg_job
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import QMessageBox
+
+import vorta.borg.borg_job
 from vorta.keyring.abc import VortaKeyring
 from vorta.store.models import ArchiveModel, EventLogModel, RepoModel
 

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -3,8 +3,9 @@ from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
-import vorta.scheduler
 from PyQt6 import QtCore
+
+import vorta.scheduler
 from vorta.application import VortaApp
 from vorta.store.models import BackupProfileModel, EventLogModel
 

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -4,9 +4,10 @@ from functools import wraps
 from unittest.mock import MagicMock
 
 import pytest
+from pytest import mark
+
 import vorta.borg
 import vorta.scheduler
-from pytest import mark
 from vorta.scheduler import ScheduleStatus, ScheduleStatusType, VortaScheduler
 from vorta.store.models import BackupProfileModel, EventLogModel
 

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -1,7 +1,8 @@
 import pytest
-import vorta.views
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import QMessageBox
+
+import vorta.views
 from vorta.views.main_window import MainWindow
 from vorta.views.source_tab import SourceTab
 

--- a/tests/unit/test_treemodel.py
+++ b/tests/unit/test_treemodel.py
@@ -2,6 +2,7 @@ from pathlib import PurePath
 
 import pytest
 from PyQt6.QtCore import QModelIndex
+
 from vorta.views.partials.treemodel import FileSystemItem, FileTreeModel
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,6 +2,7 @@ import sys
 import uuid
 
 import pytest
+
 from vorta.keyring.abc import VortaKeyring
 from vorta.utils import (
     find_best_unit_for_sizes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This PR removes flake8 from `.pre-commit-config.yaml` , `setup.cfg` and adds ruff for linting

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #1969 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ruff is faster so yeah...

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested, `pre-commit`, `make lint` works fine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
