### PR TITLE
Fix CI test matrix inconsistencies

### DIFF
--- a/.github/scripts/generate-matrix.sh
+++ b/.github/scripts/generate-matrix.sh
@@ -25,6 +25,6 @@ elif [[ "$event_name" == "push" ]] || [[ "$event_name" == "pull_request" ]]; the
     echo '{
       "python-version": ["3.12"],
       "os": ["ubuntu-24.04"],
-      "borg-version": ["1.4.2"]
+      "borg-version": ["1.4.3"]
     }' | jq -c . > matrix-integration.json
 fi

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,7 +13,7 @@ on:
       macos_version:
         description: 'macOS version for building'
         required: true
-        default: 'macos-14'
+        default: 'macos-15'
       python_version:
         description: 'Python version for building'
         required: true


### PR DESCRIPTION
- Align PR integration Borg version from 1.4.2 to 1.4.3
- Update build-macos.yml default from macos-14 to macos-15

 ### Description

  Fix two configuration inconsistencies in the CI matrix generation script 
  and macOS build workflow:

  | File | Issue | Change |
  |------|-------|--------|
  | `.github/scripts/generate-matrix.sh` | PR integration tests use Borg     
  `1.4.2` while master uses `1.4.3` | `1.4.2` → `1.4.3` |
  | `.github/workflows/build-macos.yml` | Build defaults to `macos-14` while 
  test matrix uses `macos-15` | `macos-14` → `macos-15` |

  ### Related Issue

  Closes #2377

  ### Motivation and Context

  - A PR can pass CI testing against Borg 1.4.2 but fail after merge when    
  master runs 1.4.3
  - macOS releases are built on macos-14 while tests run on macos-15, masking
   potential environment issues

  ### How Has This Been Tested?

  - CI-only configuration changes with no functional code impact
  - JSON output of both matrix script paths validated locally (all 4 blocks  
  produce valid JSON, consistent Borg versions)
  - YAML syntax of `build-macos.yml` validated locally
  - The PR's own CI run will confirm the updated matrix works end-to-end     

  ### Screenshots (if appropriate):

  N/A — No visual changes

  ### Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing
  functionality to change)

  ### Checklist:

  - [x] I have read the
  [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.

  *I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer 
  Certificate of Origin][dco].*

  [dco]: https://developercertificate.org/