### PR TITLE
Fix spelling errors in comments, docstrings, and UI widget names

### DIFF
--- a/src/vorta/assets/UI/about_tab.ui
+++ b/src/vorta/assets/UI/about_tab.ui
@@ -118,7 +118,7 @@
         </layout>
        </item>
        <item>
-        <widget class="QFrame" name="seperator">
+        <widget class="QFrame" name="separator">
          <property name="frameShape">
           <enum>QFrame::HLine</enum>
          </property>
@@ -223,7 +223,7 @@
         </layout>
        </item>
        <item>
-        <widget class="QFrame" name="seperator">
+        <widget class="QFrame" name="separator">
          <property name="frameShape">
           <enum>QFrame::HLine</enum>
          </property>

--- a/src/vorta/borg/info_archive.py
+++ b/src/vorta/borg/info_archive.py
@@ -46,7 +46,7 @@ class BorgInfoArchiveJob(BorgJob):
                     archive = ArchiveModel.get_or_none(name=remote_archive['name'], repo=repo_id)
                     archive.snapshot_id = remote_archive['id']
 
-                archive.name = remote_archive['name']  # incase name changed
+                archive.name = remote_archive['name']  # in case name changed
                 # archive.time = parser.parse(remote_archive['time'])
                 archive.duration = remote_archive['duration']
                 archive.size = remote_archive['stats']['deduplicated_size']

--- a/src/vorta/profile_export.py
+++ b/src/vorta/profile_export.py
@@ -100,7 +100,7 @@ class ProfileExport:
             while BackupProfileModel.get_or_none(BackupProfileModel.id == self.id) is not None:
                 self._profile_dict['id'] += 1
 
-            # Add suffix incase names are the same
+            # Add suffix in case names are the same
             if BackupProfileModel.get_or_none(BackupProfileModel.name == self.name) is not None:
                 suffix = 1
                 while BackupProfileModel.get_or_none(BackupProfileModel.name == f"{self.name}-{suffix}") is not None:

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -1045,7 +1045,7 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
     def toggle_compact_button_visibility(self):
         """
         Enable or disable the compact button depending on the Borg version.
-        This function runs once on startup, and everytime the profile is changed.
+        This function runs once on startup, and every time the profile is changed.
         """
         if borg_compat.check("COMPACT_SUBCOMMAND"):
             self.compactButton.setEnabled(True)

--- a/src/vorta/views/partials/treemodel.py
+++ b/src/vorta/views/partials/treemodel.py
@@ -412,7 +412,7 @@ class FileTreeModel(QAbstractItemModel, Generic[T]):
         This is called by `addItem` in a reduce statement. It should
         add a new child with the given attributes to the given item.
         This implementation provides a reasonable default, most subclasses
-        wont need to override this method. The implementation should make use
+        won't need to override this method. The implementation should make use
         of `_make_filesystemitem`, `_merge_data`, `_add_children`.
 
         Parameters
@@ -562,7 +562,7 @@ class FileTreeModel(QAbstractItemModel, Generic[T]):
 
         In TREE mode (default) the tree will be displayed as is.
         In SIMPLIFIED_TREE items will simplify the tree by combining
-        items with their single child if they posess only one.
+        items with their single child if they possess only one.
         In FLAT mode items will be displayed as a simple list. The items
         shown can be filtered by `_flat_filter`.
 


### PR DESCRIPTION
# Fix spelling errors in comments, docstrings, and UI widget names

### Description

This PR fixes several spelling errors identified using codespell across the codebase:

| File                                    | Line     | Typo                    | Fix        |
| --------------------------------------- | -------- | ----------------------- | ---------- |
| `src/vorta/profile_export.py`           | 103      | incase                  | in case    |
| `src/vorta/borg/info_archive.py`        | 49       | incase                  | in case    |
| `src/vorta/views/archive_tab.py`        | 1048     | everytime               | every time |
| `src/vorta/views/partials/treemodel.py` | 415      | wont                    | won't      |
| `src/vorta/views/partials/treemodel.py` | 565      | posess                  | possess    |
| `src/vorta/assets/UI/about_tab.ui`      | 121, 226 | seperator (widget name) | separator  |

### Related Issue

Fixes #2371

### Motivation and Context

Clean up spelling errors to improve code readability and maintain code quality. The `seperator` fix in `about_tab.ui` is a widget name attribute that is not referenced anywhere in Python code, so renaming is safe.

### How Has This Been Tested?

- All pre-commit checks pass (ruff, ruff-format, trailing whitespace, etc.)
- Changes are limited to comments, docstrings, and an unreferenced UI widget name, so no functional testing is required

### Screenshots (if appropriate):

N/A - No visual changes

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

_I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco]._

[dco]: https://developercertificate.org/
