### PR TITLE
Issue/2198 fix

### DIFF
--- a/src/vorta/keyring/kwallet.py
+++ b/src/vorta/keyring/kwallet.py
@@ -61,6 +61,12 @@ class VortaKWallet5Keyring(VortaKeyring):
 
     def try_unlock(self):
         wallet_name = self.get_result("networkWallet")
+        if not wallet_name or not isinstance(wallet_name, str) or wallet_name.strip() == "":
+            logger.error(
+                "KWallet: Could not determine a valid wallet name from 'networkWallet'. Aborting unlock attempt."
+            )
+            self.handle = -2
+            return
         wId = QVariant(0)
         wId.convert(QMetaType(QMetaType.Type.LongLong.value))
         output = self.get_result("open", args=[wallet_name, wId, 'vorta-repo'])

--- a/src/vorta/keyring/kwallet.py
+++ b/src/vorta/keyring/kwallet.py
@@ -1,25 +1,54 @@
 import logging
 import os
+from enum import Enum
 
 from PyQt6 import QtDBus
 from PyQt6.QtCore import QMetaType, QVariant
+from PyQt6.QtDBus import QDBusMessage
+from PyQt6.QtWidgets import QInputDialog
 
+from vorta.i18n import translate
 from vorta.keyring.abc import VortaKeyring
 
 logger = logging.getLogger(__name__)
 
 
-class VortaKWallet5Keyring(VortaKeyring):
-    """A wrapper for the qtdbus package to support the custom keyring backend"""
+class KWalletResult(Enum):
+    """Enum representing the possible results from KWallet operations."""
 
-    folder_name = 'Vorta'
+    INVALID = 0
+    SUCCESS = 1
+    FAILURE = 2
+
+    @staticmethod
+    def from_variant(variant):
+        """Convert a QVariant to a KWalletResult.
+
+        Args:
+            variant: The QVariant to convert.
+
+        Returns:
+            KWalletResult: The corresponding KWalletResult value.
+        """
+        try:
+            return KWalletResult(variant)
+        except ValueError:
+            return KWalletResult.INVALID
+
+
+class VortaKWallet5Keyring(VortaKeyring):
+    """A wrapper for the qtdbus package to support the custom keyring backend."""
+
+    folder_name = "Vorta"
     service_name = "org.kde.kwalletd5"
     object_path = "/modules/kwalletd5"
-    interface_name = 'org.kde.KWallet'
+    interface_name = "org.kde.KWallet"
 
     def __init__(self):
