### PR TITLE
Use events instead of calling child widgets

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -42,6 +42,7 @@ class VortaApp(QtSingleApplication):
     backup_log_event = QtCore.pyqtSignal(str, dict)
     backup_progress_event = QtCore.pyqtSignal(str)
     check_failed_event = QtCore.pyqtSignal(dict)
+    profile_changed_event = QtCore.pyqtSignal()
 
     def __init__(self, args_raw, single_app=False):
         super().__init__(str(APP_ID), args_raw)

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -152,6 +152,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
 
         # Connect to palette change
         self.app.paletteChanged.connect(lambda p: self.set_icons())
+        self.app.profile_changed_event.connect(self.populate_from_profile)
+        self.app.profile_changed_event.connect(self.toggle_compact_button_visibility)
 
     def set_icons(self):
         """Used when changing between light- and dark mode"""

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -151,7 +151,8 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.set_icons()
 
         # Connect to events
-        self.app.paletteChanged.connect(lambda p: self.set_icons())
+        self.app.paletteChanged.connect(self.set_icons)
+        self.app.paletteChanged.connect(self.populate_from_profile)
         self.app.backup_finished_event.connect(self.populate_from_profile)
         self.app.profile_changed_event.connect(self.populate_from_profile)
         self.app.profile_changed_event.connect(self.toggle_compact_button_visibility)

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -150,7 +150,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.selected_archives = None  # TODO: remove unused variable
         self.set_icons()
 
-        # Connect to palette change
+        # Connect to events
         self.app.paletteChanged.connect(lambda p: self.set_icons())
         self.app.backup_finished_event.connect(self.populate_from_profile)
         self.app.profile_changed_event.connect(self.populate_from_profile)

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -152,8 +152,10 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
 
         # Connect to palette change
         self.app.paletteChanged.connect(lambda p: self.set_icons())
+        self.app.backup_finished_event.connect(self.populate_from_profile)
         self.app.profile_changed_event.connect(self.populate_from_profile)
         self.app.profile_changed_event.connect(self.toggle_compact_button_visibility)
+        self.app.backup_cancelled_event.connect(self.cancel_action)
 
     def set_icons(self):
         """Used when changing between light- and dark mode"""

--- a/src/vorta/views/log_page.py
+++ b/src/vorta/views/log_page.py
@@ -27,6 +27,7 @@ class LogPage(LogTableBase, LogTableUI, BackupProfileMixin):
         super().__init__(parent)
         self.setupUi(self)
         self.init_ui()
+        QApplication.instance().backup_finished_event.connect(self.populate_logs)
         QApplication.instance().profile_changed_event.connect(self.populate_logs)
 
     def init_ui(self):

--- a/src/vorta/views/log_page.py
+++ b/src/vorta/views/log_page.py
@@ -1,6 +1,7 @@
 from PyQt6 import uic
 from PyQt6.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QHeaderView,
     QTableWidgetItem,
 )
@@ -26,6 +27,7 @@ class LogPage(LogTableBase, LogTableUI):
         super().__init__(parent)
         self.setupUi(self)
         self.init_ui()
+        QApplication.instance().profile_changed_event.connect(self.populate_logs)
 
     def init_ui(self):
         self.logPage.setAlternatingRowColors(True)

--- a/src/vorta/views/log_page.py
+++ b/src/vorta/views/log_page.py
@@ -7,7 +7,7 @@ from PyQt6.QtWidgets import (
 )
 
 from vorta import config
-from vorta.store.models import EventLogModel
+from vorta.store.models import BackupProfileMixin, EventLogModel
 from vorta.utils import get_asset
 
 uifile = get_asset('UI/log_page.ui')
@@ -22,7 +22,7 @@ class LogTableColumn:
     ReturnCode = 4
 
 
-class LogPage(LogTableBase, LogTableUI):
+class LogPage(LogTableBase, LogTableUI, BackupProfileMixin):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setupUi(self)
@@ -46,7 +46,13 @@ class LogPage(LogTableBase, LogTableUI):
         self.populate_logs()
 
     def populate_logs(self):
