### PR TITLE
fix: correct parameter name typo in react_to_log (mgs -> msg)

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -230,7 +230,7 @@ class VortaApp(QtSingleApplication):
             msg.setStandardButtons(QMessageBox.StandardButton.Ok)
             msg.exec()
 
-    def react_to_log(self, mgs, context):
+    def react_to_log(self, msg, context):
         """
         Trigger Vorta actions based on Borg logs. E.g. repo lock.
         """


### PR DESCRIPTION
## Summary
Fixes #2430

This PR fixes a typo in the `react_to_log` method where the parameter was named `mgs` instead of `msg`.

## Changes
- Changed parameter name from `mgs` to `msg` in `react_to_log()` method in `src/vorta/application.py`

## Details
The parameter name `mgs` was a typo - it should be `msg` (short for "message"). While this parameter isn't used in the function body (the message comes from `context.get('msgid')`), fixing the typo improves code readability and follows Python naming conventions.

## Testing
- ✅ Linting passes: `ruff check src/vorta/application.py`
- ✅ No functional changes - parameter was previously unused

## Checklist
- [x] Bug fix with no breaking changes
- [x] Code follows project conventions
- [x] Commit message is clear and descriptive