### PR TITLE
Notification timeout removed for critical errors

### DIFF
--- a/src/vorta/notifications.py
+++ b/src/vorta/notifications.py
@@ -89,7 +89,8 @@ class DBusNotifications(VortaNotifications):
         text = msg
         actions_list = QtDBus.QDBusArgument([], QtCore.QMetaType.Type.QStringList.value)
         hint = {'urgency': self.URGENCY[level]}
-        time = 5000  # milliseconds for display timeout
+        # milliseconds for display timeout
+        time = 0 if level == 'error' else 5000  # 0 -> no timeout for errors
 
         bus = QtDBus.QDBusConnection.sessionBus()
         notify = QtDBus.QDBusInterface(item, path, interface, bus)
@@ -118,4 +119,4 @@ class DBusNotifications(VortaNotifications):
         if self.notifications_suppressed(level):
             return
 
-        self._dbus_notify(title, text)
+        self._dbus_notify(title, text, level=level)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR removes the timeout for error notifications in the Vorta. Instead of disappearing after 5 seconds, error notifications will remain until the user dismisses them manually. 
```python
time = 0 if level == 'error' else 5000
```
This ensures that the user has a better chance to review critical error messages and take necessary actions, even if they don't see the notification immediately.

### Related Issue
Resolves #2045 

### How Has This Been Tested?
Tested on Linux Mint 22.1
Testing was done by calling the notification class `DBusNotifications`
```python
if __name__ == "__main__":
    from unittest.mock import MagicMock
    SettingsModel.get = MagicMock(return_value=MagicMock(value=True))

    notifier = DBusNotifications()
    notifier.deliver('Test Notify', 'This is a test notification', level='error')
    print("Test Notification ran...")
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