-        event_logs = [s for s in EventLogModel.select().order_by(EventLogModel.start_time.desc())]
+        profile = self.profile()
+        event_logs = [
+            s
+            for s in EventLogModel.select()
+            .where(EventLogModel.profile == profile.id)
+            .order_by(EventLogModel.start_time.desc())
+        ]
 
         sorting = self.logPage.isSortingEnabled()
         self.logPage.setSortingEnabled(False)

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -185,18 +185,15 @@ class MainWindow(MainWindowBase, MainWindowUI):
         if not backup_profile_id:
             return
         self.current_profile = BackupProfileModel.get(id=backup_profile_id)
-        self.archiveTab.populate_from_profile()
-        self.repoTab.populate_from_profile()
-        self.sourceTab.populate_from_profile()
-        self.scheduleTab.schedulePage.populate_from_profile()
-        self.scheduleTab.networksPage.populate_wifi()
-        self.scheduleTab.networksPage.setup_connections()
-        self.scheduleTab.shellCommandsPage.populate_from_profile()
-
+        self.app.profile_changed_event.emit()
+        # self.archiveTab.populate_from_profile()
+        # self.repoTab.populate_from_profile()
+        # self.sourceTab.populate_from_profile()
+        # self.scheduleTab.schedulePage.populate_from_profile()
         SettingsModel.update({SettingsModel.str_value: self.current_profile.id}).where(
             SettingsModel.key == 'previous_profile_id'
         ).execute()
-        self.archiveTab.toggle_compact_button_visibility()
+        # self.archiveTab.toggle_compact_button_visibility()
 
     def profile_clicked_action(self):
         if self.miscWidget.isVisible():
@@ -266,11 +263,12 @@ class MainWindow(MainWindowBase, MainWindowUI):
                 self.tr('Profile import successful!'),
                 self.tr('Profile {} imported.').format(profile.name),
             )
-            self.repoTab.populate_from_profile()
-            self.scheduleTab.logPage.populate_logs()
-            self.scheduleTab.networksPage.populate_wifi()
-            self.miscTab.populate()
+            # self.repoTab.populate_from_profile()
+            # self.scheduleTab.logPage.populate_logs()
+            # self.scheduleTab.networksPage.populate_wifi()
+            # self.miscTab.populate()
             self.populate_profile_selector()
+            self.app.profile_changed_event.emit()
 
         filename = QFileDialog.getOpenFileName(
             self,

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -319,10 +319,6 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.set_log('')
 
     def backup_finished_event(self):
-        self.archiveTab.populate_from_profile()
-        self.repoTab.init_repo_stats()
-        self.scheduleTab.logPage.populate_logs()
-
         if not self.app.jobs_manager.is_worker_running() and (
             self.archiveTab.remaining_refresh_archives == 0 or self.archiveTab.remaining_refresh_archives == 1
         ):  # Either the refresh is done or this is the last archive to refresh.
@@ -332,7 +328,6 @@ class MainWindow(MainWindowBase, MainWindowUI):
     def backup_cancelled_event(self):
         self._toggle_buttons(create_enabled=True)
         self.set_log(self.tr('Task cancelled'))
-        self.archiveTab.cancel_action()
 
     def closeEvent(self, event):
         # Save window state in SettingsModel

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -260,10 +260,6 @@ class MainWindow(MainWindowBase, MainWindowUI):
                 self.tr('Profile import successful!'),
                 self.tr('Profile {} imported.').format(profile.name),
             )
-            # self.repoTab.populate_from_profile()
-            # self.scheduleTab.logPage.populate_logs()
-            # self.scheduleTab.networksPage.populate_wifi()
-            # self.miscTab.populate()
             self.populate_profile_selector()
             self.app.profile_changed_event.emit()
 

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -184,16 +184,13 @@ class MainWindow(MainWindowBase, MainWindowUI):
         backup_profile_id = profile.data(Qt.ItemDataRole.UserRole) if profile else None
         if not backup_profile_id:
             return
