### PR TITLE
Skip reading file size if path name is too long

### DIFF
--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -121,7 +121,8 @@ def get_directory_size(dir_path, exclude_patterns):
                     if not is_excluded:
                         data_size_filtered += stat.st_size
                         seen_filtered.add(stat.st_ino)
-            except (FileNotFoundError, PermissionError):
+            except (FileNotFoundError, PermissionError, OSError):
+                # OSError is thrown when the file path name exceeds the maximum length allowed by the operating system
                 continue
 
     files_count_filtered = len(seen_filtered)


### PR DESCRIPTION


### Description
The Python os.stat() function below throws an unhandled OSError exception if the file being read's path length exceeds what the OS allows (e.g. 255 on Win7, 1024 on Mac).
https://github.com/borgbase/vorta/blob/0a316e7aa9ae8e61ff3a1e72dcd57c8a2b7976da/src/vorta/utils.py#L116-L125

### Related Issue
fixes https://github.com/borgbase/vorta/issues/2115


### Motivation and Context
Currently, the whole application will crash when estimating backup size if a single file (even if it's excluded) exceeds the maximum length allowed by the OS. PR https://github.com/borgbase/vorta/pull/2206 addresses excluding files from being calculated as part of the backup size, and this PR ignores files that have an excessive path length.

### How Has This Been Tested?
I've run the pytest and pre-commit tests and they have passed.
I'm unable to manually test this as MacOS will not allow me to create a file with a path length exceeding 1024.


### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
