### PR TITLE
Open Settings/About in modal dialog instead of toggling main tabs

### DIFF
--- a/src/vorta/views/dialogs/settings_dialog.py
+++ b/src/vorta/views/dialogs/settings_dialog.py
@@ -1,0 +1,38 @@
+from PyQt6 import QtCore
+from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QTabWidget, QVBoxLayout
+
+
+class SettingsDialog(QDialog):
+    def __init__(self, parent=None, misc_tab=None, about_tab=None):
+        super().__init__(parent)
+
+        self.setWindowTitle(self.tr("Settings"))
+        self.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        self.setWindowFlag(QtCore.Qt.WindowType.WindowContextHelpButtonHint, False)
+        self.resize(820, 620)
+
+        layout = QVBoxLayout(self)
+
+        self.tabs = QTabWidget(self)
+        layout.addWidget(self.tabs)
+
+        if misc_tab is not None:
+            misc_tab.setParent(self.tabs)
+            self.tabs.addTab(misc_tab, self.tr("Settings"))
+
+        if about_tab is not None:
+            about_tab.setParent(self.tabs)
+            self.tabs.addTab(about_tab, self.tr("About"))
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def open_settings(self):
+        self.setWindowTitle(self.tr("Settings"))
+        self.tabs.setCurrentIndex(0)
+
+    def open_about(self):
+        self.setWindowTitle(self.tr("About"))
+        self.tabs.setCurrentIndex(1)

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -6,6 +6,7 @@ from PyQt6 import QtCore, uic
 from PyQt6.QtCore import QPoint, Qt
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtGui import QFontMetrics, QKeySequence, QShortcut
+from vorta.views.dialogs.settings_dialog import SettingsDialog
 from PyQt6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -81,6 +82,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.scheduleTab = ScheduleTab(self.scheduleTabSlot, profile_provider=self.get_current_profile)
         self.miscTab = MiscTab(self.SettingsTabSlot, profile_provider=self.get_current_profile)
         self.aboutTab = AboutTab(self.AboutTabSlot, profile_provider=self.get_current_profile)
+        self.settingsDialog = SettingsDialog(parent=self, misc_tab=self.miscTab, about_tab=self.aboutTab)
         self.aboutTab.set_borg_details(borg_compat.version, borg_compat.path)
         self.miscWidget.hide()
         self.tabWidget.setCurrentIndex(0)
@@ -210,8 +212,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.app.profile_changed_event.emit()
 
     def profile_clicked_action(self):
-        if self.miscWidget.isVisible():
-            self.toggle_misc_visibility()
+        pass
 
     def profile_rename_action(self):
         backup_profile_id = self.profileSelector.currentItem().data(Qt.ItemDataRole.UserRole)
@@ -319,16 +320,14 @@ class MainWindow(MainWindowBase, MainWindowUI):
         self.profileSelector.setCurrentItem(profile)
 
     def toggle_misc_visibility(self):
-        if self.miscWidget.isVisible():
-            self.miscWidget.hide()
-            self.tabWidget.setCurrentIndex(0)
-            self.miscButton.setStyleSheet("font-weight: normal;")
-            self.tabWidget.show()
-        else:
-            self.tabWidget.hide()
-            self.miscWidget.setCurrentIndex(0)
-            self.miscButton.setStyleSheet("font-weight: bold;")
-            self.miscWidget.show()
+        # Open Settings/About as a dialog instead of toggling the main tab bar away.
+        if self.settingsDialog.isVisible():
+            self.settingsDialog.raise_()
+            self.settingsDialog.activateWindow()
+            return
+
+        self.settingsDialog.open_settings()
+        self.settingsDialog.open()
 
     def backup_started_event(self):
         self._toggle_buttons(create_enabled=False)


### PR DESCRIPTION
### Description
Reworked the bottom-left **Settings / About** button behavior to open Settings/About in a **modal dialog** instead of toggling the main tab bar out of view. The dialog reuses the existing `MiscTab` and `AboutTab` widgets and supports closing via the Close button / Esc. If the dialog is already open, clicking the button focuses/raises it.

### Related Issue
Fixes https://github.com/borgbase/vorta/issues/2492

### Motivation and Context
The previous “Settings / About” toggle pattern hid the primary navigation tabs (Repository, Sources, Schedule, Archives) and required users to discover an unintuitive way to return. Opening Settings/About in a modal dialog keeps the main UI context visible and matches common desktop UX conventions, making it clearer how to close and return.

### How Has This Been Tested?
Manual testing on Windows:
- Launched app with `python -m vorta`
- Clicked **Settings / About** to open the dialog
- Verified main tab bar remains visible and unchanged in the background
- Verified Close button and Esc close the dialog and return to the prior main view/state
- Verified clicking **Settings / About** again while the dialog is open raises/focuses it

### Screenshots (if appropriate):
N/A

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.