### PR TITLE
Refactor views with BaseTab and introduce RepoTabViewModel

### DIFF
--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -56,6 +56,13 @@ class RepoModel(BaseModel):
     def is_remote_repo(self):
         return not self.url.startswith('/')
 
+    def is_shared_with_other_profiles(self, excluding_profile_id: int | None = None) -> bool:
+        """Return whether another profile still references this repository."""
+        query = BackupProfileModel.select().where(BackupProfileModel.repo == self)
+        if excluding_profile_id is not None:
+            query = query.where(BackupProfileModel.id != excluding_profile_id)
+        return query.exists()
+
     class Meta:
         database = DB
 

--- a/src/vorta/views/about_tab.py
+++ b/src/vorta/views/about_tab.py
@@ -5,8 +5,8 @@ from PyQt6 import QtCore, uic
 
 from vorta import config
 from vorta._version import __version__
-from vorta.store.models import BackupProfileMixin
 from vorta.utils import get_asset
+from vorta.views.base_tab import BaseTab
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/about_tab.ui')
@@ -15,12 +15,12 @@ AboutTabUI, AboutTabBase = uic.loadUiType(uifile)
 logger = logging.getLogger(__name__)
 
 
-class AboutTab(AboutTabBase, AboutTabUI, BackupProfileMixin):
+class AboutTab(BaseTab, AboutTabBase, AboutTabUI):
     refresh_archive = QtCore.pyqtSignal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, profile_provider=None):
         """Init."""
