### PR TITLE
Improved GUI to clarify the passphrase field

### DIFF
--- a/src/vorta/assets/UI/repo_add.ui
+++ b/src/vorta/assets/UI/repo_add.ui
@@ -2,53 +2,22 @@
 <ui version="4.0">
  <class>AddRepository</class>
  <widget class="QDialog" name="AddRepository">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>463</width>
+    <height>253</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add Repository</string>
+  </property>
   <property name="modal">
    <bool>true</bool>
   </property>
-  <property name="windowTitle">
-    <string>Add Repository</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="verticalSpacing">
-    <number>0</number>
-   </property>
-   <item row="2" column="0">
-    <widget class="QLabel" name="errorText">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>11</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::PlainText</enum>
-     </property>
-     <property name="scaledContents">
-      <bool>false</bool>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
+   <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -83,6 +52,7 @@
         <widget class="QLabel" name="title">
          <property name="font">
           <font>
+           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -157,13 +127,13 @@
          </property>
         </widget>
        </item>
-        <item row="3" column="0">
-          <widget class="QLabel" name="label_4">
-          <property name="text">
-            <string/>
-          </property>
-          </widget>
-        </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabWidgetPage2">
@@ -222,12 +192,59 @@
      </widget>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="1" column="0">
+    <widget class="QLabel" name="errorText">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>NOTE: Keep the passphrase safe in another secure location as well</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/vorta/assets/UI/repo_add.ui
+++ b/src/vorta/assets/UI/repo_add.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>463</width>
+    <width>577</width>
     <height>253</height>
    </rect>
   </property>
@@ -231,7 +231,7 @@
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="noteLabel">
        <property name="text">
         <string>NOTE: Keep the passphrase safe in another secure location as well</string>
        </property>

--- a/src/vorta/assets/UI/repo_add.ui
+++ b/src/vorta/assets/UI/repo_add.ui
@@ -233,7 +233,7 @@
      <item>
       <widget class="QLabel" name="noteLabel">
        <property name="text">
-        <string>NOTE: Keep the passphrase safe in another secure location as well</string>
+        <string>NOTE: Keep a backup of your passphrase in a separate location.</string>
        </property>
       </widget>
      </item>

--- a/src/vorta/views/partials/password_input.py
+++ b/src/vorta/views/partials/password_input.py
@@ -9,7 +9,9 @@ from vorta.views.utils import get_colored_icon
 
 
 class PasswordLineEdit(QLineEdit):
-    def __init__(self, *, parent: Optional[QWidget] = None, show_visibility_button: bool = True) -> None:
+    def __init__(
+        self, *, parent: Optional[QWidget] = None, show_visibility_button: bool = True, placeholder_text: str = ""
+    ) -> None:
         super().__init__(parent)
 
         self._show_visibility_button = show_visibility_button
@@ -17,6 +19,7 @@ class PasswordLineEdit(QLineEdit):
         self._visible = False
 
         self.setEchoMode(QLineEdit.EchoMode.Password)
+        self.setPlaceholderText(placeholder_text)
 
         if self._show_visibility_button:
             self.showHideAction = QAction(self.tr("Show password"), self)
@@ -84,8 +87,8 @@ class PasswordInput(QObject):
             self._label_confirm = QLabel(self.tr("Confirm passphrase:"))
 
         # Create password line edits
-        self.passwordLineEdit = PasswordLineEdit()
-        self.confirmLineEdit = PasswordLineEdit()
+        self.passwordLineEdit = PasswordLineEdit(placeholder_text=self.tr("Enter new encryption passphrase"))
+        self.confirmLineEdit = PasswordLineEdit(placeholder_text=self.tr("Confirm new encryption passphrase"))
         self.validation_label = QLabel("")
 
         self.passwordLineEdit.editingFinished.connect(self.on_editing_finished)

--- a/src/vorta/views/partials/password_input.py
+++ b/src/vorta/views/partials/password_input.py
@@ -19,7 +19,8 @@ class PasswordLineEdit(QLineEdit):
         self._visible = False
 
         self.setEchoMode(QLineEdit.EchoMode.Password)
-        self.setPlaceholderText(placeholder_text)
+        if placeholder_text:
+            self.setPlaceholderText(placeholder_text)
 
         if self._show_visibility_button:
             self.showHideAction = QAction(self.tr("Show password"), self)

--- a/src/vorta/views/repo_add_dialog.py
+++ b/src/vorta/views/repo_add_dialog.py
@@ -232,7 +232,7 @@ class ExistingRepoWindow(RepoWindow):
         self.setWindowTitle("Add Existing Repository")
 
         self.passwordLabel = QLabel(self.tr('Password:'))
-        self.passwordInput = PasswordLineEdit()
+        self.passwordInput = PasswordLineEdit(placeholder_text=self.tr("Enter the encryption passphrase"))
         self.repoDataFormLayout.addRow(self.passwordLabel, self.passwordInput)
 
     def set_password(self, URL):


### PR DESCRIPTION

### Description

This PR adds more clarity to passphrase field of "Add new repository" and "Add existing repository" sections.

Changes made:
-  Added placeholder text in passphrase field for better clarity for the users.
- Added a NOTE section to notify the importance of keeping the entered passphrase safe.
- UI of `repo_add.ui` has been modified.
- No existing functionality has been changed.

### Related Issue
Resolves #2194

### Motivation and Context
Several users reported confusion regarding the passphrase field in the "Add new repository" of Vorta and requested an improved UI with clearer information.

### How Has This Been Tested?
- Tested the UI by running the build

### Screenshots:
![Screenshot 2025-02-19 233714](https://github.com/user-attachments/assets/eaa67773-aace-427c-a0f0-b305e0e41dc6)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x]  I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x]  My code follows the code style of this project.
- [ ]  My change requires a change to the documentation.
- [ ]  I have updated the documentation accordingly.
- [ ]  I have added tests to cover my changes.
- [ ]  All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
