### PR TITLE
Improved GUI to clarify Passphrase Field (Issue #2193)

### DIFF
--- a/src/vorta/assets/UI/repo_add.ui
+++ b/src/vorta/assets/UI/repo_add.ui
@@ -225,7 +225,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="passphraseLabel">
      <property name="text">
-      <string>This passphrase will be required to access backup.</string>
+      <string>This passphrase will be required to access your backup.</string>
      </property>
     </widget>
    </item>

--- a/src/vorta/assets/UI/repo_add.ui
+++ b/src/vorta/assets/UI/repo_add.ui
@@ -223,6 +223,13 @@
     </widget>
    </item>
    <item row="3" column="0">
+    <widget class="QLabel" name="passphraseLabel">
+     <property name="text">
+      <string>This passphrase will be required to access backup.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/src/vorta/keyring/abc.py
+++ b/src/vorta/keyring/abc.py
@@ -39,7 +39,7 @@ class VortaKeyring:
 
     def get_backend_warning(self):
         if self.is_system:
-            return trans_late('utils', 'Storing password in your password manager.')
+            return trans_late('utils', 'This passphrase is required to access your backup.')
         else:
             return trans_late('utils', 'Saving password with Vorta settings.')
 

--- a/src/vorta/keyring/abc.py
+++ b/src/vorta/keyring/abc.py
@@ -39,7 +39,7 @@ class VortaKeyring:
 
     def get_backend_warning(self):
         if self.is_system:
-            return trans_late('utils', 'This passphrase is required to access your backup.')
+            return trans_late('utils', 'Storing password in your password manager.')
         else:
             return trans_late('utils', 'Saving password with Vorta settings.')
 


### PR DESCRIPTION

### Description
This pull request improves the user interface while creating a new repository by providing clearer instructions for the passphrase field. The improvement here addresses the user confusion by explicitly stating the purpose of passphrase (for encryption).

### Related Issue
Fixes #2193 - Clarifies the passphrase field when creating a new repository.

### Motivation and Context
When creating a new repository in Vorta, the users were unclear about the purpose of passphrase field. This change explicitly states the purpose of passphrase. This is crucial because without this passphrase users cannot decrypt their backup.

### How Has This Been Tested?
The changes were tested by :
- Launching the "Create New Repository" dialog and verifying that the passphrase field is correctly labeled.
- Ensuring tooltip now clearly states the importance of passphrase and recommends to store it.
- Testing the GUI for proper layout and sectioning under new "Encryption" header.

### Screenshots:

Before

![Before](https://github.com/user-attachments/assets/93211eb1-7422-4bf2-931d-4b2f55729674)

After

![After](https://github.com/user-attachments/assets/b2ef7c0a-0339-44f1-b74c-b889feba5082)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
