### PR TITLE
git push origin fix-exclusion-export

### DIFF
--- a/src/vorta/profile_export.py
+++ b/src/vorta/profile_export.py
@@ -5,7 +5,7 @@ from json import JSONDecodeError
 from playhouse.shortcuts import dict_to_model, model_to_dict
 
 from vorta.keyring.abc import VortaKeyring
-from vorta.store.connection import DB, SCHEMA_VERSION, init_db
+
 from vorta.store.models import (
     BackupProfileModel,
     RepoModel,
@@ -13,6 +13,7 @@ from vorta.store.models import (
     SettingsModel,
     SourceFileModel,
     WifiSettingModel,
+    ExclusionModel,
 )
 
 
@@ -63,6 +64,11 @@ class ProfileExport:
         profile_dict['SourceFileModel'] = [
             model_to_dict(source, recurse=False, exclude=[SourceFileModel.id])
             for source in SourceFileModel.select().where(SourceFileModel.profile == profile)
+        ]
+        # Add ExclusionModel
+        profile_dict['ExclusionModel'] = [
+        model_to_dict(exclusion, recurse=False, exclude=[ExclusionModel.id])
+        for exclusion in ExclusionModel.select().where(ExclusionModel.profile == profile)
         ]
         # Add SchemaVersion
         profile_dict['SchemaVersion'] = model_to_dict(SchemaVersion.get(id=1))


### PR DESCRIPTION
### Summary

Fix missing exclusion data in profile export.

### Problem

When exporting a profile, exclusion rules (custom and preset) were not included in the exported JSON. This caused incomplete exports and loss of exclusion configuration when importing profiles.

### Solution

Added ExclusionModel data to the export process in `ProfileExport.from_db`, following the same pattern used for SourceFileModel and other related models.

### Result

Exported profiles now correctly include:
- Custom exclusions
- Preset exclusions

### Testing

- Added exclusion via UI
- Exported profile
- Verified `ExclusionModel` is present in JSON output

Fixes #2414