### PR TITLE
Adding Flatpak app caches to "All Cache Files" exclusion preset.

### DIFF
--- a/src/vorta/assets/exclusion_presets/temp.json
+++ b/src/vorta/assets/exclusion_presets/temp.json
@@ -18,16 +18,16 @@
         "slug": "cache-files",
         "patterns": [
             "fm:*/.cache",
-            "fm:*/Caches"
-            "fm:*/.var/app/*/cache"
-            "fm:*/.var/app/*/Cache"
-            "fm:*/.var/app/*/Code Cache"
-            "fm:*/.var/app/*/DawnCache"
-            "fm:*/.var/app/*/GPUCache"
-            "fm:*/.var/app/*/CacheStorage"
-            "fm:*/.var/app/*/ScriptCache"
-            "fm:*/.var/app/*/.ld.so"
-            "fm:*/.var/app/*/tmp/*
+            "fm:*/Caches",
+            "fm:*/.var/app/*/cache",
+            "fm:*/.var/app/*/Cache",
+            "fm:*/.var/app/*/Code Cache",
+            "fm:*/.var/app/*/DawnCache",
+            "fm:*/.var/app/*/GPUCache",
+            "fm:*/.var/app/*/CacheStorage",
+            "fm:*/.var/app/*/ScriptCache",
+            "fm:*/.var/app/*/.ld.so",
+            "fm:*/.var/app/*/tmp/*"
         ],
         "tags": [
             "type:system","os:linux", "os:darwin"],

--- a/src/vorta/assets/exclusion_presets/temp.json
+++ b/src/vorta/assets/exclusion_presets/temp.json
@@ -19,6 +19,15 @@
         "patterns": [
             "fm:*/.cache",
             "fm:*/Caches"
+            "fm:*/.var/app/*/cache"
+            "fm:*/.var/app/*/Cache"
+            "fm:*/.var/app/*/Code Cache"
+            "fm:*/.var/app/*/DawnCache"
+            "fm:*/.var/app/*/GPUCache"
+            "fm:*/.var/app/*/CacheStorage"
+            "fm:*/.var/app/*/ScriptCache"
+            "fm:*/.var/app/*/.ld.so"
+            "fm:*/.var/app/*/tmp/*
         ],
         "tags": [
             "type:system","os:linux", "os:darwin"],


### PR DESCRIPTION
### Description
On temp.json, added a few more patterns to the "All Cache File" exclusion preset. Excluded directories:
 -  *Cache dirs (though listed without a wildcard to avoid greedy matching);
 -  .ld.so library linking cache;
 -  tmp dir.

### Related Issue
#2230 

### Motivation and Context
Going to Sources > Manage Excluded Items... > Presets and selecting "All Cache Files", Flatpak application caches are still included in backup. This fixes that.

### How Has This Been Tested?
I've tested this by adding the proposed changes to the "Raw" exclusion patterns tab. I've also tested manually removing the dirs from a few few Flatpak apps and they regenerated these without issue on their next run.

### Screenshots (if appropriate):
None.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
