### PR TITLE
refactor: remove unused profile_id from schedule_changed signal

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -37,8 +37,8 @@ class ScheduleStatus(NamedTuple):
 
 
 class VortaScheduler(QtCore.QObject):
-    #: The schedule for the profile with the given id changed.
-    schedule_changed = QtCore.pyqtSignal(int)
+    #: The schedule for a profile changed.
+    schedule_changed = QtCore.pyqtSignal()
 
     def __init__(self):
         super().__init__()
@@ -222,13 +222,13 @@ class VortaScheduler(QtCore.QObject):
                     profile_id,
                 )
                 # Emit signal so that e.g. the GUI can react to the new schedule
-                self.schedule_changed.emit(profile_id)
+                self.schedule_changed.emit()
                 return
 
             if profile.schedule_mode == 'off':
                 logger.debug('Scheduler for profile %s is disabled.', profile_id)
                 # Emit signal so that e.g. the GUI can react to the new schedule
-                self.schedule_changed.emit(profile_id)
+                self.schedule_changed.emit()
                 return
 
             logger.info('Setting timer for profile %s', profile_id)
@@ -267,7 +267,7 @@ class VortaScheduler(QtCore.QObject):
                 )
                 self.timers[profile_id] = {'type': ScheduleStatusType.NO_PREVIOUS_BACKUP}
                 # Emit signal so that e.g. the GUI can react to the new schedule
-                self.schedule_changed.emit(profile_id)
+                self.schedule_changed.emit()
                 return
 
             # calculate next scheduled time
@@ -356,7 +356,7 @@ class VortaScheduler(QtCore.QObject):
                 }
 
         # Emit signal so that e.g. the GUI can react to the new schedule
-        self.schedule_changed.emit(profile_id)
+        self.schedule_changed.emit()
 
     def reload_all_timers(self):
         logger.debug('Refreshing all scheduler timers')

--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -61,9 +61,7 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
             lambda new_val, attr='compaction_weeks': self.save_profile_attr(attr, new_val)
         )
 
-        self._schedule_changed_connection = self.app.scheduler.schedule_changed.connect(
-            lambda pid: self.draw_next_scheduled_backup()
-        )
+        self._schedule_changed_connection = self.app.scheduler.schedule_changed.connect(self.draw_next_scheduled_backup)
         self.destroyed.connect(self._on_destroyed)
         self.populate_from_profile()
 

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -30,7 +30,7 @@ def test_schedule_tab(qapp: VortaApp, qtbot, clockmock):
 
     # Work around
     # because already 'deleted' scheduletabs are still connected to the signal
-    qapp.scheduler.schedule_changed.connect(lambda *args: tab.draw_next_scheduled_backup())
+    qapp.scheduler.schedule_changed.connect(tab.draw_next_scheduled_backup)
 
     # Test
     qtbot.mouseClick(tab.scheduleOffRadio, QtCore.Qt.MouseButton.LeftButton)


### PR DESCRIPTION
The int parameter emitted by schedule_changed was never used by any connected handlers - they all discarded it and retrieved the profile ID via self.profile().id instead. This simplifies the signal to emit no parameters and allows direct method connections without lambda wrappers.

Continuation of https://github.com/borgbase/vorta/pull/2321 by [@cincodenada](https://github.com/cincodenada)