### PR TITLE
A better way to show Borg's errors

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -299,7 +299,7 @@ class VortaApp(QtSingleApplication):
                         double_newline,
                         str(exception),
                         double_newline,
-                        self.tr('Consider removing or repairing this file to ' 'get rid of this message.'),
+                        self.tr('Consider removing or repairing this file to get rid of this message.'),
                     ),
                 )
                 return

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -300,19 +300,16 @@ class BorgJob(JobInterface, BackupProfileMixin):
                             self.app.backup_log_event.emit(f'[{self.params["profile_name"]}] {parsed["message"]}', {})
                         elif parsed['type'] == 'archive_progress' and not parsed.get('finished', False):
                             msg = (
-                                f"{translate('BorgJob','Files')}: {parsed['nfiles']}, "
-                                f"{translate('BorgJob','Original')}: {pretty_bytes(parsed['original_size'])}, "
+                                f"{translate('BorgJob', 'Files')}: {parsed['nfiles']}, "
+                                f"{translate('BorgJob', 'Original')}: {pretty_bytes(parsed['original_size'])}, "
                                 # f"{translate('BorgJob','Compressed')}: {pretty_bytes(parsed['compressed_size'])}, "
-                                f"{translate('BorgJob','Deduplicated')}: {pretty_bytes(parsed.get('deduplicated_size', 0))}"  # noqa: E501
+                                f"{translate('BorgJob', 'Deduplicated')}: {pretty_bytes(parsed.get('deduplicated_size', 0))}"  # noqa: E501
                             )
                             self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {msg}")
                     except json.decoder.JSONDecodeError:
                         msg = line.strip()
                         if msg:  # Log only if there is something to log.
                             error_msg = stderr
-                            self.app.backup_progress_event.emit(
-                                f"[{self.params['profile_name']}] `{' '.join(self.cmd)}` has failed."
-                            )
                             logger.warning(msg)
 
             if p.poll() is not None:

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -317,7 +317,7 @@ class BorgJob(JobInterface, BackupProfileMixin):
                 stdout.append(read_async(p.stdout))
                 break
 
-        if error_msg:
+        if error_msg and self.process.returncode != 0:
             self.app.error_signal.emit(error_msg)
 
         result = {

--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -310,6 +310,9 @@ class BorgJob(JobInterface, BackupProfileMixin):
                         msg = line.strip()
                         if msg:  # Log only if there is something to log.
                             error_msg = stderr
+                            self.app.backup_progress_event.emit(
+                                f"[{self.params['profile_name']}] `{' '.join(self.cmd)}` has failed."
+                            )
                             logger.warning(msg)
 
             if p.poll() is not None:

--- a/src/vorta/borg/check.py
+++ b/src/vorta/borg/check.py
@@ -26,9 +26,9 @@ class BorgCheckJob(BorgJob):
         if result['returncode'] != 0:
             self.app.backup_progress_event.emit(
                 f"[{self.params['profile_name']}] "
-                + translate('RepoCheckJob', 'Repo check failed. See the <a href="{0}">logs</a> for details.').format(
-                    config.LOG_DIR.as_uri()
-                )
+                + translate(
+                    'RepoCheckJob', 'Repo check command has failed. See the <a href="{0}">logs</a> for details.'
+                ).format(config.LOG_DIR.as_uri())
             )
             self.app.check_failed_event.emit(result)
         else:

--- a/src/vorta/borg/delete.py
+++ b/src/vorta/borg/delete.py
@@ -22,7 +22,12 @@ class BorgDeleteJob(BorgJob):
 
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
-        self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Archive deleted.')}")
+        if result['returncode'] == 0:
+            self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Archive deleted.')}")
+        else:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] {self.tr('Archive delete has failed.')}"
+            )
 
     @classmethod
     def prepare(cls, profile, archives: List[str]):

--- a/src/vorta/borg/delete.py
+++ b/src/vorta/borg/delete.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from vorta import config
+from vorta.i18n import translate
 from vorta.store.models import RepoModel
 from vorta.utils import borg_compat
 
@@ -22,12 +24,15 @@ class BorgDeleteJob(BorgJob):
 
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
-        if result['returncode'] == 0:
-            self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Archive deleted.')}")
-        else:
+        if result['returncode'] != 0:
             self.app.backup_progress_event.emit(
-                f"[{self.params['profile_name']}] {self.tr('Archive delete has failed.')}"
+                f"[{self.params['profile_name']}] "
+                + translate(
+                    'BorgDeleteJob', 'Delete command has failed. See the <a href="{0}">logs</a> for details.'
+                ).format(config.LOG_DIR.as_uri())
             )
