### PR TITLE
Exclusion presets: add Firefox Snap Cache

### DIFF
--- a/src/vorta/assets/exclusion_presets/browsers.json
+++ b/src/vorta/assets/exclusion_presets/browsers.json
@@ -136,4 +136,27 @@
         "tags": ["application:firefox", "type:browser", "os:linux"],
         "author": "Divi, Renner0E"
     }
+    {
+        "name": "Mozilla Firefox Snap cache and config files",
+        "slug": "firefox-snap-cache",
+        "patterns": [
+            "fm:*/snap/firefox/common/.cache",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/pluginreg.dat",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/compreg.dat",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/xpti.dat",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/XUL.mfasl",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/XPC.mfasl",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/extensions.cache",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/extensions.ini",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/extensions.rdf",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/extensions.sqlite-journal",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/extensions.sqlite",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/blocklist.xml",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/urlclassifier3.sqlite",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/.parentlock",
+            "fm:*/snap/firefox/common/.mozilla/firefox/*/minidumps"
+        ],
+        "tags": ["application:firefox", "type:browser", "os:linux"],
+        "author": "chaikney"
+    }
 ]


### PR DESCRIPTION
### Description
I have taken the exclusions from the existing firefox set, and matched them with those files that exist in the Snap package. Based on the Snap in KDE Neon.
Only one file modified.

### Related Issue
(https://github.com/borgbase/vorta/issues/2085)

### Motivation and Context
The existing presets to exclude firefox cache files cover flatpaks but not Snaps. I added them manually to my own backup exclusions but I think they are probably more widely applicable.

### How Has This Been Tested?
Not in this format; the exclusions are those I use already and the formatting seems to be simple enough to not be very concerning. (Famous last words?)


### Screenshots (if appropriate):
N/A
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
