### PR TITLE
Fix whitespace error: use of shlex.split instead of .split() (fix #2164)

### DIFF
--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -234,7 +234,9 @@ class BorgJob(JobInterface, BackupProfileMixin):
                 profile=self.params.get('profile_id', None),
             )
             log_entry.save()
-            logger.info('Running command %s', ' '.join(self.cmd))
+            cmd_log_tmp = [s.replace(" ", "\\ ") for s in self.cmd]  # escape whitespace - for logs
+            logger.info('Running command %s', ' '.join(cmd_log_tmp))
+            del cmd_log_tmp
 
         p = Popen(
             self.cmd,

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 import tempfile
 from datetime import datetime as dt
@@ -102,8 +103,8 @@ class BorgCreateJob(BorgJob):
         suffix_command = []
         if profile.repo.create_backup_cmd:
             s1, sep, s2 = profile.repo.create_backup_cmd.partition('-- ')
-            extra_cmd_options = s1.split()
-            suffix_command = (sep + s2).split()
+            extra_cmd_options = shlex.split(s1)
+            suffix_command = shlex.split(sep + s2)
 
         if n_backup_folders == 0 and '--paths-from-command' not in extra_cmd_options:
             ret['message'] = trans_late('messages', 'Add some folders to back up first.')


### PR DESCRIPTION
### Description
As described in but #2164, Vorta/ borg raises an error when valid borg commands with whitespace are
provided via Vortas "Extra borg commands".
The issues arise when a folder/ filename contains whitespace. 
The issue came up here: https://github.com/borgbase/vorta/discussions/2156#discussioncomment-11470549 

<!--- Describe your changes in detail -->
### Related Issue
Extra borg arguments with white space raise an error #2164

### Motivation and Context
See the following borg issue: https://github.com/borgbackup/borg/issues/8578

There are different ways how borg can receive options (with folder/ name containing whitespace).
The following is a list of **valid borg options** - all of them raise an error in Vorta: 
```
--pattern=-subdir/test\ folder
'--pattern=-subdir/test folder'
--pattern='-subdir/test folder'
```

When investigating, I found that this issue is due to the use of standard python `.split()` function in create.py. 
The `.split()` function separates by whitespace - as a result, item names containing whitespace are split up: 
```
s1 = "--pattern=-subdir/test\ folder"
x = s1.split()
print(x)
$ ['--pattern=-subdir/test\\', 'folder']
```
If this type of list is passed to Popen, 'folder' is treated as an attribute, which led to the error. 

The solution for this type of error is the use of `shlex.split()` instead of standard .split(). 
Note that shlex.split is alredy used by Vorta, in other places, e.g. in /borg/borg_job.py
`shlex.split()` recognises the escaped whitespace in the item names, as required - the resulting attribute can 
be passed to Popen as is. 

When using `shlex.split()`, one, minor, resulting issue is that the **borg command** (shell command) **printed to the Vorta logs** does not escape the whitespace, since `shlex.split()` removes the escape character. 
Since I wanted to provide a working borg command equivalent in the Vorta logs, I just added a additional step, where I replace whitespace by escaped whitespace (in the `cmd` attributes) - before printing the borg commands to the logs.  
As a result, borg prints a command with escaped whitespaces (inside attributes only) that could be coppied/ run in the Shell. 

An alternative would be to print the list of attributes, as is - but this does not lead to an easily readable borg command in the logs - that could be coppied/ pasted to the shell (a property I would like to keep) 

### How Has This Been Tested?
- I tested with the following Extra borg arguments - and checked the resulting logs - and if borg did in fact exclude my "`test folder`"
```
--pattern=-subdir/test\ folder
'--pattern=-subdir/test folder'
--pattern='-subdir/test folder'
```
- In the Vora logs, the whitespace in item names are escaped.  
- I also tested the case where no Extra borg arguments where delivered. 
- I also tested cased with extra borg arguments and suffix commands. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x ] My code follows the code style of this project.

My change does not requires a change to the documentation.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
