### PR TITLE
Keep the profile list sorted when creating/renaming profiles

### DIFF
--- a/src/vorta/tray_menu.py
+++ b/src/vorta/tray_menu.py
@@ -59,10 +59,10 @@ class TrayMenu(QSystemTrayIcon):
             cancel_action.triggered.connect(self.app.backup_cancelled_event.emit)
         else:
             status.setText(self.tr('Next Task: %s') % next_task_time)
-            profiles = BackupProfileModel.select().order_by(BackupProfileModel.name)
+            profiles = BackupProfileModel.select()
             if profiles.count() > 1:
                 profile_menu = menu.addMenu(self.tr('Backup Now'))
-                for profile in profiles:
+                for profile in sorted(profiles, key=lambda p: (p.name.casefold(), p.name)):
                     new_item = profile_menu.addAction(profile.name)
                     new_item.triggered.connect(lambda state, i=profile.id: self.app.create_backup_action(i))
             else:

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -284,13 +284,18 @@ class MainWindow(MainWindowBase, MainWindowUI):
     def profile_add_edit_result(self, profile_name, profile_id):
         # Profile is renamed
         if self.profileSelector.currentItem().data(Qt.ItemDataRole.UserRole) == profile_id:
-            self.profileSelector.currentItem().setText(profile_name)
+            profile = self.profileSelector.takeItem(self.profileSelector.currentRow())
+            profile.setText(profile_name)
         # Profile is added
         else:
             profile = QListWidgetItem(profile_name)
             profile.setData(Qt.ItemDataRole.UserRole, profile_id)
-            self.profileSelector.addItem(profile)
-            self.profileSelector.setCurrentItem(profile)
+        # Insert the profile at the correct position
+        row = len(
+            [i for i in range(self.profileSelector.count()) if self.profileSelector.item(i).text() < profile.text()]
+        )
+        self.profileSelector.insertItem(row, profile)
+        self.profileSelector.setCurrentItem(profile)
 
     def toggle_misc_visibility(self):
         if self.miscWidget.isVisible():

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -65,7 +65,8 @@ class MainWindow(MainWindowBase, MainWindowUI):
         prev_profile_id = SettingsModel.get(key='previous_profile_id')
         self.current_profile = BackupProfileModel.get_or_none(id=prev_profile_id.str_value)
         if self.current_profile is None:
-            self.current_profile = BackupProfileModel.select().order_by('name').first()
+            profiles = BackupProfileModel.select()
+            self.current_profile = min(profiles, key=lambda p: (p.name.casefold(), p.name))
 
         # Load tab models
         self.repoTab = RepoTab(self.repoTabSlot)
@@ -161,7 +162,8 @@ class MainWindow(MainWindowBase, MainWindowUI):
         current_item = None
 
         # Add items to the QListWidget
-        for profile in BackupProfileModel.select().order_by(BackupProfileModel.name):
+        profiles = BackupProfileModel.select()
+        for profile in sorted(profiles, key=lambda p: (p.name.casefold(), p.name)):
             item = QListWidgetItem(profile.name)
             item.setData(Qt.ItemDataRole.UserRole, profile.id)
 
@@ -291,9 +293,13 @@ class MainWindow(MainWindowBase, MainWindowUI):
             profile = QListWidgetItem(profile_name)
             profile.setData(Qt.ItemDataRole.UserRole, profile_id)
         # Insert the profile at the correct position
-        row = len(
-            [i for i in range(self.profileSelector.count()) if self.profileSelector.item(i).text() < profile.text()]
-        )
+        # Both the casefolded and the original name are used as the key to keep the order stable
+        profile_key = (profile.text().casefold(), profile.text())
+        row = 0
+        for i in range(self.profileSelector.count()):
+            item_name = self.profileSelector.item(i).text()
+            if (item_name.casefold(), item_name) < profile_key:
+                row += 1
         self.profileSelector.insertItem(row, profile)
         self.profileSelector.setCurrentItem(profile)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Creating a new profile adds the new profile at the bottom of the list in the main window. Similarly, editing an existing profile doesn't change its position in the list. This change keeps the list sorted alphabetically in both cases.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1983

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
