### PR TITLE
feat: show busy dialog while parsing archive contents for extract

### DIFF
--- a/src/vorta/assets/UI/dialogs/repo/change_passphrase.ui
+++ b/src/vorta/assets/UI/dialogs/repo/change_passphrase.ui
@@ -80,9 +80,6 @@
      <property name="textFormat">
       <enum>Qt::PlainText</enum>
      </property>
-     <property name="scaledContents">
-      <bool>false</bool>
-     </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>

--- a/src/vorta/assets/UI/dialogs/repo/change_passphrase.ui
+++ b/src/vorta/assets/UI/dialogs/repo/change_passphrase.ui
@@ -56,6 +56,42 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="errorText">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QLabel" name="noteLabel_3">

--- a/src/vorta/assets/UI/dialogs/repo/change_passphrase.ui
+++ b/src/vorta/assets/UI/dialogs/repo/change_passphrase.ui
@@ -56,39 +56,6 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="errorText">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>11</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::PlainText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QLabel" name="noteLabel_3">

--- a/src/vorta/borg/create.py
+++ b/src/vorta/borg/create.py
@@ -122,6 +122,7 @@ class BorgCreateJob(BorgJob):
             )
             if wifi_is_disallowed.count() > 0 and profile.repo.is_remote_repo():
                 ret['message'] = trans_late('messages', 'Current Wifi is not allowed.')
+                ret['level'] = 'info'
                 return ret
 
         if (
@@ -130,6 +131,7 @@ class BorgCreateJob(BorgJob):
             and network_status_monitor.is_network_metered()
         ):
             ret['message'] = trans_late('messages', 'Not running backup over metered connection.')
+            ret['level'] = 'info'
             return ret
 
         ret['profile'] = profile

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -450,13 +450,19 @@ class VortaScheduler(QtCore.QObject):
                 job.result.connect(self.notify)
                 self.app.jobs_manager.add_job(job)
             else:
-                logger.error('Conditions for backup not met. Aborting.')
-                logger.error(msg['message'])
-                notifier.deliver(
-                    self.tr('Vorta Backup'),
-                    translate('messages', msg['message']),
-                    level='error',
-                )
+                # Default to 'error': unexpected failures notify.
+                # Expected skips (WiFi/metered) use 'info' to suppress.
+                level = msg.get('level', 'error')
+                if level == 'error':
+                    logger.error('Conditions for backup not met. Aborting.')
+                    logger.error(msg['message'])
+                    notifier.deliver(
+                        self.tr('Vorta Backup'),
+                        translate('messages', msg['message']),
+                        level='error',
+                    )
+                else:
+                    logger.info('Backup skipped: %s', msg['message'])
                 self.pause(profile_id)
 
     def notify(self, result: dict[str, Any]) -> None:

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -13,6 +13,7 @@ from PyQt6.QtWidgets import (
     QLayout,
     QMenu,
     QMessageBox,
+    QProgressDialog,
     QStyledItemDelegate,
     QTableView,
     QTableWidgetItem,
@@ -23,7 +24,9 @@ from vorta.borg.check import BorgCheckJob
 from vorta.borg.compact import BorgCompactJob
 from vorta.borg.delete import BorgDeleteJob
 from vorta.borg.diff import BorgDiffJob
+from vorta.borg.extract import BorgExtractJob
 from vorta.borg.info_archive import BorgInfoArchiveJob
+from vorta.borg.list_archive import BorgListArchiveJob
 from vorta.borg.list_repo import BorgListRepoJob
 from vorta.borg.prune import BorgPruneJob
 from vorta.borg.rename import BorgRenameJob
@@ -32,17 +35,19 @@ from vorta.i18n.richtext import escape, format_richtext, link
 from vorta.store.models import ArchiveModel, SettingsModel
 from vorta.utils import (
     borg_compat,
+    choose_file_dialog,
     find_best_unit_for_sizes,
     format_archive_name,
     get_asset,
     get_mount_points,
     pretty_bytes,
 )
-from vorta.views.archive.archive_extract import ArchiveExtract
 from vorta.views.archive.archive_mount import ArchiveMount
 from vorta.views.base_tab import BaseTab
 from vorta.views.dialogs.archive import diff_result
+from vorta.views.dialogs.archive import extract as extract_dialog
 from vorta.views.dialogs.archive.diff_result import DiffResultDialog, DiffTree
+from vorta.views.dialogs.archive.extract import ExtractDialog, ExtractTree
 from vorta.views.source_tab import SizeItem
 from vorta.views.utils import get_colored_icon
 
@@ -83,7 +88,6 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         )
 
         self.archive_mount = ArchiveMount(self)
