### PR TITLE
Fixes #2120 (plus changes to status info and tray icon active duration)

### DIFF
--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -53,7 +53,7 @@ class BorgCreateJob(BorgJob):
                 self.app.backup_log_event.emit('', {})
                 self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Backup finished.')}")
 
-    def progress_event(self, fmt=None):
+    def progress_event(self, fmt):
         self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {fmt}")
 
     def started_event(self):

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -301,7 +301,7 @@ class VortaScheduler(QtCore.QObject):
                             profile.name,
                             profile_id,
                         )
-                        self.create_backup(profile_id)
+                        threading.Thread(target=self.create_backup, args=(profile_id,)).start()
                     finally:
                         self.lock.acquire()  # with-statement will try to release
 
@@ -337,7 +337,7 @@ class VortaScheduler(QtCore.QObject):
                 timer = QTimer()
                 timer.setSingleShot(True)
                 timer.setInterval(int(timer_ms))
-                timer.timeout.connect(lambda: self.create_backup(profile_id))
+                timer.timeout.connect(lambda: threading.Thread(target=self.create_backup, args=(profile_id,)).start())
                 timer.start()
 
                 self.timers[profile_id] = {
@@ -410,7 +410,7 @@ class VortaScheduler(QtCore.QObject):
                 self.tr('Starting background backup for %s.') % profile.name,
                 level='info',
             )
-            msg = BorgCreateJob.prepare(profile)
+            msg = BorgCreateJob.prepare(profile, app=self.app)
             if msg['ok']:
                 logger.info('Preparation for backup successful.')
                 msg['category'] = 'scheduled'

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -88,7 +88,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.miscTab.refresh_archive.connect(self.archiveTab.populate_from_profile)
 
         self.miscButton.clicked.connect(self.toggle_misc_visibility)
-        self.createStartBtn.clicked.connect(self.app.create_backup_event.emit)
+        self.createStartBtn.clicked.connect(self.app.create_backup_action)
         self.cancelButton.clicked.connect(self.app.backup_cancelled_event.emit)
 
         QShortcut(QKeySequence("Ctrl+W"), self).activated.connect(self.on_close_window)

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -88,7 +88,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.miscTab.refresh_archive.connect(self.archiveTab.populate_from_profile)
 
         self.miscButton.clicked.connect(self.toggle_misc_visibility)
-        self.createStartBtn.clicked.connect(self.app.create_backup_action)
+        self.createStartBtn.clicked.connect(self.app.create_backup_event.emit)
         self.cancelButton.clicked.connect(self.app.backup_cancelled_event.emit)
 
         QShortcut(QKeySequence("Ctrl+W"), self).activated.connect(self.on_close_window)
@@ -99,6 +99,8 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.app.backup_log_event.connect(self.set_log)
         self.app.backup_progress_event.connect(self.set_progress)
         self.app.backup_cancelled_event.connect(self.backup_cancelled_event)
+        self.app.pre_backup_event.connect(self.pre_backup_event)
+        self.app.post_backup_event.connect(self.post_backup_event)
 
         # Init profile list
         self.populate_profile_selector()
@@ -338,6 +340,17 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self._toggle_buttons(create_enabled=True)
         self.set_log(self.tr('Task cancelled'))
         self.archiveTab.cancel_action()
+
+    def pre_backup_event(self, pid):
+        self._toggle_buttons(create_enabled=False)
+        self.set_log(self.tr(f"Running pre backup commands [PID: {pid}]"))
+
+    def post_backup_event(self, pid, active=True):
+        if active:
+            self.set_log(self.tr(f"Running post backup commands [PID: {pid}]"))
+        else:
+            self._toggle_buttons(create_enabled=True)
+            self.set_log('')
 
     def closeEvent(self, event):
         # Save window state in SettingsModel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add pre/post backup signals and emit them in BorgCreateJob.pre_post_backup_cmd.
Use them to toggle start/cancel buttons, tray icon active/inactive and provide enhanced status info. Also run VortaApp.create_backup_action/VortaScheduler.create_backup in a new thread to prevent GUI freezing whilst running pre/post backup commands. 

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#2120](https://github.com/borgbase/vorta/issues/2120)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I experienced this issue when running pre/post backup commands to mount/unmount a gdrive.
It solves the problem of the backup finished signal occurring before long running post backup commands have completed, preventing the start/cancel buttons being toggled back to their resting state.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running manual and scheduled backups.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
