### PR TITLE
feat: Delete key removes items in source and profile lists

### DIFF
--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -110,7 +110,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.profileRenameButton.clicked.connect(self.profile_rename_action)
         self.profileExportButton.clicked.connect(self.profile_export_action)
         self.profileDeleteButton.clicked.connect(self.profile_delete_action)
-        QShortcut(QKeySequence(Qt.Key.Key_Delete), self.profileSelector).activated.connect(self.profile_delete_action)
+        QShortcut(QKeySequence.StandardKey.Delete, self.profileSelector).activated.connect(self.profile_delete_action)
         self.profileAddButton.addAction(self.tr("Create new profile"), self.profile_add_action)
         self.profileAddButton.addAction(self.tr("Import from file…"), self.profile_import_action)
 

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -110,6 +110,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.profileRenameButton.clicked.connect(self.profile_rename_action)
         self.profileExportButton.clicked.connect(self.profile_export_action)
         self.profileDeleteButton.clicked.connect(self.profile_delete_action)
+        QShortcut(QKeySequence(Qt.Key.Key_Delete), self.profileSelector).activated.connect(self.profile_delete_action)
         self.profileAddButton.addAction(self.tr("Create new profile"), self.profile_add_action)
         self.profileAddButton.addAction(self.tr("Import from file…"), self.profile_import_action)
 

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -91,6 +91,8 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         # Shortcuts
         shortcut_copy = QShortcut(QtGui.QKeySequence.StandardKey.Copy, self.sourceFilesWidget)
         shortcut_copy.activated.connect(self.source_copy)
+        shortcut_delete = QShortcut(QtGui.QKeySequence(Qt.Key.Key_Delete), self.sourceFilesWidget)
+        shortcut_delete.activated.connect(self.source_remove)
 
         # Connect signals
         self.addButton.clicked.connect(self.source_add)

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -91,7 +91,7 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         # Shortcuts
         shortcut_copy = QShortcut(QtGui.QKeySequence.StandardKey.Copy, self.sourceFilesWidget)
         shortcut_copy.activated.connect(self.source_copy)
-        shortcut_delete = QShortcut(QtGui.QKeySequence(Qt.Key.Key_Delete), self.sourceFilesWidget)
+        shortcut_delete = QShortcut(QtGui.QKeySequence.StandardKey.Delete, self.sourceFilesWidget)
         shortcut_delete.activated.connect(self.source_remove)
 
         # Connect signals

--- a/tests/unit/test_profile.py
+++ b/tests/unit/test_profile.py
@@ -1,6 +1,7 @@
 import tempfile
 
 from PyQt6 import QtCore
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QDialogButtonBox, QFileDialog, QMessageBox, QToolTip
 
 from vorta.store.models import BackupProfileModel, SourceFileModel
@@ -84,3 +85,20 @@ def test_profile_import_no_duplicate_sources(qapp, qtbot, mocker):
     imported_sources = [source.dir for source in SourceFileModel.select().where(SourceFileModel.profile == profile)]
     assert set(imported_sources) == set(sources)
     assert len(imported_sources) == len(sources)
+
+
+def test_profile_delete_key(qapp, qtbot, mocker):
+    """Delete key on profileSelector triggers profile deletion."""
+    main = qapp.main_window
+
+    main.profile_add_action()
+    add_profile_window = main.window
+    qtbot.keyClicks(add_profile_window.profileNameField, 'Delete Key Test')
+    save_button = add_profile_window.buttonBox.button(QDialogButtonBox.StandardButton.Save)
+    qtbot.mouseClick(save_button, QtCore.Qt.MouseButton.LeftButton)
+    assert BackupProfileModel.get_or_none(name='Delete Key Test') is not None
+
+    mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.StandardButton.Yes)
+    main.profileSelector.setFocus()
+    qtbot.keyPress(main.profileSelector, Qt.Key.Key_Delete)
+    assert BackupProfileModel.get_or_none(name='Delete Key Test') is None

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from PyQt6 import QtCore
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QMessageBox
 from test_constants import TEST_TEMP_DIR
 
@@ -39,9 +40,17 @@ def test_source_add_remove(qapp, qtbot, mocker, source_env):
     tab.source_add()
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() > initial_count, **pytest._wait_defaults)
 
-    # test remove
+    # test remove via button
     tab.sourceFilesWidget.selectRow(initial_count)  # Select the new row
     qtbot.mouseClick(tab.removeButton, QtCore.Qt.MouseButton.LeftButton)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == initial_count, **pytest._wait_defaults)
+
+    # test remove via Delete key
+    tab.source_add()
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() > initial_count, **pytest._wait_defaults)
+    tab.sourceFilesWidget.selectRow(initial_count)
+    tab.sourceFilesWidget.setFocus()
+    qtbot.keyPress(tab.sourceFilesWidget, Qt.Key.Key_Delete)
     qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == initial_count, **pytest._wait_defaults)
 
 


### PR DESCRIPTION
Closes #2447

Added a Delete key shortcut to both the source files table and the profile selector list, wired to the existing remove/delete actions.