### PR TITLE
fix: guard darwin network test import behind platform check

### DIFF
--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -1,76 +1,76 @@
 import sys
 from unittest.mock import MagicMock
- 
+
 import pytest
- 
+
 pytestmark = pytest.mark.skipif(sys.platform != 'darwin', reason="macOS only")
- 
+
 if sys.platform == 'darwin':
     from vorta.network_status import darwin  # noqa: E402
- 
- 
+
+
 def test_get_current_wifi_when_wifi_is_on(mocker):
     mock_interface = MagicMock()
     mock_network = MagicMock()
     mock_interface.lastNetworkJoined.return_value = mock_network
     mock_network.ssid.return_value = "Coffee Shop Wifi"
- 
+
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
- 
+
     result = instance.get_current_wifi()
- 
+
     assert result == "Coffee Shop Wifi"
- 
- 
+
+
 def test_get_current_wifi_when_wifi_is_off(mocker):
     mock_interface = MagicMock()
     mock_interface.lastNetworkJoined.return_value = None
- 
+
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
- 
+
     result = instance.get_current_wifi()
- 
+
     assert result is None
- 
- 
+
+
 def test_get_current_wifi_when_no_wifi_interface(mocker):
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=None)
- 
+
     result = instance.get_current_wifi()
- 
+
     assert result is None
- 
- 
+
+
 @pytest.mark.parametrize("is_hotspot_enabled", [True, False])
 def test_network_is_metered_with_ios(mocker, is_hotspot_enabled):
     mock_interface = MagicMock()
     mock_network = MagicMock()
     mock_interface.lastNetworkJoined.return_value = mock_network
     mock_network.isPersonalHotspot.return_value = is_hotspot_enabled
- 
+
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
- 
+
     result = instance.is_network_metered()
- 
+
     assert result == is_hotspot_enabled
- 
- 
+
+
 def test_network_is_metered_when_wifi_is_off(mocker):
     mock_interface = MagicMock()
     mock_interface.lastNetworkJoined.return_value = None
- 
+
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
- 
+
     result = instance.is_network_metered()
- 
+
     assert result is False
