### PR TITLE
Skip darwin tests on non-darwin platforms

### DIFF
--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -3,10 +3,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-if sys.platform != 'darwin':
-    pytest.skip("Skipping darwin-only network tests", allow_module_level=True)
+pytestmark = pytest.mark.skipif(sys.platform != 'darwin', reason="macOS only")
 
-from vorta.network_status import darwin
+from vorta.network_status import darwin  # noqa: E402
 
 
 def test_get_current_wifi_when_wifi_is_on(mocker):

--- a/tests/network_manager/test_network_manager.py
+++ b/tests/network_manager/test_network_manager.py
@@ -1,10 +1,13 @@
+import sys
 from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
 
-from vorta.network_status.abc import SystemWifiInfo
-from vorta.network_status.network_manager import (
+pytestmark = pytest.mark.skipif(sys.platform != 'linux', reason="Linux only")
+
+from vorta.network_status.abc import SystemWifiInfo  # noqa: E402
+from vorta.network_status.network_manager import (  # noqa: E402
     ActiveConnectionInfo,
     DBusException,
     NetworkManagerDBusAdapter,


### PR DESCRIPTION
### Description
Adds a simple check to skip a darwin-only test on non-darwin platforms

### Related Issue
#2318 

### Motivation and Context
I want to be able to run the tests on my Linux machine :)

### How Has This Been Tested?
Ran tests, they all ran except for the darwin one which was skipped as expected

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
