### PR TITLE
Fix #2445 Add missing WindowMaximizeButtonHint to window flags

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -53,7 +53,11 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.setWindowIcon(get_colored_icon("icon"))
         if sys.platform.startswith('linux'):
             self.app.setDesktopFileName('com.borgbase.Vorta')
-        self.setWindowFlags(QtCore.Qt.WindowType.WindowCloseButtonHint | QtCore.Qt.WindowType.WindowMinimizeButtonHint)
+        self.setWindowFlags(
+            QtCore.Qt.WindowType.WindowCloseButtonHint
+            | QtCore.Qt.WindowType.WindowMinimizeButtonHint
+            | QtCore.Qt.WindowType.WindowMaximizeButtonHint
+        )
         self.createStartBtn = LoadingButton(self.tr("Start Backup"))
         self.gridLayout.addWidget(self.createStartBtn, 0, 0, 1, 1)
         self.createStartBtn.setGif(get_asset("icons/loading"))


### PR DESCRIPTION
### Description

The main window's maximize button in the title bar does not work. This is because `setWindowFlags` only sets `WindowCloseButtonHint` and `WindowMinimizeButtonHint`, missing `WindowMaximizeButtonHint`. I've added it.

### Related Issue

#2445

### Motivation and Context

To maximize the window.

### How Has This Been Tested?

Manually verified that the maximize button in the title bar becomes functional after the change.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/
