### PR TITLE
Add Select All / Select None buttons to network selection UI

### DIFF
--- a/src/vorta/assets/UI/networks_page.ui
+++ b/src/vorta/assets/UI/networks_page.ui
@@ -22,15 +22,46 @@
          <property name="spacing">
           <number>4</number>
          </property>
-         <item>
-          <widget class="QLabel" name="wifiListLabel">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Allowed Networks:</string>
-           </property>
-          </widget>
+        <item>
+          <layout class="QHBoxLayout" name="wifiListHeaderLayout">
+           <item>
+            <widget class="QLabel" name="wifiListLabel">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Allowed Networks:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="selectAllButton">
+             <property name="text">
+              <string>Select All</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="selectNoneButton">
+             <property name="text">
+              <string>Select None</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
           <widget class="QListWidget" name="wifiListWidget">

--- a/src/vorta/views/networks_page.py
+++ b/src/vorta/views/networks_page.py
@@ -1,6 +1,6 @@
 from PyQt6 import uic
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QCheckBox, QLabel, QListWidget, QListWidgetItem
+from PyQt6.QtWidgets import QCheckBox, QLabel, QListWidget, QListWidgetItem, QPushButton
 
 from vorta.store.models import WifiSettingModel
 from vorta.utils import get_asset, get_sorted_wifis
@@ -18,10 +18,14 @@ class NetworksPage(BaseTab, NetworksBase, NetworksUI):
         self.wifiListLabel: QLabel = self.findChild(QLabel, 'wifiListLabel')
         self.meteredNetworksCheckBox: QCheckBox = self.findChild(QCheckBox, 'meteredNetworksCheckBox')
         self.wifiListWidget: QListWidget = self.findChild(QListWidget, 'wifiListWidget')
+        self.selectAllButton: QPushButton = self.findChild(QPushButton, 'selectAllButton')
+        self.selectNoneButton: QPushButton = self.findChild(QPushButton, 'selectNoneButton')
 
         # Connect signals
         self.meteredNetworksCheckBox.stateChanged.connect(self.on_metered_networks_state_changed)
         self.wifiListWidget.itemChanged.connect(self.save_wifi_item)
+        self.selectAllButton.clicked.connect(self.select_all_networks)
+        self.selectNoneButton.clicked.connect(self.select_no_networks)
         self.track_profile_change(self.populate_wifi, call_now=True)
 
     def on_metered_networks_state_changed(self, state):
@@ -51,3 +55,13 @@ class NetworksPage(BaseTab, NetworksBase, NetworksUI):
             db_item = WifiSettingModel.get(ssid=item.text(), profile=profile.id)
             db_item.allowed = item.checkState() == Qt.CheckState.Checked
             db_item.save()
+
+    def select_all_networks(self):
+        self.set_all_wifi_items(Qt.CheckState.Checked)
+
+    def select_no_networks(self):
+        self.set_all_wifi_items(Qt.CheckState.Unchecked)
+
+    def set_all_wifi_items(self, check_state):
+        for row in range(self.wifiListWidget.count()):
+            self.wifiListWidget.item(row).setCheckState(check_state)

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import QWidget
 
 import vorta.scheduler
 from vorta.application import VortaApp
-from vorta.store.models import BackupProfileModel, EventLogModel
+from vorta.store.models import BackupProfileModel, EventLogModel, WifiSettingModel
 from vorta.views.schedule_tab import ScheduleTab
 
 PROFILE_NAME = 'Default'
@@ -92,3 +92,41 @@ def test_schedule_tab_forwards_profile_provider_to_child_pages(qapp: VortaApp, q
     assert tab.shellCommandsPage.profile().id == profile.id
     assert tab.networksPage.profile().id == profile.id
     assert tab.logPage.profile().id == profile.id
+
+
+def test_networks_page_select_all_and_none_persist(qapp: VortaApp, qtbot):
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    WifiSettingModel.create(ssid='Home WiFi', allowed=False, profile=profile.id)
+    WifiSettingModel.create(ssid='Office WiFi', allowed=True, profile=profile.id)
+
+    host = QWidget()
+    qtbot.addWidget(host)
+    tab = ScheduleTab(host, profile_provider=lambda: BackupProfileModel.get(id=profile.id))
+
+    tab.networksPage.populate_wifi()
+
+    qtbot.mouseClick(tab.networksPage.selectAllButton, QtCore.Qt.MouseButton.LeftButton)
+
+    assert [tab.networksPage.wifiListWidget.item(i).checkState() for i in range(tab.networksPage.wifiListWidget.count())] == [
+        QtCore.Qt.CheckState.Checked,
+        QtCore.Qt.CheckState.Checked,
+    ]
+    assert (
+        WifiSettingModel.select()
+        .where(WifiSettingModel.profile == profile.id, WifiSettingModel.allowed == True)  # noqa
+        .count()
+        == 2
+    )
+
+    qtbot.mouseClick(tab.networksPage.selectNoneButton, QtCore.Qt.MouseButton.LeftButton)
+
+    assert [tab.networksPage.wifiListWidget.item(i).checkState() for i in range(tab.networksPage.wifiListWidget.count())] == [
+        QtCore.Qt.CheckState.Unchecked,
+        QtCore.Qt.CheckState.Unchecked,
+    ]
+    assert (
+        WifiSettingModel.select()
+        .where(WifiSettingModel.profile == profile.id, WifiSettingModel.allowed == False)  # noqa
+        .count()
+        == 2
+    )


### PR DESCRIPTION
Adds Select All and Select None buttons to the Allowed Networks section in Schedule -> Networks.

Changes:
- Added two buttons to the Networks UI
- Implemented handlers to toggle all WiFi items
- Reused existing itemChanged/save flow for persistence
- Added a unit test covering the new behavior

Closes #2441