-        self.archive_extract = ArchiveExtract(self)
 
         #: Tooltip dict to save the tooltips set in the designer
         self.tooltip_dict: Dict[QWidget, str] = {}
@@ -142,7 +146,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         self.bRefreshArchive.clicked.connect(self.refresh_archive_info)
         self.bRename.clicked.connect(self.cell_double_clicked)
         self.bDelete.clicked.connect(self.delete_action)
-        self.bExtract.clicked.connect(self.archive_extract.extract_action)
+        self.bExtract.clicked.connect(self.extract_action)
         self.compactButton.clicked.connect(self.compact_action)
 
         # other signals
@@ -212,7 +216,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             (self.bRefreshArchive, self.refresh_archive_info),
             (self.bDiff, self.diff_action),
             (self.bMountArchive, self.archive_mount.bmountarchive_clicked),
-            (self.bExtract, self.archive_extract.extract_action),
+            (self.bExtract, self.extract_action),
             (self.bRename, self.cell_double_clicked),
             (self.bDelete, self.delete_action),
         ]
@@ -487,7 +491,8 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             archive_cell = self.archiveTable.item(row_selected[0].row(), 4)
             if archive_cell:
                 archive_name = archive_cell.text()
-                params['cmd'][-1] += f'::{archive_name}'
+                cmd: list = params['cmd']  # type: ignore[index]
+                cmd[-1] += f'::{archive_name}'
 
         job = BorgCheckJob(params['cmd'], params, self.profile().repo.id)
         job.updated.connect(self._set_status)
@@ -590,6 +595,85 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             setattr(profile, f'prune_{i}', getattr(self, f'prune_{i}').value())
         profile.prune_keep_within = self.prune_keep_within.text()
         profile.save()
+
+    def extract_action(self):
+        """
+        Open a dialog for choosing what to extract from the selected archive.
+        """
+        profile = self.profile()
+
+        row_selected = self.archiveTable.selectionModel().selectedRows()
+        if row_selected:
+            archive_cell = self.archiveTable.item(row_selected[0].row(), 4)
+            if archive_cell:
+                archive_name = archive_cell.text()
+                params = BorgListArchiveJob.prepare(profile, archive_name)
+
+                if not params['ok']:
+                    self._set_status(params['message'])
+                    return
+                self._set_status('')
+                self._toggle_all_buttons(False)
+
+                job = BorgListArchiveJob(params['cmd'], params, self.profile().repo.id)
+                job.updated.connect(self.mountErrors.setText)
+                job.result.connect(self.extract_list_result)
+                self.app.jobs_manager.add_job(job)
+                return job
+        else:
+            self._set_status(self.tr('Select an archive to restore first.'))
+
+    def extract_list_result(self, result):
+        """Process the contents of the archive to extract."""
+        self._set_status('')
+        if result['returncode'] == 0:
+            archive = ArchiveModel.get(name=result['params']['archive_name'])
+            model = ExtractTree()
+
+            progress = QProgressDialog(self.tr("Processing archive contents…"), None, 0, 0, self)
+            progress.setWindowTitle(self.tr("Please wait"))
+            progress.setWindowModality(Qt.WindowModality.WindowModal)
+            progress.setMinimumDuration(0)
+            progress.setValue(0)
+            self._extract_progress = progress
+
+            self._t = extract_dialog.ParseThread(result['data'], model)
+            self._t.finished.connect(self._extract_progress.close)
+            self._t.finished.connect(self._extract_progress.deleteLater)
+            self._t.finished.connect(lambda: self.extract_show_dialog(archive, model))
+            self._t.start()
+
+    def extract_show_dialog(self, archive, model):
+        """Show the dialog for choosing the archive contents to extract."""
+        self._set_status('')
+
+        def process_result():
+            def receive():
+                extraction_folder = dialog.selectedFiles()
+                if extraction_folder:
+                    params = BorgExtractJob.prepare(self.profile(), archive.name, model, extraction_folder[0])
+                    if params['ok']:
+                        self._toggle_all_buttons(False)
+                        job = BorgExtractJob(params['cmd'], params, self.profile().repo.id)
+                        job.updated.connect(self.mountErrors.setText)
+                        job.result.connect(self.extract_archive_result)
+                        self.app.jobs_manager.add_job(job)
+                    else:
+                        self._set_status(params['message'])
+
+            dialog = choose_file_dialog(self, self.tr("Choose Extraction Point"), want_folder=True)
+            dialog.open(receive)
+
+        window = ExtractDialog(archive, model)
+        self._toggle_all_buttons(True)
+        window.setParent(self, QtCore.Qt.WindowType.Sheet)
+        self._window = window  # for testing
+        window.show()
+        window.accepted.connect(process_result)
+
+    def extract_archive_result(self, result):
+        """Finished extraction."""
+        self._toggle_all_buttons(True)
 
     def cell_double_clicked(self, row=None, column=None):
         if not self.bRename.isEnabled():

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -151,7 +151,11 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         files_count = int(files_count)
 
         for item in items:
