### PR TITLE
Add return type annotations to config functions

### DIFF
--- a/src/vorta/config.py
+++ b/src/vorta/config.py
@@ -17,7 +17,7 @@ def default_dev_dir() -> Path:
     return Path(__file__).parent.parent.parent / '.dev_config'
 
 
-def init_from_platformdirs():
+def init_from_platformdirs() -> None:
     """Initializes config dirs for system-wide use"""
     dirs = platformdirs.PlatformDirs(APP_NAME, APP_AUTHOR)
     init(dirs.user_data_path, dirs.user_log_path, dirs.user_cache_path, dirs.user_cache_path / 'tmp', Path.home())
@@ -35,7 +35,7 @@ def init_dev_mode(dir: Path):
     )
 
 
-def init(settings: Path, logs: Path, cache: Path, tmp: Path, bootstrap: Path):
+def init(settings: Path, logs: Path, cache: Path, tmp: Path, bootstrap: Path) -> None:
     """Initializes config directories with provided paths"""
     global SETTINGS_DIR
     global LOG_DIR

--- a/src/vorta/utils.py
+++ b/src/vorta/utils.py
@@ -52,7 +52,7 @@ class FilePathInfoAsync(QThread):
         self.signal.emit(self.path, str(self.size), str(self.files_count))
 
 
-def normalize_path(path):
+def normalize_path(path: str) -> str:
     """normalize paths for MacOS (but do nothing on other platforms)"""
     # HFS+ converts paths to a canonical form, so users shouldn't be required to enter an exact match.
     # Windows and Unix filesystems allow different forms, so users always have to enter an exact match.
@@ -62,7 +62,7 @@ def normalize_path(path):
 # prepare patterns as borg does
 # see `FnmatchPattern._prepare` at
 # https://github.com/borgbackup/borg/blob/master//src/borg/patterns.py
-def prepare_pattern(pattern):
+def prepare_pattern(pattern: str) -> str:
     """Prepare and process fnmatch patterns as borg does"""
     if pattern.endswith(os.path.sep):
         # trailing sep indicates that the contents should be excluded


### PR DESCRIPTION
This PR adds missing return type annotations (-> None) to functions
in config.py to improve typing coverage and readability.