### PR TITLE
Add make lint-staged target for faster development workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export VORTA_SRC := src/vorta
 export APPSTREAM_METADATA := src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
 VERSION := $(shell uv run python -c "from src.vorta._version import __version__; print(__version__)")
 
-.PHONY: help clean lint test test-unit test-integration \
+.PHONY: help clean lint lint-staged test test-unit test-integration \
         bump-version pypi-release release-preflight changelog update-appcast \
         translations-from-source translations-push translations-pull translations-to-qm translations-update \
         flatpak-install
@@ -91,6 +91,9 @@ flatpak-install: translations-to-qm
 
 lint:
 	uv run pre-commit run --all-files --show-diff-on-failure
+
+lint-staged:  ## Run linting on staged files only
+	uv run pre-commit run --show-diff-on-failure
 
 test:
 	uv run nox -- --cov=vorta


### PR DESCRIPTION
### Description

This PR adds a new `make lint-staged` target to the Makefile that runs pre-commit hooks only on staged files, providing faster feedback during development.

**Changes:**
- Added `lint-staged` target that runs `uv run pre-commit run --show-diff-on-failure`
- Updated `.PHONY` declaration to include the new target
- The new target is documented with `## Run linting on staged files only` so it appears in `make help`

The existing `make lint` target remains unchanged and continues to lint all files, which is useful for comprehensive checks and CI workflows.

### Related Issue

Resolves #2382

### Motivation and Context

Currently, `make lint` runs pre-commit on all files (`--all-files`), which can be slow during active development. While developers can run `uv run pre-commit run` directly to lint only staged files, this command is not documented in the Makefile and is less discoverable for contributors.

This change:
- Provides faster iteration during development (only checks staged files)
- Makes the command more discoverable through `make help`
- Follows the existing pattern of other make targets
- Improves developer experience without changing existing workflows

### How Has This Been Tested?

**Test 1: With linting errors**
- Created a Python file with intentional linting issues (unused imports, formatting errors)
- Ran `uv run pre-commit run --show-diff-on-failure`
- Verified that ruff caught errors and ruff-format auto-fixed formatting issues

**Test 2: Without errors**
- Fixed remaining issues and staged the clean file
- Ran the command again
- All pre-commit hooks passed successfully

**Test 3: Verified Makefile syntax**
- Confirmed the new target appears in the correct format for `make help`
- Tested that it only checks staged files (pre-commit stashed unstaged files as expected)

### Screenshots (if appropriate):
<img width="272" height="848" alt="image" src="https://github.com/user-attachments/assets/522ff707-ac62-4c12-95f1-60dbb2d038b4" />


### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/
