### PR TITLE
Add exclude pattern for Java development artefacts

### DIFF
--- a/src/vorta/assets/exclusion_presets/dev.json
+++ b/src/vorta/assets/exclusion_presets/dev.json
@@ -118,5 +118,16 @@
         "tags": [
             "type:system", "os:linux", "os:darwin"],
         "author": "shivansh02"
+    },
+    {
+        "name": "Java Development Artefacts",
+        "slug": "java-development-artefacts",
+        "patterns": [
+            "fm:*/.jdk/*",
+            "fm:*/.m2/*",
+            "fm:*/.gradle/*"
+        ],
+        "tags": ["type:dev", "lang:java", "os:linux", "os:darwin"],
+        "author": "MrMinemeet"
     }
 ]


### PR DESCRIPTION
Adds exclusion patterns for java development artifacts, i.e. `.jdk`, `.gradle` and `.m2` directories.

### Description
Dev environments such as IntelliJ pull additional JDK versions into `.jdk` directories.
`.m2` and `.gradle` are artefact directories for Maven and Gradle respectively 

### Related Issue
-

### Motivation and Context
Reduce amount of (temporary) artifacts that get backed up 

### How Has This Been Tested?
Change still provides valid JSON

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
