### PR TITLE
palette_changed connection moved to schedule_tab

### DIFF
--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -65,8 +65,6 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
 
         self.app.scheduler.schedule_changed.connect(lambda pid: self.draw_next_scheduled_backup())
 
-        self.app.paletteChanged.connect(lambda p: self.set_icons())
-
     def on_scheduler_change(self, _):
         profile = self.profile()
         for label, obj in self.schedulerRadioMapping.items():

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -25,6 +25,7 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.init_shell_commands_page()
         self.init_networks_page()
         self.init_schedule_page()
+        self.app.paletteChanged.connect(lambda p: self.set_icons())
 
         self.app.backup_finished_event.connect(self.logPage.populate_logs)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Moved `palette_changed` connection from schedule_page.py to schedule_tab.py, where `set_icons()` is defined.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #2048 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Could not test as changing themes does not work on my system.
### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
