### PR TITLE
Clarify repository menu labels for init vs existing repos

### DIFF
--- a/src/vorta/views/repo_tab.py
+++ b/src/vorta/views/repo_tab.py
@@ -38,8 +38,8 @@ class RepoTab(BaseTab, RepoBase, RepoUI):
         # init repo add button
         self.menuAddRepo = QMenu(self.bAddRepo)
 
-        self.menuAddRepo.addAction(self.tr("New Repository…"), self.new_repo)
-        self.menuAddRepo.addAction(self.tr("Existing Repository…"), self.add_existing_repo)
+        self.menuAddRepo.addAction(self.tr("Initialize Empty Repository…"), self.new_repo)
+        self.menuAddRepo.addAction(self.tr("Use Existing Repository…"), self.add_existing_repo)
 
         self.bAddRepo.setMenu(self.menuAddRepo)
 


### PR DESCRIPTION
This PR updates the “Add Repository” menu labels to make the difference between initializing a new Borg repository and adding an existing one clearer.

The current labels are:

- “New Repository…”
- “Existing Repository…”

I changed them to more explicit Borg-style wording so users can better distinguish between:

- initializing a new/empty repository
- adding or using a repository that already exists

### Motivation and Context

I ran into this problem myself. I had an existing Borg repository on my server and wanted to add it to Vorta. I interpreted “New Repository…” as meaning “new to Vorta,” not “initialize a new Borg repository.”

Because of that misunderstanding, I chose the wrong action and initialized a repository where I actually wanted to add an existing one. This destroyed the existing repository state I expected to keep.


### Status of this PR

* **⚠️ I do not fully understand Vorta’s translation system yet. I would appreciate help from a maintainer or contributor to make sure this change is completed correctly for all translations.**