### PR TITLE
Add codespell spell-checking to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,15 @@ repos:
       # Run the formatter.
       - id: ruff-format
 
+  # spell checking
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        exclude: "^src/vorta/i18n/|uv\\.lock"
+        additional_dependencies:
+          - tomli
+
   # format python files
   # - repo: https://github.com/psf/black
   #   rev: 22.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,10 @@ ignore = [
 [tool.ruff.format]
 quote-style = "preserve"
 
+[tool.codespell]
+skip = "src/vorta/i18n,*.qm"
+ignore-words-list = "doubleclick,caf,datas"
+
 [tool.pytest.ini_options]
 addopts = "-vs"
 testpaths = ["tests"]


### PR DESCRIPTION
Adds codespell (v2.4.1) as a pre-commit hook to catch spelling errors      
  before commits are pushed. Configuration in pyproject.toml excludes
  translation files (i18n), lock files, and known false positives (Qt enum     names, unicode test strings, PyInstaller keywords).                        
                                                                             
  Closes #2374

  ### Description

  Add `codespell` spell-checking to the existing pre-commit hook
  configuration to automatically catch typos before code is committed.       

  **`.pre-commit-config.yaml`:**
  - Add codespell hook (v2.4.1) after the ruff hooks
  - Exclude `src/vorta/i18n/` (non-English Qt Linguist translation files) and
   `uv.lock` (contains package name `astroid`)
  - Include `tomli` as additional dependency for pyproject.toml config       
  reading

  **`pyproject.toml`:**
  - Add `[tool.codespell]` configuration section
  - `skip`: i18n directory and `.qm` binary files (for direct CLI usage      
  outside pre-commit)
  - `ignore-words-list`: `doubleclick` (Qt enum
  `QSystemTrayIcon.ActivationReason.DoubleClick`), `caf` (part of unicode    
  `café` in test path), `datas` (PyInstaller `Analysis()` keyword)

  ### Related Issue

  Closes #2374

  ### Motivation and Context

  Issue #2371 identified several spelling errors (`incase`, `everytime`,     
  `wont`, `posess`, `seperator`) that had to be caught manually. Adding      
  codespell to pre-commit hooks prevents typos from reaching the codebase in 
  the first place, using the existing pre-commit infrastructure that
  contributors already have set up.

  ### How Has This Been Tested?

  - `uv run pre-commit run codespell --all-files` — passes clean with zero   
  findings
  - `uv run pre-commit run --all-files` — all 9 hooks pass
  - Verified codespell catches real typos by testing with deliberate
  misspellings (`speling`, `eror`) — both were detected
  - Verified all 3 suppressed words are genuine false positives:
    - `doubleclick` → Qt enum value in `tray_menu.py:39`
    - `caf` → part of unicode literal `caf\u00e9` (café) in
  `test_utils.py:118`
    - `datas` → PyInstaller API keyword in `package/vorta.spec:23,57`        
  - Verified all excluded paths only contain false positives (hundreds of    
  non-English words in translation files, `astroid` package name in lock     
  file)

  ### Screenshots (if appropriate):
<img width="727" height="693" alt="image" src="https://github.com/user-attachments/assets/1caf44b2-54b6-4965-8eca-51142edba408" />


  N/A — No visual changes

  ### Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing
  functionality to change)

  ### Checklist:
  - [x] I have read the
  [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.

  *I provide my contribution under the terms of the
  [license](./../LICENSE.txt) of this repository and I affirm the [Developer 
  Certificate of Origin][dco].*

  [dco]: https://developercertificate.org/