### PR TITLE
l10n - make string translatable (syntax fix)

### DIFF
--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -79,9 +79,7 @@ def get_misc_settings() -> List[Dict[str, str]]:
             'value': True,
             'type': 'checkbox',
             'group': security,
-            'label': trans_late(
-                'settings', "Store repository passwords in system keychain, if available"
-            ),
+            'label': trans_late('settings', 'Store repository passwords in system keychain, if available'),
             'tooltip': trans_late(
                 'settings', "Otherwise Vorta's configuration database stores the password in plaintext."
             ),

--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -80,8 +80,7 @@ def get_misc_settings() -> List[Dict[str, str]]:
             'type': 'checkbox',
             'group': security,
             'label': trans_late(
-                'settings',
-                'Store repository passwords in system keychain, if available',
+                'settings', "Store repository passwords in system keychain, if available"
             ),
             'tooltip': trans_late(
                 'settings', "Otherwise Vorta's configuration database stores the password in plaintext."


### PR DESCRIPTION
String is not appearing on Transifex, so tried to modify its form based on ones, which does.