### PR TITLE
hide password field if encryption is none

### DIFF
--- a/src/vorta/views/partials/password_input.py
+++ b/src/vorta/views/partials/password_input.py
@@ -170,3 +170,9 @@ class PasswordInput(QObject):
         self.add_form_to_layout(form_layout)
         widget.setLayout(form_layout)
         return widget
+
+    def set_visibility(self, visible: bool) -> None:
+        self._label_password.setVisible(visible)
+        self._label_confirm.setVisible(visible)
+        self.passwordLineEdit.setVisible(visible)
+        self.confirmLineEdit.setVisible(visible)

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -199,8 +199,10 @@ class AddRepoWindow(RepoWindow):
         '''Validates passwords only if its going to be used'''
         if self.values['encryption'] == 'none':
             self.passwordInput.set_validation_enabled(False)
+            self.passwordInput.set_visibility(False)
         else:
             self.passwordInput.set_validation_enabled(True)
+            self.passwordInput.set_visibility(True)
 
     def display_backend_warning(self):
         '''Display password backend message based off current keyring'''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Hides the password fields in repo_add_dialog if _Advanced > Encryption: None_
### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> #1995 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Helps avoid confusion if a password is needed or not.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by me locally.

### Screenshots (if appropriate):
![Screenshot from 2024-05-31 18-37-30](https://github.com/borgbase/vorta/assets/89853707/2c3bd19c-e928-4f73-bbc2-f48b8a623475)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