+
         self.current_profile = BackupProfileModel.get(id=backup_profile_id)
-        self.app.profile_changed_event.emit()
-        # self.archiveTab.populate_from_profile()
-        # self.repoTab.populate_from_profile()
-        # self.sourceTab.populate_from_profile()
-        # self.scheduleTab.schedulePage.populate_from_profile()
         SettingsModel.update({SettingsModel.str_value: self.current_profile.id}).where(
             SettingsModel.key == 'previous_profile_id'
         ).execute()
-        # self.archiveTab.toggle_compact_button_visibility()
+
+        self.app.profile_changed_event.emit()
 
     def profile_clicked_action(self):
         if self.miscWidget.isVisible():

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -46,6 +46,7 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
 
         # Connect to palette change
         QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
+        QApplication.instance().profile_changed_event.connect(self.populate)
 
     def populate(self):
         """

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -44,7 +44,7 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
 
         self.populate()
 
-        # Connect to palette change
+        # Connect to events
         QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
         QApplication.instance().profile_changed_event.connect(self.populate)
 

--- a/src/vorta/views/networks_page.py
+++ b/src/vorta/views/networks_page.py
@@ -18,14 +18,12 @@ class NetworksPage(NetworksBase, NetworksUI, BackupProfileMixin):
         self.meteredNetworksCheckBox: QCheckBox = self.findChild(QCheckBox, 'meteredNetworksCheckBox')
         self.wifiListWidget: QListWidget = self.findChild(QListWidget, 'wifiListWidget')
 
-        self.populate_wifi()
-        self.setup_connections()
-        QApplication.instance().profile_changed_event.connect(self.populate_wifi)
-        QApplication.instance().profile_changed_event.connect(self.setup_connections)
-
-    def setup_connections(self):
+        # Connect signals
         self.meteredNetworksCheckBox.stateChanged.connect(self.on_metered_networks_state_changed)
         self.wifiListWidget.itemChanged.connect(self.save_wifi_item)
+        QApplication.instance().profile_changed_event.connect(self.populate_wifi)
+
+        self.populate_wifi()
 
     def on_metered_networks_state_changed(self, state):
         profile = self.profile()

--- a/src/vorta/views/networks_page.py
+++ b/src/vorta/views/networks_page.py
@@ -1,6 +1,6 @@
 from PyQt6 import uic
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QCheckBox, QLabel, QListWidget, QListWidgetItem
+from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QListWidget, QListWidgetItem
 
 from vorta.store.models import BackupProfileMixin, WifiSettingModel
 from vorta.utils import get_asset, get_sorted_wifis
@@ -20,6 +20,8 @@ class NetworksPage(NetworksBase, NetworksUI, BackupProfileMixin):
 
         self.populate_wifi()
         self.setup_connections()
+        QApplication.instance().profile_changed_event.connect(self.populate_wifi)
+        QApplication.instance().profile_changed_event.connect(self.setup_connections)
 
     def setup_connections(self):
         self.meteredNetworksCheckBox.stateChanged.connect(self.on_metered_networks_state_changed)

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -63,11 +63,11 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         self.bAddSSHKey.clicked.connect(self.create_ssh_key)
 
         self.set_icons()
-
-        # Connect to palette change
-        QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
-
         self.populate_from_profile()  # needs init of ssh and compression items
+
+        # Connect to events
+        QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
+        QApplication.instance().profile_changed_event.connect(self.populate_from_profile)
 
     def set_icons(self):
         self.bAddSSHKey.setIcon(get_colored_icon("plus"))

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -68,6 +68,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         # Connect to events
         QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
         QApplication.instance().profile_changed_event.connect(self.populate_from_profile)
+        QApplication.instance().backup_finished_event.connect(self.init_repo_stats)
 
     def set_icons(self):
         self.bAddSSHKey.setIcon(get_colored_icon("plus"))

--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -64,6 +64,9 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
         self.app.scheduler.schedule_changed.connect(lambda pid: self.draw_next_scheduled_backup())
         self.populate_from_profile()
 
+        # Listen for events
+        self.app.profile_changed_event.connect(self.populate_from_profile)
+
     def on_scheduler_change(self, _):
         profile = self.profile()
         for label, obj in self.schedulerRadioMapping.items():

--- a/src/vorta/views/shell_commands_page.py
+++ b/src/vorta/views/shell_commands_page.py
@@ -15,8 +15,16 @@ class ShellCommandsPage(QWidget, BackupProfileMixin):
         self.postBackupCmdLineEdit: QLineEdit = self.findChild(QLineEdit, 'postBackupCmdLineEdit')
         self.createCmdLineEdit: QLineEdit = self.findChild(QLineEdit, 'createCmdLineEdit')
         self.populate_from_profile()
-        self.setup_connections()
 
+        self.preBackupCmdLineEdit.textEdited.connect(
+            lambda new_val, attr='pre_backup_cmd': self.save_profile_attr(attr, new_val)
+        )
+        self.postBackupCmdLineEdit.textEdited.connect(
+            lambda new_val, attr='post_backup_cmd': self.save_profile_attr(attr, new_val)
+        )
+        self.createCmdLineEdit.textEdited.connect(
+            lambda new_val, attr='create_backup_cmd': self.save_repo_attr(attr, new_val)
+        )
         QApplication.instance().profile_changed_event.connect(self.populate_from_profile)
 
     def populate_from_profile(self):
@@ -34,17 +42,6 @@ class ShellCommandsPage(QWidget, BackupProfileMixin):
             self.createCmdLineEdit.setEnabled(False)
             self.preBackupCmdLineEdit.setEnabled(False)
             self.postBackupCmdLineEdit.setEnabled(False)
-
-    def setup_connections(self):
-        self.preBackupCmdLineEdit.textEdited.connect(
-            lambda new_val, attr='pre_backup_cmd': self.save_profile_attr(attr, new_val)
-        )
-        self.postBackupCmdLineEdit.textEdited.connect(
-            lambda new_val, attr='post_backup_cmd': self.save_profile_attr(attr, new_val)
-        )
-        self.createCmdLineEdit.textEdited.connect(
-            lambda new_val, attr='create_backup_cmd': self.save_repo_attr(attr, new_val)
-        )
 
     def save_profile_attr(self, attr, new_value):
         profile = self.profile()

--- a/src/vorta/views/shell_commands_page.py
+++ b/src/vorta/views/shell_commands_page.py
@@ -1,5 +1,5 @@
 from PyQt6 import uic
-from PyQt6.QtWidgets import QLineEdit, QWidget
+from PyQt6.QtWidgets import QApplication, QLineEdit, QWidget
 
 from vorta.store.models import BackupProfileMixin
 from vorta.utils import get_asset
@@ -16,6 +16,8 @@ class ShellCommandsPage(QWidget, BackupProfileMixin):
         self.createCmdLineEdit: QLineEdit = self.findChild(QLineEdit, 'createCmdLineEdit')
         self.populate_from_profile()
         self.setup_connections()
+
+        QApplication.instance().profile_changed_event.connect(self.populate_from_profile)
 
     def populate_from_profile(self):
         profile = self.profile()

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -106,12 +106,13 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
         self.bExclude.clicked.connect(self.show_exclude_dialog)
         header.sortIndicatorChanged.connect(self.update_sort_order)
 
-        # Connect to palette change
-        QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
-
         # Populate
         self.populate_from_profile()
         self.set_icons()
+
+        # Listen for events
+        QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
+        QApplication.instance().profile_changed_event.connect(self.populate_from_profile)
 
     def set_icons(self):
         "Used when changing between light- and dark mode"


### PR DESCRIPTION
This uses Qt signals instead of calling child widgets and their `populate_from_profile()` method.

Fixes #1962

Replaces #1964