### PR TITLE
fix: rename three_months_ago to six_months_ago in connection.py

### DIFF
--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -73,10 +73,10 @@ def init_db(con=None):
         .group_by(EventLogModel.profile)
     )
 
-    three_months_ago = datetime.now() - timedelta(days=6 * 30)
+    six_months_ago = datetime.now() - timedelta(days=6 * 30)
     entry = Tuple(EventLogModel.profile, EventLogModel.start_time)
     EventLogModel.delete().where(
-        EventLogModel.start_time < three_months_ago,
+        EventLogModel.start_time < six_months_ago,
         entry.not_in(last_backups_per_profile),
         entry.not_in(last_scheduled_backups_per_profile),
     ).execute()


### PR DESCRIPTION
### Description
Rename `three_months_ago` variable to `six_months_ago` in `store/connection.py`.
The variable is calculated as `6 * 30` days (180 days), but its name implies 3 months.

### Related Issue
No issue , this is a minor naming fix ,encountered while exploring the codebase for gsoc :bug:  

### Motivation and Context
The variable name `three_months_ago` is misleading because the actual value
is `timedelta(days=6 * 30)` = 180 days (6 months). just name change and this is my first pr :face_in_clouds: 

### How Has This Been Tested?
Only a variable rename , no logic was changed. Existing tests cover the
behavior. Ran `make test-unit` locally and all tests passed.

### Screenshots (if appropriate):
N/A

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the CONTRIBUTING guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
