### PR TITLE
logs: Add borg command arguments and a shell command approximation

### DIFF
--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -234,9 +234,22 @@ class BorgJob(JobInterface, BackupProfileMixin):
                 profile=self.params.get('profile_id', None),
             )
             log_entry.save()
-            cmd_log_tmp = [s.replace(" ", "\\ ") for s in self.cmd]  # escape whitespace - for logs
-            logger.info('Running command %s', ' '.join(cmd_log_tmp))
-            del cmd_log_tmp
+            logger.info('borg command arguments: %s', self.cmd)
+
+            # logs: Provide a shell command approximation.
+            cmd_tmp = self.cmd[:]
+            special_strings = [' ', '*', '?', 're:']
+            for i, arg in enumerate(cmd_tmp):
+                if any(specialstr in arg for specialstr in special_strings):
+                    if ('re:' in arg) and ('=' in arg) and (arg.find('=') < arg.find('re:')):
+                        cmd_tmp[i] = arg.replace("=", "='", 1)  # add quote after first "="
+                    elif ('re:' not in arg) and ('=' in arg):
+                        cmd_tmp[i] = arg.replace("=", "='", 1)
+                    else:
+                        cmd_tmp[i] = arg.replace(arg, "'" + arg)  # add quote at start
+                    cmd_tmp[i] += "'"  # add quote at the end
+            logger.info('shell command approximation: %s', ' '.join(cmd_tmp))
+            del cmd_tmp
 
         p = Popen(
             self.cmd,


### PR DESCRIPTION
### Description
This pull request has two purposes:
1. new: logs: print the list of borg command arguments, that are used in Vorta
2. modify: logs: print a shell approximation for the borg command that respects the borg recommendations.

The pull request only concerns what is printed to the logs.

### Related Issue
https://github.com/borgbase/vorta/issues/2189

Currently, when executing borg command, an "approximate" of the (shell) borg command is printed to the logs.
This command is an _approximation_ in the sense that it is artificially constructed from a list of command line arguments `cmd`, that is used internally by Vorta.  

Note that the list of command line arguments `cmd` does neither require nor contain quotation marks and can be passed "as is" to Popen()

For shell usage, however, borg recommends putting the following into quotation marks: 
- item names that contain whitespace " ",  since escaping with "\" is shell specific.
- arguments with characters that are used for pattern matching "*" "?"
- regular expressions

This pull request does two thing: 
1. Print the unmodified list of borg arguments `cmd` to the logs
2. Changes to the shell command approximation:
    - change the description, and make clear that this is a shell command approximation
    - add quotation marks, where recommendet 
    -  the aim is to get a shell command that could be copy/pasted to any shell and be directly executed.

### Motivation and Context
- currently there can be differences between the borg command in the logs and the actual list of borg arguments, this makes debugging cumbersome. See #2164
- the borg command (approximation) in the logs currently does not fit to the borg recommendations, i.e. use quotation marks for white space or regular expressions.

### How Has This Been Tested?
The following borg arguments have been added to the "extra borg arguments" via the Vorta UI - to check if the resulting shell command approximation provides the intended format / quotation marks:

```
--remote-path=/usr/local/bin/borg                   #no changes required
--pattern='+home/user/test folder/testfile'     #white space in folder name
--pattern='-re:home/user/test\sfolder2'          #regular expression
--pattern='-re:crazy?=cra'                         #regualr expression that contains a "="
-e 're:crazy?=cra'                                #regular expression but without pattern=
-e '/home/user/*.tmp'                            #wildcard should be quoted
-e /home/user/test/cache                          #no changes required
--patterns-from /home/user/patterns.lst        #no changes required
```

These are the **resulting etries in the logs**: 

The list of _borg command line arguments_ `cmd`: 
`2025-01-13 12:35:57,302 - vorta.borg.borg_job - INFO - borg command arguments: ['/usr/bin/borg', 'create', '--remote-path=/usr/local/bin/borg', '--list', '--progress', '--info', '--log-json', '--json', '--filter=AM', '-C', 'lz4', '--pattern=+home/user/test folder/testfile', '--pattern=-home/user/test folder', '--pattern=-re:home/user/test\\sfolder2', '--pattern=-re:crazy?=cra', '-e', 're:crazy?=cra', '-e', '/home/user/*.tmp', '-e', '/home/user/test/cache', '--patterns-from', '/home/user/patterns.lst', 'ssh://user@192.168.0.5:22/~/backup/vorta-repo::user-2025-01-13-123557', '/home/user']`

The _shell command approximation_: 
`2025-01-13 12:35:57,302 - vorta.borg.borg_job - INFO - shell command approximation: /usr/bin/borg create --remote-path=/usr/local/bin/borg --list --progress --info --log-json --json --filter=AM -C lz4 --pattern='+home/user/test folder/testfile' --pattern='-home/user/test folder' --pattern='-re:home/user/test\sfolder2' --pattern='-re:crazy?=cra' -e 're:crazy?=cra' -e '/home/user/*.tmp' -e /home/user/test/cache --patterns-from /home/user/patterns.lst ssh://user@192.168.0.5:22/~/backup/vorta-repo::user-2025-01-13-123557 /home/user`

Ths shell command approximation can be copied to a shell "as is".


### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
