### PR TITLE
fix: import darwin module conditionally for macOS tests

### DIFF
--- a/tests/network_manager/test_darwin.py
+++ b/tests/network_manager/test_darwin.py
@@ -5,7 +5,8 @@ import pytest
 
 pytestmark = pytest.mark.skipif(sys.platform != 'darwin', reason="macOS only")
 
-from vorta.network_status import darwin  # noqa: E402
+if sys.platform == 'darwin':
+    from vorta.network_status import darwin
 
 
 def test_get_current_wifi_when_wifi_is_on(mocker):


### PR DESCRIPTION

### Description

The change makes the import of a macOS-specific module conditional, so it's only attempted, if the system running the test is macOS. This fixes the failed import observed in #2480.

### Related Issue

see #2480

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes a bug that prevents non-macOS systems from executing this project's test suite.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've rerun the steps outlined in [CONTRIBUTING.md](https://github.com/borgbase/vorta/blob/master/.github/CONTRIBUTING.md#development), and saw all tests pass (or skip) as expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
