### PR TITLE
Remove test workaround from list_repo.py, add proper error handling (#2392)

### DIFF
--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -50,12 +50,11 @@ def test_repo_list(qapp, qtbot, mocker, borg_json_output, archive_env):
     assert tab.bCheck.isEnabled()
 
 
-def test_repo_prune(qapp, qtbot, mocker, borg_json_output, archive_env):
+def test_repo_prune(qapp, qtbot, mock_borg_popen, archive_env):
     main, tab = archive_env
 
-    stdout, stderr = borg_json_output('prune')
-    popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
-    mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
+    # Prune triggers a list refresh, so we need fresh handles for both jobs
+    mock_borg_popen(['prune', 'list'])
 
     qtbot.mouseClick(tab.bPrune, QtCore.Qt.MouseButton.LeftButton)
 


### PR DESCRIPTION
 ### Description

  Remove test-specific workaround from production code and fix the underlying test infrastructure issue.                                                           
  **Changes:**                                                                                                                                                  
  - **src/vorta/borg/list_repo.py**: Remove `if not result['data']: result['data'] = {}` workaround, add proper error handling with logging for unexpected data 
  types
  - **tests/unit/conftest.py**: Add `mock_borg_popen` fixture that provides fresh file handles for each Popen call, supporting job chaining scenarios
  - **tests/unit/test_archives.py**: Update `test_repo_prune` to use new fixture (prune triggers list refresh = 2 jobs)

  ### Related Issue

  Closes #2392

  ### Motivation and Context

  Production code contained a test-specific workaround that silently masked potential errors. The root cause was test infrastructure reusing file handles across
   chained jobs - when job A (prune) read from a file handle, job B (list) would get empty content because the file position was at EOF.

  ### How Has This Been Tested?

  - Verified same tests pass/fail on both master and fix branch (no regressions)
  - Linting passes (`ruff check`)
  - Full verification will happen on CI (Linux/macOS) since the affected tests use `os.set_blocking()` which doesn't work on Windows

  ### Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ### Checklist:

  - [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.

  *I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*    

  [dco]: https://developercertificate.org/