-        """
-        Test whether DBus and KDEWallet are available.
+        """Initialize the KWallet keyring and test DBus and KDEWallet availability.
+
+        Raises:
+            KWalletNotAvailableException: If KWallet is not available or enabled.
         """
         self.iface = QtDBus.QDBusInterface(
             self.service_name,
@@ -28,10 +57,17 @@ class VortaKWallet5Keyring(VortaKeyring):
             QtDBus.QDBusConnection.sessionBus(),
         )
         self.handle = -1
-        if not (self.iface.isValid() and self.get_result("isEnabled") is True):
+        if not (self.iface.isValid() and self.get_result("isEnabled") is KWalletResult.SUCCESS):
             raise KWalletNotAvailableException
 
     def set_password(self, service, repo_url, password):
+        """Set a password in the KWallet.
+
+        Args:
+            service: The service name.
+            repo_url: The repository URL.
+            password: The password to store.
+        """
         self.get_result(
             "writePassword",
             args=[self.handle, self.folder_name, repo_url, password, service],
@@ -39,50 +75,112 @@ class VortaKWallet5Keyring(VortaKeyring):
         logger.debug(f"Saved password for repo {repo_url}")
 
     def get_password(self, service, repo_url):
+        """Retrieve a password from the KWallet.
+
+        Args:
+            service: The service name.
+            repo_url: The repository URL.
+
+        Returns:
+            str or None: The retrieved password, or None if not found.
+        """
         if not (
-            self.is_unlocked and self.get_result("hasEntry", args=[self.handle, self.folder_name, repo_url, service])
+            self.is_unlocked
+            and self.get_result("hasEntry", args=[self.handle, self.folder_name, repo_url, service])
+            is KWalletResult.SUCCESS
         ):
             return None
         password = self.get_result("readPassword", args=[self.handle, self.folder_name, repo_url, service])
-        logger.debug(f"Retrieved password for repo {repo_url}")
+        logger.debug(translate("KWallet", f"Retrieved password for repo {repo_url}"))
         return password
 
     def get_result(self, method, args=[]):
+        """Call a DBus method and process the result.
+
+        Args:
+            method: The DBus method to call.
+            args: The arguments to pass to the method.
+
+        Returns:
+            KWalletResult: The result of the DBus call.
+        """
         if args:
             result = self.iface.callWithArgumentList(QtDBus.QDBus.CallMode.AutoDetect, method, args)
         else:
             result = self.iface.call(QtDBus.QDBus.CallMode.AutoDetect, method)
-        return result.arguments()[0]
+
+        if result.type() == QDBusMessage.MessageType.ErrorMessage:
+            logger.error(translate("KWallet", f"Method '{method}' returned an error message."))
+            return KWalletResult.INVALID
+
+        return KWalletResult.from_variant(result.arguments())
 
     @property
     def is_unlocked(self):
+        """Check if the wallet is unlocked.
+
+        Returns:
+            bool: True if the wallet is unlocked, False otherwise.
+        """
         self.try_unlock()
         return self.handle > 0
 
     def try_unlock(self):
+        """Attempt to unlock the wallet.
+
+        Raises:
+            ValueError: If the wallet name is invalid or unlocking fails.
+        """
         wallet_name = self.get_result("networkWallet")
-        if not wallet_name or not isinstance(wallet_name, str) or wallet_name.strip() == "":
-            logger.error(
-                "KWallet: Could not determine a valid wallet name from 'networkWallet'. Aborting unlock attempt."
+        if wallet_name == KWalletResult.INVALID:
+            wallet_name, ok = QInputDialog.getText(
+                None,
+                translate("KWallet", "Create Wallet"),
+                translate("KWallet", "Enter a name for the new wallet:"),
             )
-            self.handle = -2
-            return
+            if not ok or not wallet_name.strip():
+                logger.error(
+                    translate(
+                        "KWallet",
+                        "Could not determine a valid wallet name. Aborting unlock attempt.",
+                    )
+                )
+                self.handle = -2
+                return
+
         wId = QVariant(0)
         wId.convert(QMetaType(QMetaType.Type.LongLong.value))
-        output = self.get_result("open", args=[wallet_name, wId, 'vorta-repo'])
+        output = self.get_result("open", args=[wallet_name, wId, "vorta-repo"])
+        if output == KWalletResult.INVALID:
+            logger.error(translate("KWallet", "Failed to open wallet. Aborting unlock attempt."))
+            self.handle = -2
+            return
+
         try:
-            self.handle = int(output)
+            self.handle = int(output.value)
         except ValueError:  # For when kwallet is disabled or dbus otherwise broken
             self.handle = -2
 
     @classmethod
     def get_priority(cls):
+        """Get the priority of the keyring.
+
+        Returns:
+            int: The priority value.
+        """
         return 6 if "KDE" in os.getenv("XDG_CURRENT_DESKTOP", "") else 4
 
     @property
     def is_system(self):
+        """Check if the keyring is a system keyring.
+
+        Returns:
+            bool: True if it is a system keyring, False otherwise.
+        """
         return True
 
 
 class KWalletNotAvailableException(Exception):
+    """Exception raised when KWallet is not available."""
+
     pass

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -924,7 +924,9 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             for archive in archives:
                 for entry in self.archiveTable.findItems(archive, QtCore.Qt.MatchFlag.MatchExactly):
                     self.archiveTable.removeRow(entry.row())
-                ArchiveModel.get(name=archive).delete_instance()
+                archive_obj = ArchiveModel.get_or_none(name=archive)
+                if archive_obj:
+                    archive_obj.delete_instance()
 
         self._toggle_all_buttons(True)
 

--- a/tests/unit/test_kwallet.py
+++ b/tests/unit/test_kwallet.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt6.QtCore import QVariant
+
+from vorta.keyring.kwallet import KWalletNotAvailableException, KWalletResult, VortaKWallet5Keyring
+
+
+@pytest.fixture
+def kwallet_keyring():
+    with patch('vorta.keyring.kwallet.QtDBus.QDBusInterface') as MockInterface:
+        mock_iface = MockInterface.return_value
+        mock_iface.isValid.return_value = True
+
+        with patch.object(VortaKWallet5Keyring, 'get_result') as mock_get_result:
+            mock_get_result.side_effect = lambda method, args=[]: (
+                KWalletResult.SUCCESS if method == "isEnabled" else KWalletResult.FAILURE
+            )
+
+            mock_iface.callWithArgumentList.return_value.arguments.return_value = [KWalletResult.SUCCESS.value]
+            yield VortaKWallet5Keyring()
+
+
+@patch('vorta.keyring.kwallet.QtDBus.QDBusInterface')
+def test_init_valid(mock_iface):
+    mock_iface.return_value.isValid.return_value = True
+    with patch.object(VortaKWallet5Keyring, 'get_result', return_value=KWalletResult.SUCCESS):
+        keyring = VortaKWallet5Keyring()
+        assert keyring.iface.isValid()
+
+
+@patch('vorta.keyring.kwallet.QtDBus.QDBusInterface')
+def test_init_invalid(mock_iface):
+    mock_iface.return_value.isValid.return_value = False
+
+    with pytest.raises(KWalletNotAvailableException):
+        VortaKWallet5Keyring()
+
+
+def test_set_password(kwallet_keyring):
+    with patch.object(kwallet_keyring, 'get_result', return_value=KWalletResult.SUCCESS) as mock_get_result:
+        kwallet_keyring.set_password('test_service', 'test_repo', 'test_password')
+        mock_get_result.assert_called_once_with(
+            "writePassword",
+            args=[kwallet_keyring.handle, kwallet_keyring.folder_name, 'test_repo', 'test_password', 'test_service'],
+        )
+
+
+class MockResult:
+    def __init__(self, value):
+        self.value = value
+
+
+def test_get_password(kwallet_keyring):
+    wId = QVariant(0)
+
+    with patch.object(kwallet_keyring, 'get_result') as mock_get_result:
+        mock_get_result.side_effect = [
+            'test_wallet',  # networkWallet
+            MockResult(42),  # open
+            KWalletResult.SUCCESS,  # hasEntry
+            'test_password',  # readPassword
+        ]
+
+        password = kwallet_keyring.get_password('test_service', 'test_repo')
+
+        # Debug assertions to ensure proper flow
+        mock_get_result.assert_any_call("networkWallet")
+        mock_get_result.assert_any_call("open", args=['test_wallet', wId, 'vorta-repo'])
+        mock_get_result.assert_any_call(
+            "hasEntry", args=[kwallet_keyring.handle, kwallet_keyring.folder_name, 'test_repo', 'test_service']
+        )
+        mock_get_result.assert_any_call(
+            "readPassword", args=[kwallet_keyring.handle, kwallet_keyring.folder_name, 'test_repo', 'test_service']
+        )
+
+        assert password == 'test_password'
+
+
+def test_get_password_not_found(kwallet_keyring):
+    kwallet_keyring.iface.callWithArgumentList.return_value.arguments.return_value = [KWalletResult.FAILURE.value]
+
+    password = kwallet_keyring.get_password('test_service', 'test_repo')
+    assert password is None
+
+
+def test_try_unlock(kwallet_keyring):
+    kwallet_keyring.iface.call.return_value.arguments.return_value = ['test_wallet']
+    kwallet_keyring.iface.callWithArgumentList.return_value.arguments.return_value = [KWalletResult.SUCCESS.value]
+
+    kwallet_keyring.try_unlock()
+    assert kwallet_keyring.handle > 0


### PR DESCRIPTION
keyring/kwallet.py: Modified VortaKWallet5Keyring to use enums for results and added error handling. More logging. Reorganized methods, added more doc strings, added pytests

### Description
<!--- Describe your changes in detail -->
keyring/kwallet.py: Modified VortaKWallet5Keyring to use enums for results and added error handling. More logging. Reorganized methods, added more doc strings, added pytests

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue #2198](https://github.com/borgbase/vorta/issues/2198)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See [Issue 2198](https://github.com/borgbase/vorta/issues/2198) Added option to prompt user for wallet name if none can be found or determined.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pytest unit tests and mocks, used QT 6.9 libraries in Kubuntu Linux. (Noble 24.04), and "works-on-my-machine" test :)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
