### PR TITLE
Fix generic window icon on Wayland

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 
 from PyQt6 import QtCore, uic
@@ -47,6 +48,8 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.setWindowTitle('Vorta for Borg Backup')
         self.app = parent
         self.setWindowIcon(get_colored_icon("icon"))
+        if sys.platform.startswith('linux'):
+            self.app.setDesktopFileName('com.borgbase.Vorta')
         self.setWindowFlags(QtCore.Qt.WindowType.WindowCloseButtonHint | QtCore.Qt.WindowType.WindowMinimizeButtonHint)
         self.createStartBtn = LoadingButton(self.tr("Start Backup"))
         self.gridLayout.addWidget(self.createStartBtn, 0, 0, 1, 1)


### PR DESCRIPTION
Fix the main window icon on Wayland

### Description
On Wayland, calling `setWindowIcon()` to set the window icon is no longer supported, the correct way is to call `setDesktopFileName()` instead. The desktop file is then used to load the correct icon.

See https://doc.qt.io/qt-6/qguiapplication.html#desktopFileName-prop and https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon for more information.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/e9a11f8d-3c48-4b2d-b866-a5f341f0b99c)

After
![image](https://github.com/user-attachments/assets/82cb373e-7eb5-436f-afd8-44e4c0772cc5)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
