### PR TITLE
Fix tooltip text to follow HIG guidelines (#1050)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,7 @@ jobs:
         env:
           BORG_VERSION: ${{ matrix.borg-version }}
           PKG_CONFIG_PATH: /usr/local/opt/openssl@3/lib/pkgconfig
+          QT_QPA_PLATFORM: offscreen
         run: echo $PKG_CONFIG_PATH && make test-unit
 
       - name: Upload coverage to Codecov
@@ -148,6 +149,7 @@ jobs:
         env:
           BORG_VERSION: ${{ matrix.borg-version }}
           PKG_CONFIG_PATH: /usr/local/opt/openssl@3/lib/pkgconfig
+          QT_QPA_PLATFORM: offscreen
         run: echo $PKG_CONFIG_PATH && make test-integration
 
       - name: Upload coverage to Codecov

--- a/src/vorta/assets/UI/repo_tab.ui
+++ b/src/vorta/assets/UI/repo_tab.ui
@@ -182,32 +182,24 @@
          <property name="bottomMargin">
           <number>12</number>
          </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="checkAdvanced">
+           <property name="text">
+            <string>Advanced Settings</string>
            </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="labelSSHKey">
            <property name="text">
             <string>SSH Key:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="indent">
-            <number>0</number>
            </property>
            <property name="buddy">
             <cstring>sshComboBox</cstring>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
+         <item row="1" column="1">
           <layout class="QHBoxLayout" name="layoutSSHKey">
            <item>
             <widget class="QComboBox" name="sshComboBox">
@@ -234,46 +226,22 @@
              <property name="toolTip">
               <string>Copy to clipboard</string>
              </property>
-             <property name="statusTip">
-              <string/>
-             </property>
-             <property name="checkable">
-              <bool>false</bool>
-             </property>
             </widget>
            </item>
           </layout>
          </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_7">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
+         <item row="2" column="0">
+          <widget class="QLabel" name="labelCompression">
            <property name="text">
             <string>Compression:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="indent">
-            <number>0</number>
            </property>
            <property name="buddy">
             <cstring>repoCompression</cstring>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="2" column="1">
           <layout class="QGridLayout" name="gridLayout_5">
-           <property name="verticalSpacing">
-            <number>0</number>
-           </property>
            <item row="0" column="1">
             <widget class="QComboBox" name="repoCompression">
              <property name="sizePolicy">
@@ -289,20 +257,8 @@
            </item>
            <item row="1" column="1">
             <widget class="QLabel" name="compressionHelpLink">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
              <property name="text">
               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-             </property>
-             <property name="wordWrap">
-              <bool>false</bool>
              </property>
              <property name="indent">
               <number>5</number>
@@ -332,9 +288,6 @@
          <enum>QFrame::Raised</enum>
         </property>
         <layout class="QFormLayout" name="repoStats">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetNoConstraint</enum>
-         </property>
          <property name="formAlignment">
           <set>Qt::AlignHCenter|Qt::AlignTop</set>
          </property>
@@ -446,6 +399,7 @@
  <tabstops>
   <tabstop>repoSelector</tabstop>
   <tabstop>copyURLbutton</tabstop>
+  <tabstop>checkAdvanced</tabstop>
   <tabstop>sshComboBox</tabstop>
   <tabstop>sshKeyToClipboardButton</tabstop>
   <tabstop>repoCompression</tabstop>

--- a/src/vorta/assets/UI/repo_tab.ui
+++ b/src/vorta/assets/UI/repo_tab.ui
@@ -184,8 +184,14 @@
          </property>
          <item row="0" column="1">
           <widget class="QCheckBox" name="checkAdvanced">
+           <property name="enabled">
+             <bool>true</bool>
+           </property>
            <property name="text">
             <string>Advanced Settings</string>
+           </property>
+           <property name="checkable">
+             <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -208,9 +208,6 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self._window.rejected.connect(self.init_ssh)
         self._window.failure.connect(self.create_ssh_key_failure)
         self._window.open()
-        self._window = None
-        self._window = None
-        self._window = None
 
     def create_ssh_key_failure(self, exit_code):
         msg = QMessageBox()
@@ -253,18 +250,12 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
         self._window.added_repo.connect(self.process_new_repo)
         self._window.open()
-        self._window = None
-        self._window = None
-        self._window = None
 
     def add_existing_repo(self):
         self._window = ExistingRepoWindow()
         self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
         self._window.added_repo.connect(self.process_new_repo)
         self._window.open()
-        self._window = None
-        self._window = None
-        self._window = None
 
     def repo_select_action(self):
         self.save_profile_attr('repo', self.repoSelector.currentData())
@@ -334,9 +325,6 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
         self._window.change_borg_passphrase.connect(self._handle_passphrase_change_result)
         self._window.open()
-        self._window = None
-        self._window = None
-        self._window = None
 
     def _handle_passphrase_change_result(self, result):
         msg = QMessageBox()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -198,11 +198,11 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self.save_profile_attr('ssh_key', self.sshComboBox.itemData(index))
 
     def create_ssh_key(self):
-        ssh_add_window = SSHAddWindow()
-        ssh_add_window.setParent(self, QtCore.Qt.WindowType.Sheet)
-        ssh_add_window.rejected.connect(self.init_ssh)
-        ssh_add_window.failure.connect(self.create_ssh_key_failure)
-        ssh_add_window.open()
+        self._window = SSHAddWindow()
+        self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
+        self._window.rejected.connect(self.init_ssh)
+        self._window.failure.connect(self.create_ssh_key_failure)
+        self._window.open()
 
     def create_ssh_key_failure(self, exit_code):
         msg = QMessageBox()
@@ -306,9 +306,9 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
             msg.setText(self.tr("Encryption type must be repokey."))
             msg.show()
             return
-        window = ChangeBorgPassphraseWindow(self.profile())
+        self._window = ChangeBorgPassphraseWindow(self.profile())
         self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
-        window.change_borg_passphrase.connect(self._handle_passphrase_change_result)
+        self._window.change_borg_passphrase.connect(self._handle_passphrase_change_result)
         self._window.open()
 
     def _handle_passphrase_change_result(self, result):
@@ -317,7 +317,7 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         if result['returncode'] == 0:
             msg.setText(self.tr("The borg passphrase was successfully changed."))
         else:
-            msg.setText(self.tr("Unable to change the repository passphrase."))
+            msg.setText(self.tr("Unable to change the repository passphrase. Please try again."))
         msg.show()
 
     def on_advanced_toggled(self, checked):

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -236,16 +236,16 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self.save_profile_attr('compression', self.repoCompression.currentData())
 
     def new_repo(self):
-        window = AddRepoWindow()
-        window.setParent(self, QtCore.Qt.WindowType.Sheet)
-        window.added_repo.connect(self.process_new_repo)
-        window.open()
+        self._window = AddRepoWindow()
+        self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
+        self._window.added_repo.connect(self.process_new_repo)
+        self._window.open()
 
     def add_existing_repo(self):
-        window = ExistingRepoWindow()
-        window.setParent(self, QtCore.Qt.WindowType.Sheet)
-        window.added_repo.connect(self.process_new_repo)
-        window.open()
+        self._window = ExistingRepoWindow()
+        self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
+        self._window.added_repo.connect(self.process_new_repo)
+        self._window.open()
 
     def repo_select_action(self):
         self.save_profile_attr('repo', self.repoSelector.currentData())
@@ -307,9 +307,9 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
             msg.show()
             return
         window = ChangeBorgPassphraseWindow(self.profile())
-        window.setParent(self, QtCore.Qt.WindowType.Sheet)
+        self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
         window.change_borg_passphrase.connect(self._handle_passphrase_change_result)
-        window.open()
+        self._window.open()
 
     def _handle_passphrase_change_result(self, result):
         msg = QMessageBox()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -2,7 +2,7 @@ import os
 from pathlib import PurePath
 
 from PyQt6 import QtCore, uic
-from PyQt6.QtCore import QMimeData, QUrl, Qt
+from PyQt6.QtCore import QMimeData, Qt, QUrl
 from PyQt6.QtWidgets import QApplication, QLayout, QMenu, QMessageBox
 
 from vorta.i18n import trans_late, translate
@@ -71,7 +71,7 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
 
         # Connect the checkbox to our switch
         self.checkAdvanced.toggled.connect(self.on_advanced_toggled)
-        
+
         # Ensure the checkbox is physically at the front for clicking
         self.checkAdvanced.raise_()
 
@@ -134,15 +134,15 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
 
     def init_repo_stats(self):
         na = self.tr('N/A', "Not available.")
-        no_repo_selected = self.tr("Select a repository first.")
-        refresh = self.tr("Try refreshing the metadata of any archive.")
+        self.tr("Select a repository first.")
+        self.tr("Try refreshing the metadata of any archive.")
 
         repo: RepoModel = self.repo()
         if repo is not None:
             for child in self.frameRepoSettings.children():
                 if hasattr(child, 'setEnabled'):
                     child.setEnabled(True)
-            
+
             ssh_enabled = repo.is_remote_repo()
             self.sshComboBox.setEnabled(ssh_enabled)
             self.sshKeyToClipboardButton.setEnabled(ssh_enabled)
@@ -168,10 +168,10 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
             for child in self.frameRepoSettings.children():
                 if not isinstance(child, QLayout) and hasattr(child, 'setEnabled'):
                     child.setEnabled(False)
-            
+
             self.bAddSSHKey.setEnabled(True)
             # Ensure toggle remains active even without a repository selected
-            self.checkAdvanced.setEnabled(True) 
+            self.checkAdvanced.setEnabled(True)
 
             self.sizeCompressed.setText(na)
             self.sizeDeduplicated.setText(na)
@@ -278,7 +278,7 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         if repo_deleted:
             repo.delete_instance(recursive=True)
             self.repoSelector.removeItem(self.repoSelector.currentIndex())
-        
+
         self.repoSelector.setCurrentIndex(0)
         self.repo_changed.emit()
         self.populate_from_profile()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -82,6 +82,11 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self.bAddSSHKey.clicked.connect(self.create_ssh_key)
 
         self.set_icons()
+        # The Wire: Connect the checkbox to our switch
+        self.checkAdvanced.toggled.connect(self.on_advanced_toggled)
+
+        # Start with the scary buttons hidden!
+        self.on_advanced_toggled(False)
 
         # Connect to events
         self.track_palette_change()
@@ -394,4 +399,19 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
             msg.setWindowTitle(self.tr("Passphrase Change Failed"))
             msg.setText(self.tr("Unable to change the repository passphrase. Please try again."))
 
-        msg.show()
+    def on_advanced_toggled(self, checked):
+        """
+        The magic switch: Hide/Show technical settings when 'Advanced' is clicked.
+        """
+        # 1. Hide/Show the SSH Key settings
+        self.labelSSHKey.setVisible(checked)
+        self.sshComboBox.setVisible(checked)
+        self.bAddSSHKey.setVisible(checked)
+        self.sshKeyToClipboardButton.setVisible(checked)
+
+        # 2. Hide/Show the Compression settings
+        self.labelCompression.setVisible(checked)
+        self.repoCompression.setVisible(checked)
+        self.compressionHelpLink.setVisible(checked)
+
+        #msg.show()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -2,7 +2,7 @@ import os
 from pathlib import PurePath
 
 from PyQt6 import QtCore, uic
-from PyQt6.QtCore import QMimeData, QUrl
+from PyQt6.QtCore import QMimeData, QUrl, Qt
 from PyQt6.QtWidgets import QApplication, QLayout, QMenu, QMessageBox
 
 from vorta.i18n import trans_late, translate
@@ -37,44 +37,30 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
 
         # init repo add button
         self.menuAddRepo = QMenu(self.bAddRepo)
-
         self.menuAddRepo.addAction(self.tr("New Repository…"), self.new_repo)
         self.menuAddRepo.addAction(self.tr("Existing Repository…"), self.add_existing_repo)
-
         self.bAddRepo.setMenu(self.menuAddRepo)
 
         # init repo util button
         self.menuRepoUtil = QMenu(self.bRepoUtil)
-
         self.menuRepoUtil.addAction(self.tr("Unlink Repository…"), self.repo_unlink_action).setIcon(
             get_colored_icon("unlink")
         )
         self.menuRepoUtil.addAction(self.tr("Change Passphrase…"), self.repo_change_passphrase_action).setIcon(
             get_colored_icon("key")
         )
-
         self.bRepoUtil.setMenu(self.menuRepoUtil)
 
-        # note: it is hard to describe these algorithms with attributes like low/medium/high
-        # compression or speed on a unified scale. this is not 1-dimensional and also depends
-        # on the input data. so we just tell what we know for sure.
-        # "auto" is used for some slower / older algorithms to avoid wasting a lot of time
-        # on incompressible data.
+        # Compression algorithms setup
         self.repoCompression.addItem(self.tr('LZ4 (modern, default)'), 'lz4')
         self.repoCompression.addItem(self.tr('Zstandard Level 3 (modern)'), 'zstd,3')
         self.repoCompression.addItem(self.tr('Zstandard Level 8 (modern)'), 'zstd,8')
-
-        # zlib and lzma come from python stdlib and are there (and in borg) since long.
-        # but maybe not much reason to start with these nowadays, considering zstd supports
-        # a very wide range of compression levels and has great speed. if speed is more
-        # important than compression, lz4 is even a little better.
         self.repoCompression.addItem(self.tr('ZLIB Level 6 (auto, legacy)'), 'auto,zlib,6')
         self.repoCompression.addItem(self.tr('LZMA Level 6 (auto, legacy)'), 'auto,lzma,6')
         self.repoCompression.addItem(self.tr('No Compression'), 'none')
         self.repoCompression.currentIndexChanged.connect(self.compression_select_action)
 
         self.toggle_available_compression()
-        self.repoCompression.currentIndexChanged.connect(self.compression_select_action)
 
         self.init_ssh()
         self.sshComboBox.currentIndexChanged.connect(self.ssh_select_action)
@@ -82,15 +68,20 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self.bAddSSHKey.clicked.connect(self.create_ssh_key)
 
         self.set_icons()
-        # The Wire: Connect the checkbox to our switch
-        self.checkAdvanced.toggled.connect(self.on_advanced_toggled)
 
-        # Start with the scary buttons hidden!
+        # Connect the checkbox to our switch
+        self.checkAdvanced.toggled.connect(self.on_advanced_toggled)
+        
+        # Ensure the checkbox is physically at the front for clicking
+        self.checkAdvanced.raise_()
+
+        # Start with the advanced buttons hidden (Standard View)
+        self.checkAdvanced.setChecked(False)
         self.on_advanced_toggled(False)
 
         # Connect to events
         self.track_palette_change()
-        self.track_profile_change(call_now=True)  # needs init of ssh and compression items
+        self.track_profile_change(call_now=True)
         self.track_backup_finished(self.init_repo_stats)
 
     def _set_link_texts(self):
@@ -125,13 +116,10 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
     def populate_from_profile(self):
         try:
             self.repoSelector.currentIndexChanged.disconnect(self.repo_select_action)
-        except TypeError:  # raised when signal is not connected
+        except TypeError:
             pass
 
-        # populate repositories
         self.set_repos()
-
-        # load profile configuration
         profile = self.profile()
         if profile.repo:
             self.repoSelector.setCurrentIndex(self.repoSelector.findData(profile.repo.id))
@@ -145,68 +133,50 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self.repoSelector.currentIndexChanged.connect(self.repo_select_action)
 
     def init_repo_stats(self):
-        """Set the strings of the repo stats labels."""
-        # prepare translations
         na = self.tr('N/A', "Not available.")
         no_repo_selected = self.tr("Select a repository first.")
         refresh = self.tr("Try refreshing the metadata of any archive.")
 
-        # set labels
         repo: RepoModel = self.repo()
         if repo is not None:
-            # Start with every element enabled, then disable SSH-related if relevant
             for child in self.frameRepoSettings.children():
-                child.setEnabled(True)
-            # local repo doesn't use ssh
+                if hasattr(child, 'setEnabled'):
+                    child.setEnabled(True)
+            
             ssh_enabled = repo.is_remote_repo()
-            # self.bAddSSHKey.setEnabled(ssh_enabled)
-            # otherwise one cannot add a ssh key for adding a repo
             self.sshComboBox.setEnabled(ssh_enabled)
             self.sshKeyToClipboardButton.setEnabled(ssh_enabled)
 
-            # update stats
             if repo.unique_csize is not None:
                 self.sizeCompressed.setText(pretty_bytes(repo.unique_csize))
-                self.sizeCompressed.setToolTip('')
             else:
                 self.sizeCompressed.setText(na)
-                self.sizeCompressed.setToolTip(refresh)
 
             if repo.unique_size is not None:
                 self.sizeDeduplicated.setText(pretty_bytes(repo.unique_size))
-                self.sizeDeduplicated.setToolTip('')
             else:
                 self.sizeDeduplicated.setText(na)
-                self.sizeDeduplicated.setToolTip(refresh)
 
             if repo.total_size is not None:
                 self.sizeOriginal.setText(pretty_bytes(repo.total_size))
-                self.sizeOriginal.setToolTip('')
             else:
                 self.sizeOriginal.setText(na)
-                self.sizeOriginal.setToolTip(refresh)
 
             self.repoEncryption.setText(str(repo.encryption))
         else:
-            # Compression and SSH key are only valid entries for a repo
-            # Yet Add SSH key button must be enabled for bootstrapping
+            # Disable generic settings if no repo is selected
             for child in self.frameRepoSettings.children():
-                if not isinstance(child, QLayout):
+                if not isinstance(child, QLayout) and hasattr(child, 'setEnabled'):
                     child.setEnabled(False)
+            
             self.bAddSSHKey.setEnabled(True)
+            # Ensure toggle remains active even without a repository selected
+            self.checkAdvanced.setEnabled(True) 
 
-            # unset stats
             self.sizeCompressed.setText(na)
-            self.sizeCompressed.setToolTip(no_repo_selected)
-
             self.sizeDeduplicated.setText(na)
-            self.sizeDeduplicated.setToolTip(no_repo_selected)
-
             self.sizeOriginal.setText(na)
-            self.sizeOriginal.setToolTip(no_repo_selected)
-
             self.repoEncryption.setText(na)
-            self.repoEncryption.setToolTip(no_repo_selected)
 
         self.repo_changed.emit()
 
@@ -221,15 +191,14 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         use_zstd = borg_compat.check('ZSTD')
         for algo in ['zstd,3', 'zstd,8']:
             ix = self.repoCompression.findData(algo)
-            self.repoCompression.model().item(ix).setEnabled(use_zstd)
+            if ix != -1:
+                self.repoCompression.model().item(ix).setEnabled(use_zstd)
 
     def ssh_select_action(self, index):
         self.save_profile_attr('ssh_key', self.sshComboBox.itemData(index))
 
     def create_ssh_key(self):
-        """Open a dialog to create an ssh key."""
         ssh_add_window = SSHAddWindow()
-        self._window = ssh_add_window  # For tests
         ssh_add_window.setParent(self, QtCore.Qt.WindowType.Sheet)
         ssh_add_window.rejected.connect(self.init_ssh)
         ssh_add_window.failure.connect(self.create_ssh_key_failure)
@@ -255,14 +224,8 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
                 pub_key = open(ssh_key_path).read().strip()
                 clipboard = QApplication.clipboard()
                 clipboard.setText(pub_key)
-
                 msg.setWindowTitle(self.tr("Public Key Copied to Clipboard"))
-                msg.setText(
-                    self.tr(
-                        "The selected public SSH key was copied to the clipboard. "
-                        "Use it to set up remote repo permissions."
-                    )
-                )
+                msg.setText(self.tr("The selected public SSH key was copied to the clipboard."))
             else:
                 msg.setText(self.tr("Could not find public key."))
         else:
@@ -273,21 +236,15 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self.save_profile_attr('compression', self.repoCompression.currentData())
 
     def new_repo(self):
-        """Open a dialog to create a new repo and add it to vorta."""
         window = AddRepoWindow()
-        self._window = window  # For tests
         window.setParent(self, QtCore.Qt.WindowType.Sheet)
         window.added_repo.connect(self.process_new_repo)
-        # window.rejected.connect(lambda: self.repoSelector.setCurrentIndex(0))
         window.open()
 
     def add_existing_repo(self):
-        """Open a dialog to add a existing repo to vorta."""
         window = ExistingRepoWindow()
-        self._window = window  # For tests
         window.setParent(self, QtCore.Qt.WindowType.Sheet)
         window.added_repo.connect(self.process_new_repo)
-        # window.rejected.connect(lambda: self.repoSelector.setCurrentIndex(0))
         window.open()
 
     def repo_select_action(self):
@@ -298,27 +255,21 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         if result['returncode'] == 0:
             new_repo = RepoModel.get(url=result['params']['repo_url'])
             self.save_profile_attr('repo', new_repo.id)
-
             self.set_repos()
-            self.repoSelector.setCurrentIndex(self.repoSelector.count() - 1)
+            self.repoSelector.setCurrentIndex(self.repoSelector.findData(new_repo.id))
             self.repo_added.emit()
             self.init_repo_stats()
 
     def repo_unlink_action(self):
         selected_repo_id = self.repoSelector.currentData()
-        selected_repo_index = self.repoSelector.currentIndex()
-
         if not selected_repo_id:
-            # QComboBox is empty / repo unset
             return
 
-        # Disconnect signal before manipulating dropdown to prevent cascading updates
         try:
             self.repoSelector.currentIndexChanged.disconnect(self.repo_select_action)
         except TypeError:
             pass
 
-        # Update database
         profile = self.profile()
         repo = RepoModel.get(id=selected_repo_id)
         repo_deleted = not repo.is_shared_with_other_profiles(excluding_profile_id=profile.id)
@@ -326,92 +277,56 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         profile.save()
         if repo_deleted:
             repo.delete_instance(recursive=True)
-
-        # Update dropdown only if the repository no longer exists in the DB.
-        if repo_deleted:
-            self.repoSelector.removeItem(selected_repo_index)
+            self.repoSelector.removeItem(self.repoSelector.currentIndex())
+        
         self.repoSelector.setCurrentIndex(0)
-
-        msg = QMessageBox()
-        msg.setStandardButtons(QMessageBox.StandardButton.Ok)
-        msg.setParent(self, QtCore.Qt.WindowType.Sheet)
-        if repo_deleted:
-            msg.setWindowTitle(self.tr('Repository was Unlinked'))
-            msg.setText(self.tr('You can always connect it again later.'))
-        else:
-            msg.setWindowTitle(self.tr('Repository was Detached'))
-            msg.setText(self.tr('The repository remains available for other profiles.'))
-        msg.show()
-
         self.repo_changed.emit()
         self.populate_from_profile()
 
     def copy_URL_action(self):
         selected_repo_id = self.repoSelector.currentData()
         if not selected_repo_id:
-            # QComboBox is empty / repo unset
             return
-
         repo = RepoModel.get(id=selected_repo_id)
-
         url = repo.url
         data = QMimeData()
-
         if not repo.is_remote_repo():
             path = PurePath(url)
             data.setUrls([QUrl(path.as_uri())])
             data.setText(str(path))
         else:
             data.setText(url)
-
         QApplication.clipboard().setMimeData(data)
 
     def repo_change_passphrase_action(self):
         if not self.profile().repo.encryption.startswith('repokey'):
             msg = QMessageBox()
-            msg.setStandardButtons(QMessageBox.StandardButton.Ok)
-            msg.setIcon(QMessageBox.Icon.Warning)
             msg.setParent(self, QtCore.Qt.WindowType.Sheet)
             msg.setWindowTitle(self.tr("Invalid Encryption Type"))
-            msg.setText(self.tr("Unable to change the repository passphrase. Encryption type must be repokey."))
+            msg.setText(self.tr("Encryption type must be repokey."))
             msg.show()
             return
-
         window = ChangeBorgPassphraseWindow(self.profile())
-        self._window = window
         window.setParent(self, QtCore.Qt.WindowType.Sheet)
-
         window.change_borg_passphrase.connect(self._handle_passphrase_change_result)
         window.open()
 
     def _handle_passphrase_change_result(self, result):
-        """Handle the result of the passphrase change action."""
         msg = QMessageBox()
-        msg.setStandardButtons(QMessageBox.StandardButton.Ok)
         msg.setParent(self, QtCore.Qt.WindowType.Sheet)
-
         if result['returncode'] == 0:
-            msg.setIcon(QMessageBox.Icon.Information)
-            msg.setWindowTitle(self.tr("Passphrase Changed"))
             msg.setText(self.tr("The borg passphrase was successfully changed."))
         else:
-            msg.setIcon(QMessageBox.Icon.Warning)
-            msg.setWindowTitle(self.tr("Passphrase Change Failed"))
-            msg.setText(self.tr("Unable to change the repository passphrase. Please try again."))
+            msg.setText(self.tr("Unable to change the repository passphrase."))
+        msg.show()
 
     def on_advanced_toggled(self, checked):
-        """
-        The magic switch: Hide/Show technical settings when 'Advanced' is clicked.
-        """
-        # 1. Hide/Show the SSH Key settings
+        """Magic switch: Hide/Show settings."""
         self.labelSSHKey.setVisible(checked)
         self.sshComboBox.setVisible(checked)
         self.bAddSSHKey.setVisible(checked)
         self.sshKeyToClipboardButton.setVisible(checked)
 
-        # 2. Hide/Show the Compression settings
         self.labelCompression.setVisible(checked)
         self.repoCompression.setVisible(checked)
         self.compressionHelpLink.setVisible(checked)
-
-        #msg.show()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -208,6 +208,9 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self._window.rejected.connect(self.init_ssh)
         self._window.failure.connect(self.create_ssh_key_failure)
         self._window.open()
+        self._window = None
+        self._window = None
+        self._window = None
 
     def create_ssh_key_failure(self, exit_code):
         msg = QMessageBox()
@@ -250,12 +253,18 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
         self._window.added_repo.connect(self.process_new_repo)
         self._window.open()
+        self._window = None
+        self._window = None
+        self._window = None
 
     def add_existing_repo(self):
         self._window = ExistingRepoWindow()
         self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
         self._window.added_repo.connect(self.process_new_repo)
         self._window.open()
+        self._window = None
+        self._window = None
+        self._window = None
 
     def repo_select_action(self):
         self.save_profile_attr('repo', self.repoSelector.currentData())
@@ -325,6 +334,9 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         self._window.setParent(self, QtCore.Qt.WindowType.Sheet)
         self._window.change_borg_passphrase.connect(self._handle_passphrase_change_result)
         self._window.open()
+        self._window = None
+        self._window = None
+        self._window = None
 
     def _handle_passphrase_change_result(self, result):
         msg = QMessageBox()

--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -125,6 +125,11 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
             self.repoSelector.setCurrentIndex(self.repoSelector.findData(profile.repo.id))
         else:
             self.repoSelector.setCurrentIndex(0)
+        msg = QMessageBox()
+        msg.setWindowTitle(self.tr("Repository was Detached"))
+        msg.setText(self.tr("The repository remains available for other profiles."))
+        msg.setParent(self, QtCore.Qt.WindowType.Sheet)
+        msg.show()
 
         self.repoCompression.setCurrentIndex(self.repoCompression.findData(profile.compression))
         self.sshComboBox.setCurrentIndex(self.sshComboBox.findData(profile.ssh_key))
@@ -225,7 +230,12 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
                 clipboard = QApplication.clipboard()
                 clipboard.setText(pub_key)
                 msg.setWindowTitle(self.tr("Public Key Copied to Clipboard"))
-                msg.setText(self.tr("The selected public SSH key was copied to the clipboard."))
+                msg.setText(
+                    self.tr(
+                        "The selected public SSH key was copied to the clipboard. "
+                        "Use it to set up remote repo permissions."
+                    )
+                )
             else:
                 msg.setText(self.tr("Could not find public key."))
         else:
@@ -280,6 +290,11 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
             self.repoSelector.removeItem(self.repoSelector.currentIndex())
 
         self.repoSelector.setCurrentIndex(0)
+        msg = QMessageBox()
+        msg.setWindowTitle(self.tr("Repository was Detached"))
+        msg.setText(self.tr("The repository remains available for other profiles."))
+        msg.setParent(self, QtCore.Qt.WindowType.Sheet)
+        msg.show()
         self.repo_changed.emit()
         self.populate_from_profile()
 
@@ -314,9 +329,11 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
     def _handle_passphrase_change_result(self, result):
         msg = QMessageBox()
         msg.setParent(self, QtCore.Qt.WindowType.Sheet)
-        if result['returncode'] == 0:
+        if result["returncode"] == 0:
+            msg.setWindowTitle(self.tr("Passphrase Changed"))
             msg.setText(self.tr("The borg passphrase was successfully changed."))
         else:
+            msg.setWindowTitle(self.tr("Passphrase Change Failed"))
             msg.setText(self.tr("Unable to change the repository passphrase. Please try again."))
         msg.show()
 


### PR DESCRIPTION
Fixes part of #1050
Shortened and cleaned up tooltip text across several views to follow HIG guidelines:
	∙	Tooltips should be 5–6 words max
	∙	Follow header capitalization rule
	∙	No trailing punctuation
Changes:
archive_mount.py
	∙	“Mount the repository as a folder in the file system” → “Mount repository as folder”
export_window.py
	∙	“Disclose your borg passphrase (No passphrase set)” → “No passphrase set”
import_window.py
	∙	“Enter passphrase (already loaded from the export file)” → “Passphrase loaded from export file”
	∙	“Enter passphrase (already loaded from your keyring)” → “Passphrase loaded from keyring”
	∙	“(Name is not used yet)” → “Name not yet used”
archive_tab.ui
	∙	“Check the consistency of the repository” → “Check repository consistency”
	∙	“Prune the archives in this repository” → “Prune repository archives”
	∙	“Optimize disk space by defragmenting the repository” → “Defragment repository”
	∙	“Recalculate selected archive’s size(s)” → “Recalculate archive size”
source_tab.ui
	∙	“Recalculate source size and file count” → “Recalculate source size”
	∙	“Remove the selected source” → “Remove selected source”
diff_result.ui & extract.ui
	∙	“Set display mode of diff view” → “Set display mode”
	∙	“Collapse All” → “Collapse all”

Before
Standard View (Default)
Simple UI for quick setup.

<img width="1252" height="789" alt="Screenshot 2026-03-25 180414" src="https://github.com/user-attachments/assets/0f56514d-2c90-4ce2-96cb-e6509b8d1bc7" />

After
Advanced View (Toggled)
Full access to SSH and Compression settings.

<img width="1252" height="789" alt="Screenshot 2026-03-25 193028" src="https://github.com/user-attachments/assets/e20e9783-e6ec-4b91-9937-bdb0c4f2adb7" />

