### PR TITLE
Ask user whether to init a new repo if adding existing repo fails

### DIFF
--- a/src/vorta/views/dialogs/repo/repo_add.py
+++ b/src/vorta/views/dialogs/repo/repo_add.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QLabel,
+    QMessageBox,
     QSizePolicy,
 )
 
@@ -88,12 +89,26 @@ class RepoWindow(AddRepoBase, AddRepoUI):
         self.errorText.repaint()
 
     def run_result(self, result):
-        self.saveButton.setEnabled(True)
-        if result['returncode'] == 0:
-            self.added_repo.emit(result)
-            self.accept()
-        else:
-            self._set_status(self.tr('Unable to add your repository.'))
+            self.saveButton.setEnabled(True)
+            if result['returncode'] == 0:
+                self.added_repo.emit(result)
+                self.accept()
+            else:
+                # New Logic for Issue #1799
+                msg = QMessageBox(self)
+                msg.setIcon(QMessageBox.Icon.Question)
+                msg.setWindowTitle(self.tr("Repository Not Found"))
+                msg.setText(self.tr("Vorta couldn't find an existing repository at this location."))
+                msg.setInformativeText(self.tr("Would you like to initialize a new repository here instead?"))
+                msg.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+                msg.setDefaultButton(QMessageBox.StandardButton.Yes)
+
+                if msg.exec() == QMessageBox.StandardButton.Yes:
+                    self.reject()
+                    if hasattr(self.parent(), 'new_repo'):
+                        self.parent().new_repo()
+                else:
+                    self._set_status(self.tr('Unable to add your repository.'))
 
     def init_ssh_key(self):
         keys = get_private_keys()


### PR DESCRIPTION
### Description
When a user attempts to add an existing repository but the connection fails (e.g., the folder is not a valid Borg repository), the application now intercepts the error and prompts the user via a QMessageBox. This prompt offers the option to initialize a new repository at that location immediately, improving the onboarding flow for new users.

### Related Issue
Closes #1799
https://github.com/borgbase/vorta/issues/1799

### Motivation and Context
Currently, if a user points Vorta to a non-initialized folder, they simply receive an error message. This change reduces friction by suggesting the logical next step

### How Has This Been Tested?
Environment: WSL2 (Ubuntu 22.04) running Vorta in a Python 3.12 virtual environment.
Test Case 1: Attempted to add an empty directory. Verified that the "Repository Not Found" dialog appeared.
Test Case 2: Clicked "Yes" on the dialog. Verified that it successfully triggered the new_repo workflow.
Test Case 3: Clicked "No" on the dialog. Verified that the standard error status message was displayed.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
