### PR TITLE
Remove wrapper lambda from SchedulePage signal connection

### DIFF
--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -61,7 +61,7 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
             lambda new_val, attr='compaction_weeks': self.save_profile_attr(attr, new_val)
         )
 
-        self.app.scheduler.schedule_changed.connect(lambda pid: self.draw_next_scheduled_backup())
+        self.app.scheduler.schedule_changed.connect(self.draw_next_scheduled_backup)
         self.populate_from_profile()
 
         # Listen for events
@@ -110,7 +110,7 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
 
         self.draw_next_scheduled_backup()
 
-    def draw_next_scheduled_backup(self):
+    def draw_next_scheduled_backup(self, pid=None):
         status = self.app.scheduler.next_job_for_profile(self.profile().id)
         if status.type in (
             ScheduleStatusType.SCHEDULED,


### PR DESCRIPTION
This should fix #2320 - after digging in a bit and comparing object addresses, it appeared that this was caused by a `schedule_changed` signal being sent to the `SchedulePage` from the MainWindow that is deleted in `init_db`.

Manually disconnecting that signal before deleting the old `MainWindow` resolved the error, and after trying some better options, found that simply removing the lambda and connecting the method directly (and adding an optional parameter to make it compatible with the signal's signature) also fixed the test.

I'm not very familiar with Qt6 specifically, but I suspect the lambda was causing some sort of lifetime issues, maybe the lambda itself was somehow outliving `SchedulePage` and preventing the signal from being deleted?

In any case, this seems like a pretty simple change that makes the tests happy on my machine.

### Related Issue
#2320 

### Motivation and Context
I want to run the tests, still :)

### How Has This Been Tested?
Ran the tests. They still succeeded.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