+        else:
+            self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Archive deleted.')}")
 
     @classmethod
     def prepare(cls, profile, archives: List[str]):

--- a/src/vorta/borg/diff.py
+++ b/src/vorta/borg/diff.py
@@ -1,3 +1,5 @@
+from vorta import config
+from vorta.i18n import translate
 from vorta.utils import borg_compat
 
 from .borg_job import BorgJob
@@ -12,10 +14,18 @@ class BorgDiffJob(BorgJob):
 
     def finished_event(self, result):
         self.app.backup_finished_event.emit(result)
-        self.app.backup_progress_event.emit(
-            f"[{self.params['profile_name']}] {self.tr('Obtained differences between archives.')}"
-        )
         self.result.emit(result)
+        if result['returncode'] != 0:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] "
+                + translate(
+                    'BorgDiffJob', 'Diff command has failed. See the <a href="{0}">logs</a> for details.'
+                ).format(config.LOG_DIR.as_uri())
+            )
+        else:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] {self.tr('Obtained differences between archives.')}"
+            )
 
     @classmethod
     def prepare(cls, profile, archive_name_1, archive_name_2):

--- a/src/vorta/borg/extract.py
+++ b/src/vorta/borg/extract.py
@@ -2,6 +2,8 @@ import tempfile
 
 from PyQt6.QtCore import QModelIndex, Qt
 
+from vorta import config
+from vorta.i18n import translate
 from vorta.utils import borg_compat
 from vorta.views.extract_dialog import ExtractTree, FileData
 from vorta.views.partials.treemodel import FileSystemItem, path_to_str
@@ -19,9 +21,17 @@ class BorgExtractJob(BorgJob):
     def finished_event(self, result):
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
-        self.app.backup_progress_event.emit(
-            f"[{self.params['profile_name']}] {self.tr('Restored files from archive.')}"
-        )
+        if result['returncode'] != 0:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] "
+                + translate(
+                    'BorgExtractJob', 'Extract command has failed. See the <a href="{0}">logs</a> for details.'
+                ).format(config.LOG_DIR.as_uri())
+            )
+        else:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] {self.tr('Restored files from archive.')}"
+            )
 
     @classmethod
     def prepare(cls, profile, archive_name, model: ExtractTree, destination_folder):

--- a/src/vorta/borg/info_archive.py
+++ b/src/vorta/borg/info_archive.py
@@ -1,3 +1,5 @@
+from vorta import config
+from vorta.i18n import translate
 from vorta.store.models import ArchiveModel, RepoModel
 from vorta.utils import borg_compat
 
@@ -12,7 +14,17 @@ class BorgInfoArchiveJob(BorgJob):
     def finished_event(self, result):
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
-        self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Refreshing archive done.')}")
+        if result['returncode'] != 0:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] "
+                + translate(
+                    'BorgInfoArchiveJob', 'Info command has failed. See the <a href="{0}">logs</a> for details.'
+                ).format(config.LOG_DIR.as_uri())
+            )
+        else:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] {self.tr('Refreshing archive done.')}"
+            )
 
     @classmethod
     def prepare(cls, profile, archive_name):

--- a/src/vorta/borg/mount.py
+++ b/src/vorta/borg/mount.py
@@ -25,10 +25,6 @@ class BorgMountJob(BorgJob):
                     'BorgMountJob', 'Mount command has failed. See the <a href="{0}">logs</a> for details.'
                 ).format(config.LOG_DIR.as_uri())
             )
-        else:
-            self.app.backup_progress_event.emit(
-                f"[{self.params['profile_name']}] {self.tr('Restored files from archive.')}"
-            )
 
     @classmethod
     def prepare(cls, profile, archive: str = None):

--- a/src/vorta/borg/mount.py
+++ b/src/vorta/borg/mount.py
@@ -16,7 +16,6 @@ class BorgMountJob(BorgJob):
         self.updated.emit(self.tr('Mounting archive into folder…'))
 
     def finished_event(self, result):