-            db_item = SourceFileModel.get(dir=path, profile=self.profile())
+            try:
+                db_item = SourceFileModel.get(dir=path, profile=self.profile())
+            except SourceFileModel.DoesNotExist:
+                continue
+
             if QFileInfo(path).isDir():
                 self.sourceFilesWidget.item(item.row(), SourceColumn.FilesCount).setText(format(files_count))
                 db_item.path_isdir = True
@@ -321,12 +325,21 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         indexes.sort()
         # remove each selected row, starting with the highest index (otherwise, higher indexes become invalid)
         for index in reversed(indexes):
+            path = self.sourceFilesWidget.item(index.row(), SourceColumn.Path).text()
             db_item = SourceFileModel.get(
-                dir=self.sourceFilesWidget.item(index.row(), SourceColumn.Path).text(),
+                dir=path,
                 profile=profile,
             )
             db_item.delete_instance()
             self.sourceFilesWidget.removeRow(index.row())
+
+            for thrd in self.updateThreads[:]:
+                if thrd.objectName() == path:
+                    try:
+                        thrd.signal.disconnect(self.set_path_info)
+                    except (RuntimeError, TypeError):
+                        pass
+                    self.updateThreads.remove(thrd)
 
             logger.debug(f"Removed source in row {index.row()}")
         self.update_total_size()

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import psutil
 import pytest
 from PyQt6 import QtCore
-from PyQt6.QtWidgets import QMenu
+from PyQt6.QtWidgets import QMenu, QProgressDialog
 from test_constants import TEST_TEMP_DIR
 
 import vorta.borg
@@ -124,13 +124,40 @@ def test_archive_extract(qapp, qtbot, mocker, borg_json_output, archive_env):
     stdout, stderr = borg_json_output('list_archive')
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
     mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
-    tab.archive_extract.extract_action()
+    tab.extract_action()
 
     qtbot.waitUntil(lambda: hasattr(tab, '_window'), **pytest._wait_defaults)
 
     model = tab._window.model
     assert model.root.children[0].subpath == 'home'
     assert 'test-archive, 2000' in tab._window.archiveNameLabel.text()
+
+
+def test_archive_extract_progress_dialog(qapp, qtbot, mocker, borg_json_output, archive_env):
+    """Progress dialog is shown while parsing archive contents and closed when done."""
+    main, tab = archive_env
+    tab.archiveTable.selectRow(0)
+    stdout, stderr = borg_json_output('list_archive')
+    popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
+    mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
+
+    # Spy on QProgressDialog.show to verify dialog is shown
+    show_spy = mocker.spy(QProgressDialog, 'show')
+
+    tab.extract_action()
+
+    # Wait for progress dialog to appear
+    qtbot.waitUntil(lambda: hasattr(tab, '_extract_progress'), **pytest._wait_defaults)
+    progress = tab._extract_progress
+
+    # Wait for extraction to complete (window appears)
+    qtbot.waitUntil(lambda: hasattr(tab, '_window'), **pytest._wait_defaults)
+
+    # Verify dialog was shown (spy caught the show call)
+    assert show_spy.called, "QProgressDialog.show() was not called"
+
+    # Verify dialog is closed after extraction completes
+    assert not progress.isVisible(), "Progress dialog should be closed after extraction"
 
 
 def test_archive_delete(qapp, qtbot, mocker, borg_json_output, archive_env):

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -51,3 +51,29 @@ def test_create_paths_from_command():
         'echo',
         TEST_SOURCE_DIR,
     ]