-        super().__init__(parent)
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(parent)
         self.versionLabel.setText(__version__)
         self.logLink.setText(

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -32,7 +32,7 @@ from vorta.borg.prune import BorgPruneJob
 from vorta.borg.rename import BorgRenameJob
 from vorta.borg.umount import BorgUmountJob
 from vorta.i18n import translate
-from vorta.store.models import ArchiveModel, BackupProfileMixin, SettingsModel
+from vorta.store.models import ArchiveModel, SettingsModel
 from vorta.utils import (
     borg_compat,
     choose_file_dialog,
@@ -43,6 +43,7 @@ from vorta.utils import (
     pretty_bytes,
 )
 from vorta.views import diff_result, extract_dialog
+from vorta.views.base_tab import BaseTab
 from vorta.views.diff_result import DiffResultDialog, DiffTree
 from vorta.views.extract_dialog import ExtractDialog, ExtractTree
 from vorta.views.source_tab import SizeItem
@@ -65,18 +66,18 @@ class IconDelegate(QStyledItemDelegate):
         option.decorationSize = option.rect.size() - QtCore.QSize(0, 10)
 
 
-class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
+class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
     prune_intervals = ['hour', 'day', 'week', 'month', 'year']
 
-    def __init__(self, parent=None, app=None):
+    def __init__(self, parent=None, app=None, profile_provider=None):
         """Init."""
-        super().__init__(parent)
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(parent)
         self.is_editing = False  # track if the cell edit was completed or canceled
         self.mount_points = {}  # mapping of archive name to mount point
         self.repo_mount_point: Optional[str] = None  # mount point of whole repo
         self.menu = None
-        self.app = app
+        self.app = app or self.app
         self.toolBox.setCurrentIndex(0)
         self.repoactions_enabled = True
         self.renamed_archive_original_name = None
@@ -158,13 +159,12 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
         self.set_icons()
 
         # Connect to events
-        self._palette_conn_1 = self.app.paletteChanged.connect(self.set_icons)
-        self._palette_conn_2 = self.app.paletteChanged.connect(self.populate_from_profile)
-        self.destroyed.connect(self._on_destroyed)
-        self.app.backup_finished_event.connect(self.populate_from_profile)
-        self.app.profile_changed_event.connect(self.populate_from_profile)
-        self.app.profile_changed_event.connect(self.toggle_compact_button_visibility)
-        self.app.backup_cancelled_event.connect(self.cancel_action)
+        self.track_palette_change()
+        self.track_palette_change(self.populate_from_profile)
+        self.track_backup_finished()
+        self.track_profile_change()
+        self.track_profile_change(self.toggle_compact_button_visibility)
+        self.track_signal(self.app.backup_cancelled_event, self.cancel_action)
 
     def set_icons(self):
         """Used when changing between light- and dark mode"""
@@ -182,13 +182,6 @@ class ArchiveTab(ArchiveTabBase, ArchiveTabUI, BackupProfileMixin):
 
         self.bmountarchive_refresh(icon_only=True)
         self.bmountrepo_refresh()
-
-    def _on_destroyed(self):
-        try:
-            self.app.paletteChanged.disconnect(self._palette_conn_1)
-            self.app.paletteChanged.disconnect(self._palette_conn_2)
-        except (TypeError, RuntimeError):
-            pass
 
     @pyqtSlot(QPoint)
     def archiveitem_contextmenu(self, pos: QPoint):

--- a/src/vorta/views/base_tab.py
+++ b/src/vorta/views/base_tab.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from PyQt6.QtWidgets import QApplication
+
+from vorta.store.models import BackupProfileModel, RepoModel
+
+ProfileProvider = Callable[[], BackupProfileModel | None]
+
+
+class BaseTab:
+    """
+    Shared functionality for tabs and nested pages that depend on the active profile.
+
+    The class keeps track of Qt signal connections so subclasses only need to declare
+    what they listen to instead of duplicating disconnect boilerplate.
+    """
+
+    def __init__(self, parent: Any = None, profile_provider: ProfileProvider | None = None) -> None:
+        super().__init__(parent)
+        self.app = QApplication.instance()
+        self._profile_provider = profile_provider or self._default_profile_provider
+        self._tracked_connections: list[tuple[Any, Any, Any]] = []
+        self.destroyed.connect(self._cleanup_tracked_connections)
+
+    def _default_profile_provider(self) -> BackupProfileModel | None:
+        current_profile = getattr(self.window(), 'current_profile', None)
+        if current_profile is None:
+            return None
+        return BackupProfileModel.get(id=current_profile.id)
+
+    def current_profile(self) -> BackupProfileModel | None:
+        return self._profile_provider()
+
+    def profile(self) -> BackupProfileModel:
+        profile = self.current_profile()
+        if profile is None:
+            raise RuntimeError("No active backup profile is available for this view.")
+        return profile
+
+    def repo(self) -> RepoModel | None:
+        return self.profile().repo
+
+    def save_profile_attr(self, attr: str, new_value: Any) -> BackupProfileModel:
+        profile = self.profile()
+        setattr(profile, attr, new_value)
+        profile.save()
+        return profile
+
+    def save_repo_attr(self, attr: str, new_value: Any) -> RepoModel | None:
+        repo = self.repo()
+        if repo is None:
+            return None
+        setattr(repo, attr, new_value)
+        repo.save()
+        return repo
+
+    def track_signal(self, signal: Any, slot: Callable[..., None]) -> Any:
+        connection = signal.connect(slot)
+        self._tracked_connections.append((signal, connection, slot))
+        return connection
+
+    def track_palette_change(self, callback: Callable[[], None] | None = None) -> Any:
+        return self.track_signal(self.app.paletteChanged, self._without_signal_args(callback or self.set_icons))
+
+    def track_profile_change(self, callback: Callable[[], None] | None = None) -> Any:
+        return self.track_signal(self.app.profile_changed_event, callback or self.populate_from_profile)
+
+    def track_backup_finished(self, callback: Callable[[], None] | None = None) -> Any:
+        return self.track_signal(self.app.backup_finished_event, callback or self.populate_from_profile)
+
+    @staticmethod
+    def _without_signal_args(callback: Callable[[], None]) -> Callable[..., None]:
+        def wrapped(*_args, **_kwargs):
+            callback()
+
+        return wrapped
+
+    def _cleanup_tracked_connections(self) -> None:
+        while self._tracked_connections:
+            signal, connection, _slot = self._tracked_connections.pop()
+            try:
+                signal.disconnect(connection)
+            except (TypeError, RuntimeError):
+                pass
+
+    def populate_from_profile(self) -> None:
+        """Template method for subclasses that render the active profile."""
+
+    def set_icons(self) -> None:
+        """Template method for subclasses that respond to palette changes."""

--- a/src/vorta/views/log_page.py
+++ b/src/vorta/views/log_page.py
@@ -1,14 +1,14 @@
 from PyQt6 import uic
 from PyQt6.QtWidgets import (
     QAbstractItemView,
-    QApplication,
     QHeaderView,
     QTableWidgetItem,
 )
 
 from vorta import config
-from vorta.store.models import BackupProfileMixin, EventLogModel
+from vorta.store.models import EventLogModel
 from vorta.utils import get_asset
+from vorta.views.base_tab import BaseTab
 
 uifile = get_asset('UI/log_page.ui')
 LogTableUI, LogTableBase = uic.loadUiType(uifile)
@@ -22,14 +22,13 @@ class LogTableColumn:
     ReturnCode = 4
 
 
-class LogPage(LogTableBase, LogTableUI, BackupProfileMixin):
-    def __init__(self, parent=None):
-        super().__init__(parent)
+class LogPage(BaseTab, LogTableBase, LogTableUI):
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(self)
         self.init_ui()
-        self._backup_finished_connection = QApplication.instance().backup_finished_event.connect(self.populate_logs)
-        self._profile_changed_connection = QApplication.instance().profile_changed_event.connect(self.populate_logs)
-        self.destroyed.connect(self._on_destroyed)
+        self.track_backup_finished(self.populate_logs)
+        self.track_profile_change(self.populate_logs)
 
     def init_ui(self):
         self.logPage.setAlternatingRowColors(True)
@@ -67,13 +66,3 @@ class LogPage(LogTableBase, LogTableUI, BackupProfileMixin):
             self.logPage.setItem(row, LogTableColumn.Repository, QTableWidgetItem(log_line.repo_url))
             self.logPage.setItem(row, LogTableColumn.ReturnCode, QTableWidgetItem(str(log_line.returncode)))
         self.logPage.setSortingEnabled(sorting)
-
-    def _on_destroyed(self):
-        try:
-            QApplication.instance().backup_finished_event.disconnect(self._backup_finished_connection)
-        except (TypeError, RuntimeError):
-            pass
-        try:
-            QApplication.instance().profile_changed_event.disconnect(self._profile_changed_connection)
-        except (TypeError, RuntimeError):
-            pass

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -75,12 +75,12 @@ class MainWindow(MainWindowBase, MainWindowUI):
             self.current_profile = min(profiles, key=lambda p: (p.name.casefold(), p.name))
 
         # Load tab models
-        self.repoTab = RepoTab(self.repoTabSlot)
-        self.sourceTab = SourceTab(self.sourceTabSlot)
-        self.archiveTab = ArchiveTab(self.archiveTabSlot, app=self.app)
-        self.scheduleTab = ScheduleTab(self.scheduleTabSlot)
-        self.miscTab = MiscTab(self.SettingsTabSlot)
-        self.aboutTab = AboutTab(self.AboutTabSlot)
+        self.repoTab = RepoTab(self.repoTabSlot, profile_provider=self.get_current_profile)
+        self.sourceTab = SourceTab(self.sourceTabSlot, profile_provider=self.get_current_profile)
+        self.archiveTab = ArchiveTab(self.archiveTabSlot, app=self.app, profile_provider=self.get_current_profile)
+        self.scheduleTab = ScheduleTab(self.scheduleTabSlot, profile_provider=self.get_current_profile)
+        self.miscTab = MiscTab(self.SettingsTabSlot, profile_provider=self.get_current_profile)
+        self.aboutTab = AboutTab(self.AboutTabSlot, profile_provider=self.get_current_profile)
         self.aboutTab.set_borg_details(borg_compat.version, borg_compat.path)
         self.miscWidget.hide()
         self.tabWidget.setCurrentIndex(0)
@@ -136,6 +136,9 @@ class MainWindow(MainWindowBase, MainWindowUI):
 
     def on_close_window(self):
         self.close()
+
+    def get_current_profile(self):
+        return BackupProfileModel.get(id=self.current_profile.id)
 
     def set_icons(self):
         self.profileAddButton.setIcon(get_colored_icon('plus'))

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -14,9 +14,10 @@ from PyQt6.QtWidgets import (
 )
 
 from vorta.i18n import translate
-from vorta.store.models import BackupProfileMixin, SettingsModel
+from vorta.store.models import SettingsModel
 from vorta.store.settings import get_misc_settings
 from vorta.utils import get_asset, search
+from vorta.views.base_tab import BaseTab
 from vorta.views.partials.tooltip_button import ToolTipButton
 from vorta.views.utils import get_colored_icon
 
@@ -26,12 +27,12 @@ MiscTabUI, MiscTabBase = uic.loadUiType(uifile)
 logger = logging.getLogger(__name__)
 
 
-class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
+class MiscTab(BaseTab, MiscTabBase, MiscTabUI):
     refresh_archive = QtCore.pyqtSignal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, profile_provider=None):
         """Init."""
-        super().__init__(parent)
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(parent)
 
         self.checkboxLayout = QFormLayout(self.frameSettings)
@@ -45,8 +46,7 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
         self.populate()
 
         # Connect to events
-        self._palette_connection = QApplication.instance().paletteChanged.connect(self.set_icons)
-        self.destroyed.connect(self._on_destroyed)
+        self.track_palette_change()
 
     def populate(self):
         """
@@ -127,12 +127,6 @@ class MiscTab(MiscTabBase, MiscTabUI, BackupProfileMixin):
         """Set or update the icons in this view."""
         for button in self.tooltip_buttons:
             button.setIcon(get_colored_icon('help-about'))
-
-    def _on_destroyed(self):
-        try:
-            QApplication.instance().paletteChanged.disconnect(self._palette_connection)
-        except (TypeError, RuntimeError):
-            pass
 
     def save_setting(self, key, new_value):
         setting = SettingsModel.get(key=key)

--- a/src/vorta/views/networks_page.py
+++ b/src/vorta/views/networks_page.py
@@ -1,17 +1,18 @@
 from PyQt6 import uic
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QListWidget, QListWidgetItem
+from PyQt6.QtWidgets import QCheckBox, QLabel, QListWidget, QListWidgetItem
 
-from vorta.store.models import BackupProfileMixin, WifiSettingModel
+from vorta.store.models import WifiSettingModel
 from vorta.utils import get_asset, get_sorted_wifis
+from vorta.views.base_tab import BaseTab
 
 uifile = get_asset('UI/networks_page.ui')
 NetworksUI, NetworksBase = uic.loadUiType(uifile)
 
 
-class NetworksPage(NetworksBase, NetworksUI, BackupProfileMixin):
-    def __init__(self, parent=None):
-        super().__init__(parent)
+class NetworksPage(BaseTab, NetworksBase, NetworksUI):
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(self)
 
         self.wifiListLabel: QLabel = self.findChild(QLabel, 'wifiListLabel')
@@ -21,8 +22,7 @@ class NetworksPage(NetworksBase, NetworksUI, BackupProfileMixin):
         # Connect signals
         self.meteredNetworksCheckBox.stateChanged.connect(self.on_metered_networks_state_changed)
         self.wifiListWidget.itemChanged.connect(self.save_wifi_item)
-        self._profile_changed_connection = QApplication.instance().profile_changed_event.connect(self.populate_wifi)
-        self.destroyed.connect(self._on_destroyed)
+        self.track_profile_change(self.populate_wifi)
 
         self.populate_wifi()
 
@@ -53,15 +53,3 @@ class NetworksPage(NetworksBase, NetworksUI, BackupProfileMixin):
             db_item = WifiSettingModel.get(ssid=item.text(), profile=profile.id)
             db_item.allowed = item.checkState() == Qt.CheckState.Checked
             db_item.save()
-
-    def save_profile_attr(self, attr, new_value):
-        profile = self.profile()
-        if profile:
-            setattr(profile, attr, new_value)
-            profile.save()
-
-    def _on_destroyed(self):
-        try:
-            QApplication.instance().profile_changed_event.disconnect(self._profile_changed_connection)
-        except (TypeError, RuntimeError):
-            pass

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -5,9 +5,10 @@ from PyQt6 import QtCore, uic
 from PyQt6.QtCore import QMimeData, QUrl
 from PyQt6.QtWidgets import QApplication, QLayout, QMenu, QMessageBox
 
-from vorta.store.models import ArchiveModel, BackupProfileMixin, RepoModel
+from vorta.store.models import RepoModel
 from vorta.utils import borg_compat, get_asset, get_private_keys, pretty_bytes
 
+from .base_tab import BaseTab
 from .repo_add_dialog import AddRepoWindow, ExistingRepoWindow
 from .repo_change_passphrase import ChangeBorgPassphraseWindow
 from .ssh_dialog import SSHAddWindow
@@ -17,12 +18,12 @@ uifile = get_asset('UI/repo_tab.ui')
 RepoUI, RepoBase = uic.loadUiType(uifile)
 
 
-class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
+class RepoTab(BaseTab, RepoBase, RepoUI):
     repo_changed = QtCore.pyqtSignal()
     repo_added = QtCore.pyqtSignal()
 
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(parent)
 
         # Populate dropdowns
@@ -78,12 +79,9 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         self.populate_from_profile()  # needs init of ssh and compression items
 
         # Connect to events
-        self._palette_connection = QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
-        self._profile_changed_connection = QApplication.instance().profile_changed_event.connect(
-            self.populate_from_profile
-        )
-        self._backup_finished_connection = QApplication.instance().backup_finished_event.connect(self.init_repo_stats)
-        self.destroyed.connect(self._on_destroyed)
+        self.track_palette_change()
+        self.track_profile_change()
+        self.track_backup_finished(self.init_repo_stats)
 
     def set_icons(self):
         self.bAddSSHKey.setIcon(get_colored_icon("plus"))
@@ -92,24 +90,9 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         self.sshKeyToClipboardButton.setIcon(get_colored_icon('copy'))
         self.copyURLbutton.setIcon(get_colored_icon('copy'))
 
-    def _on_destroyed(self):
-        try:
-            QApplication.instance().paletteChanged.disconnect(self._palette_connection)
-        except (TypeError, RuntimeError):
-            pass
-        try:
-            QApplication.instance().profile_changed_event.disconnect(self._profile_changed_connection)
-        except (TypeError, RuntimeError):
-            pass
-        try:
-            QApplication.instance().backup_finished_event.disconnect(self._backup_finished_connection)
-        except (TypeError, RuntimeError):
-            pass
-
     def set_repos(self):
         self.repoSelector.clear()
         self.repoSelector.addItem(self.tr('No repository selected'), None)
-        # set tooltip = url for each item in the repoSelector
         for repo in RepoModel.select():
             self.repoSelector.addItem(f"{repo.name + ' - ' if repo.name else ''}{repo.url}", repo.id)
             self.repoSelector.setItemData(self.repoSelector.count() - 1, repo.url, QtCore.Qt.ItemDataRole.ToolTipRole)
@@ -144,7 +127,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         refresh = self.tr("Try refreshing the metadata of any archive.")
 
         # set labels
-        repo: RepoModel = self.profile().repo
+        repo: RepoModel = self.repo()
         if repo is not None:
             # Start with every element enabled, then disable SSH-related if relevant
             for child in self.frameRepoSettings.children():
@@ -216,9 +199,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
             self.repoCompression.model().item(ix).setEnabled(use_zstd)
 
     def ssh_select_action(self, index):
-        profile = self.profile()
-        profile.ssh_key = self.sshComboBox.itemData(index)
-        profile.save()
+        self.save_profile_attr('ssh_key', self.sshComboBox.itemData(index))
 
     def create_ssh_key(self):
         """Open a dialog to create an ssh key."""
@@ -264,9 +245,7 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         msg.show()
 
     def compression_select_action(self, index):
-        profile = self.profile()
-        profile.compression = self.repoCompression.currentData()
-        profile.save()
+        self.save_profile_attr('compression', self.repoCompression.currentData())
 
     def new_repo(self):
         """Open a dialog to create a new repo and add it to vorta."""
@@ -287,17 +266,13 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
         window.open()
 
     def repo_select_action(self):
-        profile = self.profile()
-        profile.repo = self.repoSelector.currentData()
-        profile.save()
+        self.save_profile_attr('repo', self.repoSelector.currentData())
         self.init_repo_stats()
 
     def process_new_repo(self, result):
         if result['returncode'] == 0:
             new_repo = RepoModel.get(url=result['params']['repo_url'])
-            profile = self.profile()
-            profile.repo = new_repo.id
-            profile.save()
+            self.save_profile_attr('repo', new_repo.id)
 
             self.set_repos()
             self.repoSelector.setCurrentIndex(self.repoSelector.count() - 1)
@@ -305,8 +280,6 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
             self.init_repo_stats()
 
     def repo_unlink_action(self):
-        profile = self.profile()
-
         selected_repo_id = self.repoSelector.currentData()
         selected_repo_index = self.repoSelector.currentIndex()
 
@@ -321,21 +294,28 @@ class RepoTab(RepoBase, RepoUI, BackupProfileMixin):
             pass
 
         # Update database
+        profile = self.profile()
         repo = RepoModel.get(id=selected_repo_id)
-        ArchiveModel.delete().where(ArchiveModel.repo_id == repo.id).execute()
+        repo_deleted = not repo.is_shared_with_other_profiles(excluding_profile_id=profile.id)
         profile.repo = None
         profile.save()
-        repo.delete_instance(recursive=True)  # This also deletes archives.
+        if repo_deleted:
+            repo.delete_instance(recursive=True)
 
-        # Update dropdown
-        self.repoSelector.removeItem(selected_repo_index)
+        # Update dropdown only if the repository no longer exists in the DB.
+        if repo_deleted:
+            self.repoSelector.removeItem(selected_repo_index)
         self.repoSelector.setCurrentIndex(0)
 
         msg = QMessageBox()
         msg.setStandardButtons(QMessageBox.StandardButton.Ok)
         msg.setParent(self, QtCore.Qt.WindowType.Sheet)
-        msg.setWindowTitle(self.tr('Repository was Unlinked'))
-        msg.setText(self.tr('You can always connect it again later.'))
+        if repo_deleted:
+            msg.setWindowTitle(self.tr('Repository was Unlinked'))
+            msg.setText(self.tr('You can always connect it again later.'))
+        else:
+            msg.setWindowTitle(self.tr('Repository was Detached'))
+            msg.setText(self.tr('The repository remains available for other profiles.'))
         msg.show()
 
         self.repo_changed.emit()

--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -6,18 +6,17 @@ from PyQt6.QtWidgets import QApplication
 
 from vorta.i18n import get_locale
 from vorta.scheduler import ScheduleStatusType
-from vorta.store.models import BackupProfileMixin
 from vorta.utils import get_asset
+from vorta.views.base_tab import BaseTab
 
 logger = logging.getLogger(__name__)
 uifile = get_asset('UI/schedule_page.ui')
 SchedulePageUI, SchedulePageBase = uic.loadUiType(uifile)
 
 
-class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.app = QApplication.instance()
+class SchedulePage(BaseTab, SchedulePageBase, SchedulePageUI):
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(self)
         self.hasPopulatedScheduleFields = False
 
@@ -65,13 +64,12 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
             lambda new_val, attr='compaction_weeks': self.save_profile_attr(attr, new_val)
         )
 
-        self._schedule_changed_connection = self.app.scheduler.schedule_changed.connect(self.draw_next_scheduled_backup)
-        self.destroyed.connect(self._on_destroyed)
+        self.track_signal(self.app.scheduler.schedule_changed, self.draw_next_scheduled_backup)
         self.populate_from_profile()
         self.hasPopulatedScheduleFields = True
 
         # Listen for events
-        self._profile_changed_connection = self.app.profile_changed_event.connect(self.populate_from_profile)
+        self.track_profile_change()
 
     def on_scheduler_change(self, _):
         # Wait until we've populated fields _from_ the schedule before populating them back
@@ -122,16 +120,6 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
 
         self.draw_next_scheduled_backup()
 
-    def _on_destroyed(self):
-        try:
-            self.app.scheduler.schedule_changed.disconnect(self._schedule_changed_connection)
-        except (TypeError, RuntimeError):
-            pass
-        try:
-            self.app.profile_changed_event.disconnect(self._profile_changed_connection)
-        except (TypeError, RuntimeError):
-            pass
-
     def draw_next_scheduled_backup(self):
         status = self.app.scheduler.next_job_for_profile(self.profile().id)
         if status.type in (
@@ -147,13 +135,3 @@ class SchedulePage(SchedulePageBase, SchedulePageUI, BackupProfileMixin):
 
         self.nextBackupDateTimeLabel.setText(text)
         self.nextBackupDateTimeLabel.repaint()
-
-    def save_profile_attr(self, attr, new_value):
-        profile = self.profile()
-        setattr(profile, attr, new_value)
-        profile.save()
-
-    def save_repo_attr(self, attr, new_value):
-        repo = self.profile().repo
-        setattr(repo, attr, new_value)
-        repo.save()

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -1,9 +1,7 @@
 from PyQt6 import uic
-from PyQt6.QtWidgets import QApplication
 
-from vorta import application
-from vorta.store.models import BackupProfileMixin
 from vorta.utils import get_asset
+from vorta.views.base_tab import BaseTab
 from vorta.views.log_page import LogPage
 from vorta.views.networks_page import NetworksPage
 from vorta.views.schedule_page import SchedulePage
@@ -14,38 +12,36 @@ uifile = get_asset('UI/schedule_tab.ui')
 ScheduleUI, ScheduleBase = uic.loadUiType(uifile)
 
 
-class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
-    def __init__(self, parent=None):
-        super().__init__(parent)
+class ScheduleTab(BaseTab, ScheduleBase, ScheduleUI):
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(parent)
-        self.app: application.VortaApp = QApplication.instance()
         self.toolBox.setCurrentIndex(0)
         self.set_icons()
         self.init_log_page()
         self.init_shell_commands_page()
         self.init_networks_page()
         self.init_schedule_page()
-        self._palette_connection = self.app.paletteChanged.connect(lambda p: self.set_icons())
-        self._backup_finished_connection = self.app.backup_finished_event.connect(self.logPage.populate_logs)
-        self.destroyed.connect(self._on_destroyed)
+        self.track_palette_change()
+        self.track_backup_finished(self.logPage.populate_logs)
 
     def init_log_page(self):
-        self.logPage = LogPage(self)
+        self.logPage = LogPage(self, profile_provider=lambda: self.profile())
         self.logLayout.addWidget(self.logPage)
         self.logPage.show()
 
     def init_shell_commands_page(self):
-        self.shellCommandsPage = ShellCommandsPage(self)
+        self.shellCommandsPage = ShellCommandsPage(self, profile_provider=lambda: self.profile())
         self.shellCommandsLayout.addWidget(self.shellCommandsPage)
         self.shellCommandsPage.show()
 
     def init_networks_page(self):
-        self.networksPage = NetworksPage(self)
+        self.networksPage = NetworksPage(self, profile_provider=lambda: self.profile())
         self.networksLayout.addWidget(self.networksPage)
         self.networksPage.show()
 
     def init_schedule_page(self):
-        self.schedulePage = SchedulePage(self)
+        self.schedulePage = SchedulePage(self, profile_provider=lambda: self.profile())
         self.scheduleLayout.addWidget(self.schedulePage)
         self.schedulePage.show()
 
@@ -54,13 +50,3 @@ class ScheduleTab(ScheduleBase, ScheduleUI, BackupProfileMixin):
         self.toolBox.setItemIcon(1, get_colored_icon('wifi'))
         self.toolBox.setItemIcon(2, get_colored_icon('tasks'))
         self.toolBox.setItemIcon(3, get_colored_icon('terminal'))
-
-    def _on_destroyed(self):
-        try:
-            self.app.paletteChanged.disconnect(self._palette_connection)
-        except (TypeError, RuntimeError):
-            pass
-        try:
-            self.app.backup_finished_event.disconnect(self._backup_finished_connection)
-        except (TypeError, RuntimeError):
-            pass

--- a/src/vorta/views/shell_commands_page.py
+++ b/src/vorta/views/shell_commands_page.py
@@ -1,13 +1,13 @@
 from PyQt6 import uic
-from PyQt6.QtWidgets import QApplication, QLineEdit, QWidget
+from PyQt6.QtWidgets import QLineEdit, QWidget
 
-from vorta.store.models import BackupProfileMixin
 from vorta.utils import get_asset
+from vorta.views.base_tab import BaseTab
 
 
-class ShellCommandsPage(QWidget, BackupProfileMixin):
-    def __init__(self, parent=None):
-        super().__init__(parent)
+class ShellCommandsPage(BaseTab, QWidget):
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
         uifile = get_asset('UI/shell_commands_page.ui')
         uic.loadUi(uifile, self)
 
@@ -25,10 +25,7 @@ class ShellCommandsPage(QWidget, BackupProfileMixin):
         self.createCmdLineEdit.textEdited.connect(
             lambda new_val, attr='create_backup_cmd': self.save_repo_attr(attr, new_val)
         )
-        self._profile_changed_connection = QApplication.instance().profile_changed_event.connect(
-            self.populate_from_profile
-        )
-        self.destroyed.connect(self._on_destroyed)
+        self.track_profile_change()
 
     def populate_from_profile(self):
         profile = self.profile()
@@ -45,19 +42,3 @@ class ShellCommandsPage(QWidget, BackupProfileMixin):
             self.createCmdLineEdit.setEnabled(False)
             self.preBackupCmdLineEdit.setEnabled(False)
             self.postBackupCmdLineEdit.setEnabled(False)
-
-    def save_profile_attr(self, attr, new_value):
-        profile = self.profile()
-        setattr(profile, attr, new_value)
-        profile.save()
-
-    def save_repo_attr(self, attr, new_value):
-        repo = self.profile().repo
-        setattr(repo, attr, new_value)
-        repo.save()
-
-    def _on_destroyed(self):
-        try:
-            QApplication.instance().profile_changed_event.disconnect(self._profile_changed_connection)
-        except (TypeError, RuntimeError):
-            pass

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -12,13 +12,14 @@ from PyQt6.QtWidgets import (
 )
 
 from vorta.filedialog import VortaFileSelector
-from vorta.store.models import BackupProfileMixin, SettingsModel, SourceFileModel
+from vorta.store.models import SettingsModel, SourceFileModel
 from vorta.utils import (
     FilePathInfoAsync,
     get_asset,
     pretty_bytes,
     sort_sizes,
 )
+from vorta.views.base_tab import BaseTab
 from vorta.views.exclude_dialog import ExcludeDialog
 from vorta.views.utils import get_colored_icon
 
@@ -65,11 +66,11 @@ class FilesCount(QTableWidgetItem):
                 return 0
 
 
-class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
+class SourceTab(BaseTab, SourceBase, SourceUI):
     updateThreads = []
 
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(parent)
 
         # Prepare source files view
@@ -102,11 +103,8 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
         self.set_icons()
 
         # Listen for events
-        self._palette_connection = QApplication.instance().paletteChanged.connect(lambda p: self.set_icons())
-        self._profile_changed_connection = QApplication.instance().profile_changed_event.connect(
-            self.populate_from_profile
-        )
-        self.destroyed.connect(self._on_destroyed)
+        self.track_palette_change()
+        self.track_profile_change()
 
     def set_icons(self):
         "Used when changing between light- and dark mode"
@@ -122,16 +120,6 @@ class SourceTab(SourceBase, SourceUI, BackupProfileMixin):
                 path_item.setIcon(get_colored_icon('folder'))
             else:
                 path_item.setIcon(get_colored_icon('file'))
-
-    def _on_destroyed(self):
-        try:
-            QApplication.instance().paletteChanged.disconnect(self._palette_connection)
-        except (TypeError, RuntimeError):
-            pass
-        try:
-            QApplication.instance().profile_changed_event.disconnect(self._profile_changed_connection)
-        except (TypeError, RuntimeError):
-            pass
 
     @pyqtSlot(QPoint)
     def sourceitem_contextmenu(self, pos: QPoint):

--- a/tests/unit/test_base_tab.py
+++ b/tests/unit/test_base_tab.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+
+import pytest
+from PyQt6.QtWidgets import QWidget
+
+from vorta.store.models import BackupProfileModel, RepoModel
+from vorta.views.base_tab import BaseTab
+
+
+class FakeSignal:
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+        return slot
+
+    def disconnect(self, slot):
+        self._slots.remove(slot)
+
+    def emit(self, *args, **kwargs):
+        for slot in list(self._slots):
+            try:
+                slot(*args, **kwargs)
+            except TypeError:
+                slot()
+
+
+class DummyTab(BaseTab, QWidget):
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
+        self.profile_change_count = 0
+        self.palette_change_count = 0
+        self.backup_finished_count = 0
+
+    def on_profile_change(self):
+        self.profile_change_count += 1
+
+    def on_palette_change(self):
+        self.palette_change_count += 1
+
+    def on_backup_finished(self):
+        self.backup_finished_count += 1
+
+
+def test_base_tab_uses_injected_profile_provider(qapp):
+    repo = RepoModel.get(id=1)
+    injected_profile = BackupProfileModel.create(name='Injected', repo=repo.id)
+
+    tab = DummyTab(profile_provider=lambda: BackupProfileModel.get(id=injected_profile.id))
+
+    assert tab.profile().id == injected_profile.id
+
+    tab.save_profile_attr('compression', 'none')
+    assert BackupProfileModel.get(id=injected_profile.id).compression == 'none'
+
+    tab.save_repo_attr('name', 'Injected Repo')
+    assert RepoModel.get(id=repo.id).name == 'Injected Repo'
+
+
+def test_base_tab_cleans_up_tracked_connections(qapp):
+    profile = BackupProfileModel.get(id=1)
+    tab = DummyTab(profile_provider=lambda: BackupProfileModel.get(id=profile.id))
+    fake_app = SimpleNamespace(
+        profile_changed_event=FakeSignal(),
+        paletteChanged=FakeSignal(),
+        backup_finished_event=FakeSignal(),
+    )
+    tab.app = fake_app
+    tab.track_profile_change(tab.on_profile_change)
+    tab.track_palette_change(tab.on_palette_change)
+    tab.track_backup_finished(tab.on_backup_finished)
+
+    fake_app.profile_changed_event.emit()
+    fake_app.paletteChanged.emit(qapp.palette())
+    fake_app.backup_finished_event.emit({})
+    assert tab.profile_change_count == 1
+    assert tab.palette_change_count == 1
+    assert tab.backup_finished_count == 1
+
+    tab._cleanup_tracked_connections()
+    fake_app.profile_changed_event.emit()
+    fake_app.paletteChanged.emit(qapp.palette())
+    fake_app.backup_finished_event.emit({})
+    assert tab.profile_change_count == 1
+    assert tab.palette_change_count == 1
+    assert tab.backup_finished_count == 1
+
+
+def test_base_tab_falls_back_to_window_current_profile(qapp, qtbot):
+    profile = BackupProfileModel.get(id=1)
+    host = QWidget()
+    host.current_profile = profile
+    qtbot.addWidget(host)
+
+    tab = DummyTab(parent=host)
+
+    assert tab.current_profile().id == profile.id
+    assert tab.profile().id == profile.id
+
+
+def test_base_tab_handles_missing_current_profile(qapp, qtbot):
+    host = QWidget()
+    qtbot.addWidget(host)
+    tab = DummyTab(parent=host)
+
+    assert tab.current_profile() is None
+    with pytest.raises(RuntimeError, match="No active backup profile"):
+        tab.profile()

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -9,7 +9,7 @@ from PyQt6.QtWidgets import QMessageBox
 
 import vorta.borg.borg_job
 from vorta.keyring.abc import VortaKeyring
-from vorta.store.models import ArchiveModel, EventLogModel, RepoModel
+from vorta.store.models import ArchiveModel, BackupProfileModel, EventLogModel, RepoModel
 
 LONG_PASSWORD = 'long-password-long'
 SHORT_PASSWORD = 'hunter2'
@@ -76,6 +76,35 @@ def test_repo_unlink(qapp, qtbot, monkeypatch):
         qapp.create_backup_action()
 
     assert 'Select a backup repository first.' in main.progressText.text()
+
+
+def test_repo_unlink_shared_repository_keeps_dropdown_entry(qapp, qtbot, mocker, monkeypatch):
+    main = qapp.main_window
+    tab = main.repoTab
+    current_profile = main.current_profile
+    shared_repo = current_profile.repo
+    other_profile = BackupProfileModel.create(name='Shared Repo Profile', repo=shared_repo.id)
+    monkeypatch.setattr(QMessageBox, "show", lambda *args: True)
+
+    mock_title = mocker.patch.object(QMessageBox, "setWindowTitle")
+    mock_text = mocker.patch.object(QMessageBox, "setText")
+
+    assert tab.repoSelector.count() == 2
+    assert tab.repoSelector.currentData() == shared_repo.id
+
+    tab.repo_unlink_action()
+
+    refreshed_profile = BackupProfileModel.get(id=current_profile.id)
+    refreshed_other_profile = BackupProfileModel.get(id=other_profile.id)
+
+    assert refreshed_profile.repo is None
+    assert refreshed_other_profile.repo.id == shared_repo.id
+    assert RepoModel.get_or_none(id=shared_repo.id) is not None
+    assert tab.repoSelector.count() == 2
+    assert tab.repoSelector.currentData() is None
+    assert tab.repoSelector.currentIndex() == 0
+    mock_title.assert_called_with('Repository was Detached')
+    mock_text.assert_called_with('The repository remains available for other profiles.')
 
 
 def test_password_autofill(qapp, qtbot):


### PR DESCRIPTION
### Description

This PR starts the views-layer refactor from #2361 by introducing a shared `BaseTab`
abstraction, moving several views to injected profile access, and adding the first
ViewModel for `RepoTab`.

Changes included in this PR:

- added `BaseTab` to centralize:
  - active profile access via injection
  - tracked signal connections
  - automatic signal cleanup
  - shared `save_profile_attr` / `save_repo_attr` helpers
- updated several view classes to use `BaseTab` instead of repeating signal boilerplate
- wired profile injection from `MainWindow`
- added `RepoTabViewModel` and moved repo-related persistence logic out of `RepoTab`
- added unit tests for `BaseTab` and `RepoTabViewModel`

This is an incremental first slice of the refactor and does not yet include dialog
reorganization, splitting `ArchiveTab`, or adding ViewModels for the remaining tabs.

### Related Issue

Part of #2361

### Motivation and Context

The current views layer contains repeated signal connection and cleanup logic and relies
on `BackupProfileMixin`, which couples views to the window hierarchy and makes them
harder to test.

This change reduces duplicated boilerplate, introduces a cleaner injected profile-access
pattern, and establishes the first ViewModel-based separation of UI and persistence
logic. It is intended as groundwork for the larger refactor proposed in #2361.

### How Has This Been Tested?

Test environment:
- Windows
- `uv` project environment
- PyQt6 test setup already present in the repository

Passed:
- `uv run pre-commit run --files src/vorta/views/base_tab.py src/vorta/views/view_models/repo_tab_view_model.py src/vorta/views/repo_tab.py tests/unit/test_view_models.py`
- `uv run py -B -m pytest tests/unit/test_base_tab.py tests/unit/test_view_models.py tests/unit/test_misc.py tests/unit/test_schedule.py`

Notes:
- a broader repo/SSH-focused test run on this Windows setup showed some environment-sensitive failures:
  - `test_repo_unlink`
  - `test_repo_add_success`
  - `test_ssh_dialog_success`
  - `test_ssh_copy_to_clipboard_action`
  - `test_create`

### Screenshots (if appropriate):

Not applicable.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/