-        self.app.backup_finished_event.emit(result)
         self.result.emit(result)
         if result['returncode'] != 0:
             self.app.backup_progress_event.emit(

--- a/src/vorta/borg/prune.py
+++ b/src/vorta/borg/prune.py
@@ -22,7 +22,6 @@ class BorgPruneJob(BorgJob):
 
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
-        self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Pruning done.')}")
         if result['returncode'] != 0:
             self.app.backup_progress_event.emit(
                 f"[{self.params['profile_name']}] "
@@ -31,7 +30,7 @@ class BorgPruneJob(BorgJob):
                 ).format(config.LOG_DIR.as_uri())
             )
         else:
-            self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Pruning completed.')}")
+            self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Pruning done.')}")
 
     @classmethod
     def prepare(cls, profile):

--- a/src/vorta/borg/prune.py
+++ b/src/vorta/borg/prune.py
@@ -1,3 +1,5 @@
+from vorta import config
+from vorta.i18n import translate
 from vorta.store.models import RepoModel
 from vorta.utils import borg_compat, format_archive_name
 
@@ -21,6 +23,15 @@ class BorgPruneJob(BorgJob):
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
         self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Pruning done.')}")
+        if result['returncode'] != 0:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] "
+                + translate(
+                    'BorgPruneJob', 'Prune command has failed. See the <a href="{0}">logs</a> for details.'
+                ).format(config.LOG_DIR.as_uri())
+            )
+        else:
+            self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Pruning completed.')}")
 
     @classmethod
     def prepare(cls, profile):

--- a/src/vorta/borg/umount.py
+++ b/src/vorta/borg/umount.py
@@ -14,7 +14,6 @@ class BorgUmountJob(BorgJob):
         self.updated.emit(self.tr('Unmounting archive…'))
 
     def finished_event(self, result):
-        self.app.backup_finished_event.emit(result)
         self.result.emit(result)
         if result['returncode'] != 0:
             self.app.backup_progress_event.emit(

--- a/src/vorta/borg/umount.py
+++ b/src/vorta/borg/umount.py
@@ -2,6 +2,9 @@ import os.path
 
 import psutil
 
+from vorta import config
+from vorta.i18n import translate
+
 from ..i18n import trans_late
 from .borg_job import BorgJob
 
@@ -9,6 +12,17 @@ from .borg_job import BorgJob
 class BorgUmountJob(BorgJob):
     def started_event(self):
         self.updated.emit(self.tr('Unmounting archive…'))
+
+    def finished_event(self, result):
+        self.app.backup_finished_event.emit(result)
+        self.result.emit(result)
+        if result['returncode'] != 0:
+            self.app.backup_progress_event.emit(
+                f"[{self.params['profile_name']}] "
+                + translate(
+                    'BorgMountJob', 'Umount command has failed. See the <a href="{0}">logs</a> for details.'
+                ).format(config.LOG_DIR.as_uri())
+            )
 
     @classmethod
     def prepare(cls, profile, mount_point, archive_name=None):

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -348,7 +348,7 @@ class VortaScheduler(QtCore.QObject):
             else:
                 # int to big to pass it to qt which expects a c++ int
                 # wait 15 min for regular reschedule
-                logger.debug(f"Couldn't schedule for {next_time} because " f"timer value {timer_ms} too large.")
+                logger.debug(f"Couldn't schedule for {next_time} because timer value {timer_ms} too large.")
 
                 self.timers[profile_id] = {
                     'dt': next_time,

--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -177,7 +177,7 @@ def get_misc_settings() -> List[Dict[str, str]]:
                 'type': 'checkbox',
                 'label': trans_late(
                     'settings',
-                    "If the system tray isn't available, " "ask whether to continue in the background " "on exit",
+                    "If the system tray isn't available, ask whether to continue in the background on exit",
                 ),
             },
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixes [#1940](https://github.com/borgbase/vorta/issues/1974)

I think it would be better to show Borg's error messages inside Vorta's exception dialog instead of relying on the tiny progress event box.
Now most of Borgs' commands would have a "started" and "finished" messages appears in the progress event box, and the errors would appear in the exception dialog.

I also added `finished_event` function to `mount` and `umuont`, I'm not sure but I think it should have error handling also, just as the rest of the commands.

Now the command that doesn't have that change are `info_archive`, `info_repo`, `init`, `version`, and `rename`.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#1940](https://github.com/borgbase/vorta/issues/1974)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it by changing Borg's commands from the source code to force them to fail and return non-zero code, and the result for all the commands is just like the screen record.

### Screen Record:

https://github.com/user-attachments/assets/229ef7b4-2bbb-4fcb-a9b1-6abb893f191b



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
