### PR TITLE
Remove unused self.selected_archives variable in ArchiveTab (#2388)

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -154,7 +154,6 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.prune_keep_within.editingFinished.connect(self.save_prune_setting)
 
         self.populate_from_profile()
-        self.selected_archives = None  # TODO: remove unused variable
         self.set_icons()
 
         # Connect to events


### PR DESCRIPTION
### Description                                                                                                                                                  
  Remove `self.selected_archives = None` from `ArchiveTab.__init__()` in `src/vorta/views/archive_tab.py`. This instance variable was initialized but never read
   anywhere in the codebase. It already had a `# TODO: remove unused variable` comment.

  Note: The local variable `selected_archives` used elsewhere in the same file (lines 532, 973) is unrelated — those are local variables, not the instance      
  attribute.

  ### Related Issue

  Closes #2388

  ### Motivation and Context

  Dead code cleanup. The variable was write-only and flagged with a TODO for removal.

  ### How Has This Been Tested?

  - Ruff lint and format checks pass
  - Unit tests (misc, schedule, source) pass with no regressions
  - Single-line deletion with no references — no functional impact


  ### Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ### Checklist:

  - [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.

  *I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*    

  [dco]: https://developercertificate.org/