### PR TITLE
Fix the blank entry in the Custom exclusion

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -946,7 +946,9 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
             for archive in archives:
                 for entry in self.archiveTable.findItems(archive, QtCore.Qt.MatchFlag.MatchExactly):
                     self.archiveTable.removeRow(entry.row())
-                ArchiveModel.get(name=archive).delete_instance()
+                archive_obj = ArchiveModel.get_or_none(name=archive)
+                if archive_obj:
+                    archive_obj.delete_instance()
 
         self._toggle_all_buttons(True)
 

--- a/src/vorta/views/exclude_dialog.py
+++ b/src/vorta/views/exclude_dialog.py
@@ -313,18 +313,19 @@ class ExcludeDialog(ExcludeDialogBase, ExcludeDialogUi):
         When the user checks or unchecks an item, update the database.
         When the user adds a new item, add it to the database.
         '''
-        if not ExclusionModel.get_or_none(
-            name=item.text(), source=ExclusionModel.SourceFieldOptions.CUSTOM.value, profile=self.profile
-        ):
-            ExclusionModel.create(
+        if item.text().strip():  # Ensure the item text is not empty before adding to DB
+            if not ExclusionModel.get_or_none(
                 name=item.text(), source=ExclusionModel.SourceFieldOptions.CUSTOM.value, profile=self.profile
-            )
+            ):
+                ExclusionModel.create(
+                    name=item.text(), source=ExclusionModel.SourceFieldOptions.CUSTOM.value, profile=self.profile
+                )
 
-        ExclusionModel.update(enabled=item.checkState() == Qt.CheckState.Checked).where(
-            ExclusionModel.name == item.text(),
-            ExclusionModel.source == ExclusionModel.SourceFieldOptions.CUSTOM.value,
-            ExclusionModel.profile == self.profile,
-        ).execute()
+            ExclusionModel.update(enabled=item.checkState() == Qt.CheckState.Checked).where(
+                ExclusionModel.name == item.text(),
+                ExclusionModel.source == ExclusionModel.SourceFieldOptions.CUSTOM.value,
+                ExclusionModel.profile == self.profile,
+            ).execute()
 
         self.populate_preview_tab()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR fixes the blank item that was getting added in the Custom tab of the Exclusion dialog. Even though the blank entry was getting discarded in GUI, it stayed when reopening the dialog. The reason being, the item was added to the database as a blank entry right when it was created.

A condition check was added to check if the entry is not blank before adding to the database.

### Related Issue
Fixes #2267
Fixes https://github.com/borgbase/vorta/issues/2134 (Unrelated bug fix)

### How Has This Been Tested?
The fix has been tested with the GUI.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
