### PR TITLE
feat: add lint-staged make target for faster development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export VORTA_SRC := src/vorta
 export APPSTREAM_METADATA := src/vorta/assets/metadata/com.borgbase.Vorta.appdata.xml
 VERSION := $(shell uv run python -c "from src.vorta._version import __version__; print(__version__)")
 
-.PHONY: help clean lint test test-unit test-integration \
+.PHONY: help clean lint lint-staged test test-unit test-integration \
         bump-version pypi-release release-preflight changelog update-appcast \
         translations-from-source translations-to-qm \
         flatpak-install
@@ -83,6 +83,9 @@ flatpak-install: translations-to-qm
 
 lint:
 	uv run pre-commit run --all-files --show-diff-on-failure
+
+lint-staged:  ## Run linting on staged files only
+	uv run pre-commit run --show-diff-on-failure
 
 test:
 	uv run nox -- --cov=vorta


### PR DESCRIPTION
## Summary
Fixes #2382

Adds a new `make lint-staged` target to run pre-commit only on staged files, making it faster for developers to lint their changes during active development.

## Changes
- Added `lint-staged` to `.PHONY` targets
- Added `lint-staged` target that runs `uv run pre-commit run --show-diff-on-failure`
- The new target is included in `make help` output

## How to Use
```bash
# Stage your changes
git add src/vorta/my_file.py

# Run linting on staged files only (faster)
make lint-staged

# Or run on all files (comprehensive)
make lint
```

## Testing
- ✅ `make lint-staged` runs successfully
- ✅ `make help` shows the new target
- ✅ No existing functionality affected

## Checklist
- [x] Code follows project conventions
- [x] Commit message is clear and descriptive
- [x] Feature tested locally