### PR TITLE
fix: save keep-within prune setting on text change (#2404)

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -165,7 +165,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         # Connect prune setting signals (only once in init, not in populate_from_profile)
         for i in self.prune_intervals:
             getattr(self, f'prune_{i}').valueChanged.connect(self.save_prune_setting)
-        self.prune_keep_within.editingFinished.connect(self.save_prune_setting)
+        self.prune_keep_within.textChanged.connect(self.save_prune_setting)
 
         self.track_profile_change(call_now=True)
         self.set_icons()


### PR DESCRIPTION


### Description
Changed the PyQt signal for the prune_keep_within text field in src/vorta/views/archive_tab.py from editingFinished to textChanged.

### Related Issue
Closes #2404

### Motivation and Context
Previously, the keep-within pruning option's configuration was stored to the profile model through the use of the editingFinished signal. However, this meant that if the user entered a value into the text box and then quit the application without dropping focus on the text box (i.e., without pressing enter or clicking elsewhere on the screen), the configuration was lost. By switching to the textChanged signal, we ensure that the model state is updated immediately after every keystroke, as is currently the case for the archive name templates.

### How Has This Been Tested?
Manually tested in a local development environment (Windows / PyQt6):

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
