### PR TITLE
Fix for Validation Interval can be set more frequent than Backup Interval

### DIFF
--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -89,10 +89,27 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
         self.draw_next_scheduled_backup()
 
     def on_validation_change(self):
-        """Updates the minimum value of the validation week counter based on the schedule interval"""
-        if self.validationCheckBox.isChecked() and self.scheduleIntervalUnit.currentData() == 'weeks':
-            self.validationWeeksCount.setValue(self.scheduleIntervalCount.value())
-            self.validationWeeksCount.setMinimum(self.scheduleIntervalCount.value())
+        """Ensures validation interval is not smaller than the backup interval."""
+        if self.validationCheckBox.isChecked():
+            backup_unit = self.scheduleIntervalUnit.currentData()
+            backup_value = self.scheduleIntervalCount.value()
+
+            # Backup interval to weeks conversion
+            if backup_unit == 'weeks':
+                min_validation_weeks = backup_value
+            elif backup_unit == 'days':
+                min_validation_weeks = backup_value / 7
+            elif backup_unit == 'hours':
+                min_validation_weeks = backup_value / (7 * 24)
+            elif backup_unit == 'minutes':
+                min_validation_weeks = backup_value / (7 * 24 * 60)
+            else:
+                min_validation_weeks = 1  # Default case, should not happen
+
+            # Set the validation weeks count
+            min_validation_weeks = max(1, int(min_validation_weeks))  # Ensures minimum 1 week
+            self.validationWeeksCount.setValue(min_validation_weeks)
+            self.validationWeeksCount.setMinimum(min_validation_weeks)
         else:
             self.validationWeeksCount.setMinimum(1)
 

--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -44,6 +44,8 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
         self.scheduleIntervalUnit.currentIndexChanged.connect(self.on_scheduler_change)
         self.scheduleFixedTime.timeChanged.connect(self.on_scheduler_change)
 
+        self.validationCheckBox.stateChanged.connect(self.on_validation_change)
+
         self.missedBackupsCheckBox.stateChanged.connect(
             lambda new_val, attr='schedule_make_up_missed': self.save_profile_attr(attr, new_val)
         )
@@ -71,6 +73,8 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
         profile = self.profile()
         for label, obj in self.schedulerRadioMapping.items():
             if obj.isChecked():
+                self.on_validation_change()
+
                 profile.schedule_mode = label
                 profile.schedule_interval_unit = self.scheduleIntervalUnit.currentData()
                 profile.schedule_interval_count = self.scheduleIntervalCount.value()
@@ -83,6 +87,14 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
 
         self.app.scheduler.set_timer_for_profile(profile.id)
         self.draw_next_scheduled_backup()
+
+    def on_validation_change(self):
+        """Updates the minimum value of the validation week counter based on the schedule interval"""
+        if self.validationCheckBox.isChecked() and self.scheduleIntervalUnit.currentData() == 'weeks':
+            self.validationWeeksCount.setValue(self.scheduleIntervalCount.value())
+            self.validationWeeksCount.setMinimum(self.scheduleIntervalCount.value())
+        else:
+            self.validationWeeksCount.setMinimum(1)
 
     def populate_from_profile(self):
         profile = self.profile()

--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -90,7 +90,7 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
 
     def on_validation_change(self):
         """Ensures validation interval is not smaller than the backup interval."""
-        if self.validationCheckBox.isChecked():
+        if self.validationCheckBox.isChecked() and self.scheduleIntervalRadio.isChecked():
             backup_unit = self.scheduleIntervalUnit.currentData()
             backup_value = self.scheduleIntervalCount.value()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


### Description
This PR resolves the issue in the Schedule Tab where the Validate Interval QSpinBox allowed users to set the validation schedule to run more frequently than the backup schedule. This behavior was problematic since validation (using BorgCheckJob) only runs after a backup, meaning that it shouldn't be scheduled more frequently than the backup itself.

With this change, Vorta now ensures that the validation interval cannot be set to a value smaller than the backup interval, enforcing a more logical and consistent scheduling behavior.

### Related Issue
Resolves #1971

### Motivation and Context
- This change is required to enforce logical consistency between the backup and validation intervals in the Vorta scheduling system. 
- Previously, users were able to set the validation interval to run more frequently than the backup interval, which could lead to issues, as validation (via BorgCheckJob) only occurs after a backup.
### How Has This Been Tested?
- Tested the UI in the Schedule Tab to ensure that the Validate Interval QSpinBox no longer allows validation intervals smaller than the backup interval.
- Attempted to set a validation interval shorter than the backup interval, and confirmed that the UI prevents this configuration.

### Discussion:
- I've added a new function `on_validation_change()` to `/src/vorta/views/schedule_page.py`.
    - The function checks if Validation is enabled and if the Backup schedule is set to a periodic value with the unit `'week'`.
    - Since validation is measured in weeks, other units should not interfere with this logic.
    - The function ensures that the validation interval cannot be set to a value lower than the backup interval.
- On starting Vorta, the function is executed to set the validation interval value based on the backup interval.
- I also modified the `on_scheduler_change()` function to ensure this validation runs when the scheduler count or unit is changed.
- These changes prevent the user from setting the validation interval lower than the backup interval in the UI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
