### PR TITLE
Assume newer Borg version, in case check runs after first backup.

### DIFF
--- a/src/vorta/borg/_compatibility.py
+++ b/src/vorta/borg/_compatibility.py
@@ -19,7 +19,7 @@ class BorgCompatibility:
     to customize Borg commands by version in the future.
     """
 
-    version = "1.1.0"
+    version = "1.1.4"
     path = ""
 
     def set_version(self, version, path):


### PR DESCRIPTION
`borg --version` may run after the first backup. To avoid errors with zstd, we assume a Borg version that supports Zstd.

There is a risk that the user is actually using an old Borg version, but in that case, he shouldn't be able to select zstd anyways.

Fixes #2129
Fixes #2139