### PR TITLE
Re-arrange tasks to get correct finished event

### DIFF
--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -62,9 +62,9 @@ class BorgCreateJob(BorgJob):
         self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Backup started.')}")
 
     def finished_event(self, result):
+        self.pre_post_backup_cmd(self.params, cmd='post_backup_cmd', returncode=result['returncode'])
         self.app.backup_finished_event.emit(result)
         self.result.emit(result)
-        self.pre_post_backup_cmd(self.params, cmd='post_backup_cmd', returncode=result['returncode'])
 
     @classmethod
     def pre_post_backup_cmd(cls, params, cmd='pre_backup_cmd', returncode=0):


### PR DESCRIPTION
Shows the correct status after a backup is finished.

I'm guessing the issue is that we run another task after emitting the 'finished' event.

Fixes #2120 