### PR TITLE
Remove unused self.selected_archives variable in ArchiveTabRemove unused self.selected_archives variable in ArchiveTab

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -155,7 +155,6 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         self.prune_keep_within.editingFinished.connect(self.save_prune_setting)
 
         self.populate_from_profile()
-        self.selected_archives = None  # TODO: remove unused variable
         self.set_icons()
 
         # Connect to events


### PR DESCRIPTION

### Description
Removes the unused `self.selected_archives` instance variable from 
the `ArchiveTab.__init__` method. This variable was assigned but 
never read or used anywhere in the class.

### Related Issue
Fixes #2388

### Motivation and Context
The variable `self.selected_archives = None` had a TODO comment 
saying to remove it. It serves no purpose and clutters the code.

### How Has This Been Tested?
No functional change was made. Existing tests cover the affected 
class and should pass as before.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the CONTRIBUTING guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.