### PR TITLE
Override $PATH for MacOS to find native homebrew borg binaries (#2100)

### DIFF
--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -203,7 +203,12 @@ class BorgJob(JobInterface, BackupProfileMixin):
     @classmethod
     def prepare_bin(cls):
         """Find packaged borg binary. Prefer globally installed."""
-
+        # On MacOS, the PATH environment variable does not seem to be set when run as a pyinstaller binary.
+        # More info at https://github.com/borgbase/vorta/issues/2100
+        # Set the path to also find homebrew installs of Borg, and avoid falling back to the embedded binary.
+        if sys.platform == 'darwin':
+            os.environ["PATH"]="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin"
+        # Now continue looking for the borg binary to use
         borg_in_path = shutil.which('borg')
 
         if borg_in_path:

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -207,7 +207,7 @@ class BorgJob(JobInterface, BackupProfileMixin):
         # More info at https://github.com/borgbase/vorta/issues/2100
         # Set the path to also find homebrew installs of Borg, and avoid falling back to the embedded binary.
         if sys.platform == 'darwin':
-            os.environ["PATH"]="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin"
+            os.environ["PATH"]+=":/opt/homebrew/bin"
         # Now continue looking for the borg binary to use
         borg_in_path = shutil.which('borg')
 

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -207,7 +207,7 @@ class BorgJob(JobInterface, BackupProfileMixin):
         # More info at https://github.com/borgbase/vorta/issues/2100
         # Set the path to also find homebrew installs of Borg, and avoid falling back to the embedded binary.
         if sys.platform == 'darwin':
-            current_path = os.environ.get("PATH", "")
+            current_path = os.environ.get("PATH", "/usr/bin:/bin")
             os.environ["PATH"] = f"{current_path}:/opt/homebrew/bin:/usr/local/bin"
         # Now continue looking for the borg binary to use
         borg_in_path = shutil.which('borg')

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -207,7 +207,8 @@ class BorgJob(JobInterface, BackupProfileMixin):
         # More info at https://github.com/borgbase/vorta/issues/2100
         # Set the path to also find homebrew installs of Borg, and avoid falling back to the embedded binary.
         if sys.platform == 'darwin':
-            os.environ["PATH"] += ":/opt/homebrew/bin:/usr/local/bin"
+            current_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = f"{current_path}:/opt/homebrew/bin:/usr/local/bin"
         # Now continue looking for the borg binary to use
         borg_in_path = shutil.which('borg')
 

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -207,7 +207,7 @@ class BorgJob(JobInterface, BackupProfileMixin):
         # More info at https://github.com/borgbase/vorta/issues/2100
         # Set the path to also find homebrew installs of Borg, and avoid falling back to the embedded binary.
         if sys.platform == 'darwin':
-            os.environ["PATH"]+=":/opt/homebrew/bin"
+            os.environ["PATH"] += ":/opt/homebrew/bin:/usr/local/bin"
         # Now continue looking for the borg binary to use
         borg_in_path = shutil.which('borg')
 


### PR DESCRIPTION
### Description
Override the $PATH environment variable on the MacOS (Darwin) platform, so that homebrew-provided native binaries for Borg will be used, rather than falling back to the built-in Borg binary.

### Related Issue
https://github.com/borgbase/vorta/issues/2100

### Motivation and Context
For an unknown reason (see linked issue above), the PyInstaller approach to setting the PATH variable does not appear to function any more - Vorta on ARM with a homebrew-installed native borg binary will not find that binary. Debugging shows the PATH variable is set wrongly, and will never find a binary in /opt/homebrew/bin. This patch will change that.

### How Has This Been Tested?
1. Debugging statements added around existing areas of code (see linked issue) to establish the PATH being used
2. Tested with this change and observed the homebrew based binary was found and shown in About.
3. Not tested end-to-end yet, as one of the apparent issues in testing was reproducibility against a production release - while I have built it according to the Github actions, this still needs tested against a development build that is created using the normal release method.

### Screenshots (if appropriate):
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
