### PR TITLE
Fix exclusion handling for source size estimation

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -41,7 +41,7 @@ class FilePathInfoAsync(QThread):
         self.exclude_patterns = []
         for _line in (exclude_patterns_str or '').splitlines():
             line = _line.strip()
-            if line != '':
+            if line != '' and not line.startswith("#"):
                 self.exclude_patterns.append(line)
 
     def run(self):

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -205,7 +205,7 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
         path = self.sourceFilesWidget.item(index_row, SourceColumn.Path).text()
         self.sourceFilesWidget.item(index_row, SourceColumn.Size).setText(self.tr("Calculating…"))
         self.sourceFilesWidget.item(index_row, SourceColumn.FilesCount).setText(self.tr("Calculating…"))
-        getDir = FilePathInfoAsync(path, self.profile().exclude_patterns)
+        getDir = FilePathInfoAsync(path, self.profile().get_combined_exclusion_string())
         getDir.signal.connect(self.set_path_info)
         getDir.setObjectName(path)
         self.updateThreads.append(getDir)  # this is ugly, is there a better way to keep the thread object?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Firstly: if there's an exclude pattern that starts with a `#`, it should be ignored when doing source size estimation. See [`borg help patterns`](https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-patterns):

> Lines empty or starting with the number sign (‘#’) after removing whitespace on both ends are ignored.

Secondly: rather than just using the profile's `exclude_patterns` (text entered in the "raw" exclusions tab), we should estimate source size based on the combined set of patterns from the profile, including `ExclusionModel` etc. (the "presets" and "custom" tabs) – we do this by using the conveniently named `get_combined_exclusion_string()` method.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #2115 (hopefully).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, only the "raw" exclusions were used when estimating size of a backup source, not the "presets" or "custom" exclusions. (All exclusions were still passed to Borg for the actual backup.) This could lead to over-estimating the amount of material to be backed up, or even traversing parts of the filesystem that should be ignored, like `/proc` or `/run`, and potentially crashing Vorta.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have not, yet, tested this – I have an ongoing backup I'd rather not interrupt, and running two instances of Vorta at the same time seems like a bad idea. I can do so next weekend, probably.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
