### PR TITLE
Fix/2414 exclude export

### DIFF
--- a/src/vorta/profile_export.py
+++ b/src/vorta/profile_export.py
@@ -12,6 +12,7 @@ from vorta.store.models import (
     SchemaVersion,
     SettingsModel,
     SourceFileModel,
+ ExclusionModel,
     WifiSettingModel,
 )
 
@@ -75,6 +76,11 @@ class ProfileExport:
             ]
             # Add SettingsModel
             profile_dict['SettingsModel'] = [model_to_dict(s, exclude=[SettingsModel.id]) for s in SettingsModel]
+                # Add ExclusionModel
+            profile_dict['ExclusionModel'] = [
+                        model_to_dict(exclusion, recurse=False, exclude=[ExclusionModel.id])
+                        for exclusion in ExclusionModel.select().where(ExclusionModel.profile == profile)
+                    ]
         return ProfileExport(profile_dict)
 
     def to_db(self, overwrite_profile=False, overwrite_settings=True):
@@ -133,12 +139,15 @@ class ProfileExport:
         # Delete existing Sources to avoid duplicates
         SourceFileModel.delete().where(SourceFileModel.profile == self.id).execute()
         SourceFileModel.insert_many(self._profile_dict['SourceFileModel']).execute()
+            # Insert ExclusionModel
+            ExclusionModel.insert_many(self._profile_dict['ExclusionModel']).execute()
 
         # Delete added dictionaries to make it match BackupProfileModel
         del self._profile_dict['SettingsModel']
         del self._profile_dict['SourceFileModel']
         del self._profile_dict['WifiSettingModel']
         del self._profile_dict['SchemaVersion']
+            del self._profile_dict['ExclusionModel']
 
         # dict to profile
         new_profile = dict_to_model(BackupProfileModel, self._profile_dict)


### PR DESCRIPTION
## Description

Adds ExclusionModel support to the profile export/import functionality. The ExclusionModel is now properly included when exporting a backup profile and correctly restored when importing.

## Related Issue

Closes #2414

## Changes Made

- Added ExclusionModel to imports in profile_export.py
- Added ExclusionModel export in from_db() method
- Added ExclusionModel insertion in to_db() method
- Added cleanup of ExclusionModel from profile_dict after processing

## Testing

This fix ensures that exclusion patterns are properly preserved when exporting and importing backup profiles, preventing data loss during profile migration.