- 
- 
+
+
 @pytest.mark.parametrize(
     'getpacket_output_name, expected',
     [
@@ -82,49 +82,49 @@ def test_is_network_metered_with_android(getpacket_output_name, expected, monkey
     def mock_getpacket(device):
         assert device == 'en0'
         return GETPACKET_OUTPUTS[getpacket_output_name]
- 
+
     monkeypatch.setattr(darwin, 'call_ipconfig_getpacket', mock_getpacket)
- 
+
     result = darwin.is_network_metered_with_android('en0')
     assert result == expected
- 
- 
+
+
 def test_get_known_wifi_networks_when_wifi_interface_exists(monkeypatch):
     networksetup_output = """
 Preferred networks on en0:
     Home Network
     Coffee Shop Wifi
     iPhone
- 
+
     Office Wifi
     """
     monkeypatch.setattr(
         darwin, "call_networksetup_listpreferredwirelessnetworks", lambda interface_name: networksetup_output
     )
- 
+
     network_status = darwin.DarwinNetworkStatus()
     result = network_status.get_known_wifis()
- 
+
     assert len(result) == 4
     assert result[0].ssid == "Home Network"
- 
- 
+
+
 def test_get_known_wifi_networks_when_no_wifi_interface(mocker):
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=None)
- 
+
     results = instance.get_known_wifis()
- 
+
     assert results == []
- 
- 
+
+
 def test_get_network_devices(monkeypatch):
     monkeypatch.setattr(darwin, 'call_networksetup_listallhardwareports', lambda: NETWORKSETUP_OUTPUT)
- 
+
     result = list(darwin.get_network_devices())
     assert result == ['Bluetooth-Modem', 'en0', 'en1', 'en2', 'bridge0']
- 
- 
+
+
 GETPACKET_OUTPUTS = {
     'normal_router': b"""\
 op = BOOTREPLY
@@ -183,24 +183,24 @@ vendor_specific (opaque):
 0000  41 4e 44 52 4f 49 44 5f  4d 45 54 45 52 45 44     ANDROID_METERED
 """,
 }
- 
+
 NETWORKSETUP_OUTPUT = b"""\
 Hardware Port: Bluetooth DUN
 Device: Bluetooth-Modem
 Ethernet Address: N/A
- 
+
 Hardware Port: Wi-Fi
 Device: en0
 Ethernet Address: d7:02:65:7c:1e:14
- 
+
 Hardware Port: Bluetooth PAN
 Device: en1
 Ethernet Address: N/A
- 
+
 Hardware Port: Thunderbolt 1
 Device: en2
 Ethernet Address: bb:e8:c3:25:2b:12
- 
+
 Hardware Port: Thunderbolt Bridge
 Device: bridge0
 Ethernet Address: N/A

--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -1,75 +1,76 @@
 import sys
 from unittest.mock import MagicMock
-
+ 
 import pytest
-
+ 
 pytestmark = pytest.mark.skipif(sys.platform != 'darwin', reason="macOS only")
-
-from vorta.network_status import darwin  # noqa: E402
-
-
+ 
+if sys.platform == 'darwin':
+    from vorta.network_status import darwin  # noqa: E402
+ 
+ 
 def test_get_current_wifi_when_wifi_is_on(mocker):
     mock_interface = MagicMock()
     mock_network = MagicMock()
     mock_interface.lastNetworkJoined.return_value = mock_network
     mock_network.ssid.return_value = "Coffee Shop Wifi"
-
+ 
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
-
+ 
     result = instance.get_current_wifi()
-
+ 
     assert result == "Coffee Shop Wifi"
-
-
+ 
+ 
 def test_get_current_wifi_when_wifi_is_off(mocker):
     mock_interface = MagicMock()
     mock_interface.lastNetworkJoined.return_value = None
-
+ 
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
-
+ 
     result = instance.get_current_wifi()
-
+ 
     assert result is None
-
-
+ 
+ 
 def test_get_current_wifi_when_no_wifi_interface(mocker):
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=None)
-
+ 
     result = instance.get_current_wifi()
-
+ 
     assert result is None
-
-
+ 
+ 
 @pytest.mark.parametrize("is_hotspot_enabled", [True, False])
 def test_network_is_metered_with_ios(mocker, is_hotspot_enabled):
     mock_interface = MagicMock()
     mock_network = MagicMock()
     mock_interface.lastNetworkJoined.return_value = mock_network
     mock_network.isPersonalHotspot.return_value = is_hotspot_enabled
-
+ 
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
-
+ 
     result = instance.is_network_metered()
-
+ 
     assert result == is_hotspot_enabled
-
-
+ 
+ 
 def test_network_is_metered_when_wifi_is_off(mocker):
     mock_interface = MagicMock()
     mock_interface.lastNetworkJoined.return_value = None
-
+ 
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=mock_interface)
-
+ 
     result = instance.is_network_metered()
-
+ 
     assert result is False
-
-
+ 
+ 
 @pytest.mark.parametrize(
     'getpacket_output_name, expected',
     [
@@ -81,49 +82,49 @@ def test_is_network_metered_with_android(getpacket_output_name, expected, monkey
     def mock_getpacket(device):
         assert device == 'en0'
         return GETPACKET_OUTPUTS[getpacket_output_name]
-
+ 
     monkeypatch.setattr(darwin, 'call_ipconfig_getpacket', mock_getpacket)
-
+ 
     result = darwin.is_network_metered_with_android('en0')
     assert result == expected
-
-
+ 
+ 
 def test_get_known_wifi_networks_when_wifi_interface_exists(monkeypatch):
     networksetup_output = """
 Preferred networks on en0:
     Home Network
     Coffee Shop Wifi
     iPhone
-
+ 
     Office Wifi
     """
     monkeypatch.setattr(
         darwin, "call_networksetup_listpreferredwirelessnetworks", lambda interface_name: networksetup_output
     )
-
+ 
     network_status = darwin.DarwinNetworkStatus()
     result = network_status.get_known_wifis()
-
+ 
     assert len(result) == 4
     assert result[0].ssid == "Home Network"
-
-
+ 
+ 
 def test_get_known_wifi_networks_when_no_wifi_interface(mocker):
     instance = darwin.DarwinNetworkStatus()
     mocker.patch.object(instance, "_get_wifi_interface", return_value=None)
-
+ 
     results = instance.get_known_wifis()
-
+ 
     assert results == []
-
-
+ 
+ 
 def test_get_network_devices(monkeypatch):
     monkeypatch.setattr(darwin, 'call_networksetup_listallhardwareports', lambda: NETWORKSETUP_OUTPUT)
-
+ 
     result = list(darwin.get_network_devices())
     assert result == ['Bluetooth-Modem', 'en0', 'en1', 'en2', 'bridge0']
-
-
+ 
+ 
 GETPACKET_OUTPUTS = {
     'normal_router': b"""\
 op = BOOTREPLY
@@ -182,24 +183,24 @@ vendor_specific (opaque):
 0000  41 4e 44 52 4f 49 44 5f  4d 45 54 45 52 45 44     ANDROID_METERED
 """,
 }
-
+ 
 NETWORKSETUP_OUTPUT = b"""\
 Hardware Port: Bluetooth DUN
 Device: Bluetooth-Modem
 Ethernet Address: N/A
-
+ 
 Hardware Port: Wi-Fi
 Device: en0
 Ethernet Address: d7:02:65:7c:1e:14
-
+ 
 Hardware Port: Bluetooth PAN
 Device: en1
 Ethernet Address: N/A
-
+ 
 Hardware Port: Thunderbolt 1
 Device: en2
 Ethernet Address: bb:e8:c3:25:2b:12
-
+ 
 Hardware Port: Thunderbolt Bridge
 Device: bridge0
 Ethernet Address: N/A


### PR DESCRIPTION
## Problem
Running `uv run pytest tests/` on Windows fails at collection time:

    ModuleNotFoundError: No module named 'CoreWLAN'

`pytestmark` skips test execution but cannot prevent the top-level
import from running on Windows where CoreWLAN does not exist.
This crashes the entire test suite before any test runs.

## Fix
Wrapped the import in `if sys.platform == 'darwin'` so it never
executes on Windows or Linux.

## Before / After
Before: ERROR collecting tests/network_manager/test_darwin.py
After:  11 darwin tests skip cleanly on Windows

## Tested on
- Windows 11 ✅
