### PR TITLE
Fixed missing icons in GNOME Overview and GNOME Dock

### DIFF
--- a/src/vorta/assets/metadata/com.borgbase.Vorta.desktop
+++ b/src/vorta/assets/metadata/com.borgbase.Vorta.desktop
@@ -6,4 +6,4 @@ Type=Application
 Icon=com.borgbase.Vorta
 Categories=Utility;Archiving;Qt;
 Keywords=borg;
-StartupWMClass=vorta
+StartupWMClass=python3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
* Previous value didn't match the value of the running application
* With this mismatch the icons were not applied correctly in at least GNOME DE

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
Tested by setting the changes in the already installed app. Not tested by building the app.

### Screenshots (if appropriate):

### Types of changes
Added attribute to .desktop file

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