+
+
+def test_prepare_returns_info_level_when_wifi_disallowed(mocker):
+    """Test that prepare() returns level='info' when WiFi is not allowed."""
+    default_profile = BackupProfileModel.get()
+    mock_monitor = mocker.MagicMock()
+    mock_monitor.get_current_wifi.return_value = 'blocked_wifi'
+    mocker.patch('vorta.borg.create.get_network_status_monitor', return_value=mock_monitor)
+    mocker.patch(
+        'vorta.borg.create.WifiSettingModel.select',
+        return_value=mocker.MagicMock(where=lambda *a, **kw: mocker.MagicMock(count=lambda: 1)),
+    )
+    result = BorgCreateJob.prepare(default_profile)
+    assert result.get('level') == 'info'
+
+
+def test_prepare_returns_info_level_when_metered_connection(mocker):
+    """Test that prepare() returns level='info' for metered connections."""
+    default_profile = BackupProfileModel.get()
+    default_profile.dont_run_on_metered_networks = True
+    mock_monitor = mocker.MagicMock()
+    mock_monitor.get_current_wifi.return_value = None
+    mock_monitor.is_network_metered.return_value = True
+    mocker.patch('vorta.borg.create.get_network_status_monitor', return_value=mock_monitor)
+    result = BorgCreateJob.prepare(default_profile)
+    assert result.get('level') == 'info'

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import QMessageBox
 import vorta.borg.borg_job
 from vorta.keyring.abc import VortaKeyring
 from vorta.store.models import ArchiveModel, BackupProfileModel, EventLogModel, RepoModel
+from vorta.views.dialogs.repo.repo_change_passphrase import ChangeBorgPassphraseWindow
 
 LONG_PASSWORD = 'long-password-long'
 SHORT_PASSWORD = 'hunter2'
@@ -388,3 +389,18 @@ def test_handle_passphrase_change_result(qapp, qtbot, mocker, result, expected_t
     mock_instance.setWindowTitle.assert_called_once_with(tab.tr(expected_title))
     mock_instance.setText.assert_called_once_with(tab.tr(expected_text))
     mock_instance.show.assert_called_once()
+
+
+def test_change_passphrase_window_error_text(qapp, qtbot):
+    """Regression test: errorText widget must exist so _set_status() doesn't crash."""
+    mock_profile = MagicMock()
+    mock_profile.repo.url = 'test-repo.example.com:repo'
+
+    window = ChangeBorgPassphraseWindow(mock_profile)
+    qtbot.addWidget(window)
+
+    window._set_status('Unable to change the borg passphrase.')
+    assert window.errorText.text() == 'Unable to change the borg passphrase.'
+
+    window._set_status('')
+    assert window.errorText.text() == ''

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -239,3 +239,25 @@ def test_missed_startup(qapp, qtbot, window_load, clockmock, now, hour, minute, 
         assert len(event_times) == 2
     else:
         assert len(event_times) == 1
+
+
+@prepare
+def test_create_backup_no_error_notification_on_info_level(qapp, qtbot, mocker, borg_json_output):
+    """Test that notifier.deliver() is not called with level='error' when
+    prepare() returns level='info' (e.g. WiFi disallowed or metered connection)."""
+    mocker.patch(
+        'vorta.scheduler.BorgCreateJob.prepare',
+        return_value={
+            'ok': False,
+            'message': 'Current Wifi is not allowed.',
+            'level': 'info',
+        },
+    )
+    notifier_mock = mocker.patch('vorta.notifications.VortaNotifications.pick')
+    mock_notifier = mocker.MagicMock()
+    notifier_mock.return_value = mock_notifier
+
+    qapp.scheduler.create_backup(1)
+    # The error notification should be suppressed for an expected skip.
+    assert mock_notifier.deliver.call_count == 1
+    assert mock_notifier.deliver.call_args.kwargs.get('level') != 'error'


### PR DESCRIPTION
Fixes #1570

When extracting from a large archive, parsing the file list can take minutes but the UI only showed a small status-bar message. Added a QProgressDialog in indeterminate mode that appears when parsing starts and closes when done.