### PR TITLE
Compaction Scheduling

### DIFF
--- a/src/vorta/assets/UI/scheduletab.ui
+++ b/src/vorta/assets/UI/scheduletab.ui
@@ -443,6 +443,116 @@
              </item>
             </layout>
            </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="compaction_label">
+             <property name="text">
+              <string>Compaction:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <layout class="QVBoxLayout" name="verticalLayout_7">
+             <property name="spacing">
+              <number>4</number>
+             </property>
+             <property name="topMargin">
+              <number>4</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="compactionCheckBox">
+               <property name="text">
+                <string>Compact repository</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+            <widget class="QFrame" name="frameCompaction">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <layout class="QHBoxLayout" name="layoutCompaction">
+                <property name="spacing">
+                 <number>4</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <spacer name="horizontalSpacer_8">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="interval_label">
+                  <property name="text">
+                   <string>Interval:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_interval">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>4</width>
+                    <height>1</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="compactionWeeksCount">
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <number>52</number>
+                  </property>
+                  <property name="value">
+                   <number>3</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="compaction_weeks_label">
+                  <property name="text">
+                   <string>weeks</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </item>
            <item row="1" column="1">
             <spacer name="verticalSpacer_4">
              <property name="orientation">

--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -24,7 +24,7 @@ from .models import (
 )
 from .settings import get_misc_settings
 
-SCHEMA_VERSION = 22
+SCHEMA_VERSION = 23
 
 
 @signals.post_save(sender=SettingsModel)

--- a/src/vorta/store/migrations.py
+++ b/src/vorta/store/migrations.py
@@ -248,6 +248,12 @@ def run_migrations(current_schema, db_connection):
                 'name',
                 pw.CharField(default=''),
             ),
+        )
+
+    if current_schema.version < 23:
+        _apply_schema_update(
+            current_schema,
+            23,
             migrator.add_column(
                 BackupProfileModel._meta.table_name,
                 'compaction_on',

--- a/src/vorta/store/migrations.py
+++ b/src/vorta/store/migrations.py
@@ -248,6 +248,16 @@ def run_migrations(current_schema, db_connection):
                 'name',
                 pw.CharField(default=''),
             ),
+            migrator.add_column(
+                BackupProfileModel._meta.table_name,
+                'compaction_on',
+                pw.BooleanField(default=True),
+            ),
+            migrator.add_column(
+                BackupProfileModel._meta.table_name,
+                'compaction_weeks',
+                pw.IntegerField(default=3),
+            ),
         )
 
 

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -90,6 +90,8 @@ class BackupProfileModel(BaseModel):
     schedule_make_up_missed = pw.BooleanField(default=True)
     validation_on = pw.BooleanField(default=True)
     validation_weeks = pw.IntegerField(default=3)
+    compaction_on = pw.BooleanField(default=True)
+    compaction_weeks = pw.IntegerField(default=3)
     prune_on = pw.BooleanField(default=False)
     prune_hour = pw.IntegerField(default=2)
     prune_day = pw.IntegerField(default=7)

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -90,7 +90,7 @@ class BackupProfileModel(BaseModel):
     schedule_make_up_missed = pw.BooleanField(default=True)
     validation_on = pw.BooleanField(default=True)
     validation_weeks = pw.IntegerField(default=3)
-    compaction_on = pw.BooleanField(default=True)
+    compaction_on = pw.BooleanField(default=False)
     compaction_weeks = pw.IntegerField(default=3)
     prune_on = pw.BooleanField(default=False)
     prune_hour = pw.IntegerField(default=2)

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -63,10 +63,13 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.framePeriodic.setEnabled(False)
         self.frameDaily.setEnabled(False)
         self.frameValidation.setEnabled(False)
+        self.frameCompaction.setEnabled(False)
 
         self.scheduleIntervalRadio.toggled.connect(self.framePeriodic.setEnabled)
         self.scheduleFixedRadio.toggled.connect(self.frameDaily.setEnabled)
         self.validationCheckBox.toggled.connect(self.frameValidation.setEnabled)
+        self.compactionCheckBox.toggled.connect(self.frameCompaction.setEnabled)
+
 
         # POPULATE with data
         self.populate_from_profile()
@@ -104,6 +107,12 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         )
         self.validationWeeksCount.valueChanged.connect(
             lambda new_val, attr='validation_weeks': self.save_profile_attr(attr, new_val)
+        )
+        self.compactionCheckBox.stateChanged.connect(
+            lambda new_val, attr='compaction_on': self.save_profile_attr(attr, new_val)
+        )
+        self.compactionWeeksCount.valueChanged.connect(
+            lambda new_val, attr='compaction_weeks': self.save_profile_attr(attr, new_val)
         )
 
         # Connect to schedule update
@@ -153,6 +162,12 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
             QtCore.Qt.CheckState.Checked if profile.validation_on else QtCore.Qt.CheckState.Unchecked
         )
         self.validationWeeksCount.setValue(profile.validation_weeks)
+
+        #set borg compact options
+        self.compactionCheckBox.setCheckState(
+            QtCore.Qt.CheckState.Checked if profile.compaction_on else QtCore.Qt.CheckState.Unchecked
+        )
+        self.compactionWeeksCount.setValue(profile.compaction_weeks)
 
         # Other checkbox options
         self.pruneCheckBox.setCheckState(

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -70,7 +70,6 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.validationCheckBox.toggled.connect(self.frameValidation.setEnabled)
         self.compactionCheckBox.toggled.connect(self.frameCompaction.setEnabled)
 
-
         # POPULATE with data
         self.populate_from_profile()
         self.set_icons()
@@ -163,7 +162,7 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         )
         self.validationWeeksCount.setValue(profile.validation_weeks)
 
-        #set borg compact options
+        # set borg compact options
         self.compactionCheckBox.setCheckState(
             QtCore.Qt.CheckState.Checked if profile.compaction_on else QtCore.Qt.CheckState.Unchecked
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Allows users to run `borg compact` after specified intervals. Added 2 columns to the profile model: `compaction_on` to check/uncheck scheduling, and `compaction_weeks` to set interval in weeks. Default interval set to 3 weeks.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #1718 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Backup space usage is exploding for some people until they realize they have to run compact manually. This allows users to schedule running compact just like validation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by setting `compaction_cutoff`  to minutes instead of days in `scheduler.py`.
### Screenshots (if appropriate):
![Screenshot from 2024-04-05 14-04-56](https://github.com/borgbase/vorta/assets/89853707/fc807f02-9066-4557-b6b2-63c0361d4d84)
![Screenshot from 2024-04-05 14-09-33](https://github.com/borgbase/vorta/assets/89853707/eac59a13-a609-45b6-9c80-d080d16a2549)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
