### PR TITLE
Add path filters to CI to skip unnecessary runs on docs-only PRs (#2379)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [master]
   pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/**'
+      - 'noxfile.py'
+      - 'Makefile'
+      - 'package/**'
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
### Description                                                               
  Add `paths` filter to the `pull_request` trigger in                        
  `.github/workflows/test.yml` so CI only runs when relevant source or
  configuration files are modified.

  PRs that only touch documentation or metadata files (e.g., `README.md`,    
  `CONTRIBUTING.md`, `LICENSE`) will now skip the full test pipeline.        

  **Paths that trigger CI:**

  | Path | Reason |
  |------|--------|
  | `src/**` | Source code |
  | `tests/**` | Test files |
  | `pyproject.toml` | Dependencies, tool config |
  | `uv.lock` | Dependency lock file |
  | `.github/**` | CI workflows, actions, scripts |
  | `noxfile.py` | Nox test runner config |
  | `Makefile` | Build/test commands |
  | `package/**` | Packaging scripts |

  `push` to master and `workflow_dispatch` remain unfiltered.

  ### Related Issue

  Closes #2379

  ### Motivation and Context

  The test workflow triggers on all pull requests regardless of files        
  changed. Docs-only PRs spin up the full pipeline — lint, unit tests across 
  3 Python versions × 2 OSes, and integration tests — with unit tests alone  
  having a 120-minute timeout. This wastes GitHub Actions minutes and blocks 
  contributors.

  ### How Has This Been Tested?

  - CI-only YAML configuration change with no functional code changes        
  - YAML syntax validated locally
  - The PR's own CI run validates the workflow file is correctly parsed by   
  GitHub Actions

  ### Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing
  functionality to change)

  ### Checklist:

  - [x] I have read the
  [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.


  *I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer 
  Certificate of Origin][dco].*

  [dco]: https://developercertificate.org/