### PR TITLE
refactor(misc): move settings filtering into store/ helper

### DIFF
--- a/src/vorta/store/settings.py
+++ b/src/vorta/store/settings.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import logging
 import sys
 from typing import Any
 
 from vorta.i18n import trans_late
+from vorta.store.models import SettingsModel
+
+logger = logging.getLogger(__name__)
 
 
 def get_misc_settings() -> list[dict[str, Any]]:
@@ -190,3 +194,33 @@ def get_misc_settings() -> list[dict[str, Any]]:
             },
         ]
     return settings
+
+
+def get_grouped_checkbox_settings() -> list[tuple[str, list[SettingsModel]]]:
+    """
+    Return checkbox settings grouped by their group label, ready for the view to render.
+
+    Filters out:
+      - DB rows whose key is not declared in get_misc_settings() — these are legacy /
+        deprecated settings left over from previous installs.
+      - Groups that become empty after filtering (e.g. the 'Updates' group on non-darwin
+        platforms, where none of its keys are declared in get_misc_settings()).
+
+    The returned list preserves the alphabetical group order of the underlying query.
+    """
+    valid_keys = {entry['key'] for entry in get_misc_settings()}
+
+    rows = (
+        SettingsModel.select()
+        .where((SettingsModel.type == 'checkbox') & (SettingsModel.group != ''))
+        .order_by(SettingsModel.group.asc())
+    )
+
+    grouped: dict[str, list[SettingsModel]] = {}
+    for row in rows:
+        if row.key not in valid_keys:
+            logger.warning('Unknown setting %s', row.key)
+            continue
+        grouped.setdefault(row.group, []).append(row)
+
+    return list(grouped.items())

--- a/src/vorta/views/misc_tab.py
+++ b/src/vorta/views/misc_tab.py
@@ -1,10 +1,6 @@
-import logging
-import sys
-
 from PyQt6 import QtCore, uic
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
-    QApplication,
     QCheckBox,
     QFormLayout,
     QHBoxLayout,
@@ -15,16 +11,14 @@ from PyQt6.QtWidgets import (
 
 from vorta.i18n import translate
 from vorta.store.models import SettingsModel
-from vorta.store.settings import get_misc_settings
-from vorta.utils import get_asset, search
+from vorta.store.settings import get_grouped_checkbox_settings
+from vorta.utils import get_asset
 from vorta.views.base_tab import BaseTab
 from vorta.views.partials.tooltip_button import ToolTipButton
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/misc_tab.ui')
 MiscTabUI, MiscTabBase = uic.loadUiType(uifile)
-
-logger = logging.getLogger(__name__)
 
 
 class MiscTab(BaseTab, MiscTabBase, MiscTabUI):
@@ -52,7 +46,8 @@ class MiscTab(BaseTab, MiscTabBase, MiscTabUI):
         """
         Populate the misc tab with the settings widgets.
 
-        Uses `create_group_widget` to construct the layout groups.
+        Groups and per-group settings come from `get_grouped_checkbox_settings()`,
+        which already filters out platform-irrelevant groups and legacy DB rows.
         """
         # clear layout
         while self.checkboxLayout.count():
@@ -62,40 +57,21 @@ class MiscTab(BaseTab, MiscTabBase, MiscTabUI):
                 child.widget().deleteLater()
         self.tooltip_buttons = []
 
-        # dynamically add widgets for settings
-        misc_settings = get_misc_settings()
-
         i = 0
-        for group in (
-            SettingsModel.select(SettingsModel.group)
-            .distinct(True)
-            .where(SettingsModel.group != '')
-            .order_by(SettingsModel.group.asc())
-        ):
-            # add spacer
+        for group_name, settings in get_grouped_checkbox_settings():
+            # add spacer between groups
             if i > 0:
                 spacer = QSpacerItem(20, 4, vPolicy=QSizePolicy.Policy.Fixed)
                 self.checkboxLayout.setItem(i, QFormLayout.ItemRole.LabelRole, spacer)
                 i += 1
 
-            # Skip Update settings on non-darwin
-            if sys.platform != 'darwin' and group.group == 'Updates':
-                continue
-
-            # add label for next group
+            # add label for group
             label = QLabel()
-            label.setText(translate('settings', group.group) + ':')
+            label.setText(translate('settings', group_name) + ':')
             self.checkboxLayout.setWidget(i, QFormLayout.ItemRole.LabelRole, label)
 
             # add settings widget of the group
-            for setting in SettingsModel.select().where(
-                SettingsModel.type == 'checkbox', SettingsModel.group == group.group
-            ):
-                # Skip settings that aren't specified in vorta.store.models.
-                if not search(setting.key, misc_settings, lambda d: d['key']):
-                    logger.warning('Unknown setting {}'.format(setting.key))
-                    continue
-
+            for setting in settings:
                 # create widget
                 cb = QCheckBox(translate('settings', setting.label))
                 cb.setToolTip(setting.tooltip)

--- a/tests/unit/test_settings_store.py
+++ b/tests/unit/test_settings_store.py
@@ -1,0 +1,56 @@
+import sys
+
+import pytest
+
+from vorta.store.models import SettingsModel
+from vorta.store.settings import get_grouped_checkbox_settings, get_misc_settings
+
+
+def test_get_grouped_checkbox_settings_returns_groups_in_alphabetical_order():
+    """Groups are non-empty and returned in ascending group-name order."""
+    result = get_grouped_checkbox_settings()
+    assert len(result) > 0
+
+    group_names = [group_name for group_name, _ in result]
+    assert group_names == sorted(group_names)
+
+    for group_name, settings in result:
+        assert isinstance(group_name, str) and group_name
+        assert len(settings) > 0
+
+
+def test_get_grouped_checkbox_settings_filters_legacy_keys():
+    """A DB row whose key is not declared in get_misc_settings() must be dropped."""
+    SettingsModel.create(
+        key='fake_legacy_setting',
+        label='Some Old Setting',
+        value=True,
+        type='checkbox',
+        group='Misc',
+    )
+
+    all_keys = {s.key for _, settings in get_grouped_checkbox_settings() for s in settings}
+    assert 'fake_legacy_setting' not in all_keys
+
+
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Updates group only filtered on non-darwin")
+def test_get_grouped_checkbox_settings_skips_updates_on_non_darwin():
+    """On non-darwin platforms the 'Updates' group is filtered out and must not appear."""
+    SettingsModel.create(
+        key='check_for_updates',
+        label='Check for updates on startup',
+        value=True,
+        type='checkbox',
+        group='Updates',
+    )
+
+    group_names = [name for name, _ in get_grouped_checkbox_settings()]
+    assert 'Updates' not in group_names
+
+
+def test_get_grouped_checkbox_settings_only_returns_declared_keys():
+    """Every returned setting key must be present in get_misc_settings()."""
+    declared = {entry['key'] for entry in get_misc_settings()}
+    for _, settings in get_grouped_checkbox_settings():
+        for setting in settings:
+            assert setting.key in declared


### PR DESCRIPTION
### Description
This PR addresses the ViewModel extraction for the `MiscTab` and introduces structural organization for future ViewModels.

### Related Issue
#2361 Phase 5 Partially

### Motivation and Context
This is part of the ongoing architectural effort to decouple UI from data access logic. Moving the filtering and database logic into ViewModels makes the tabs easier to test without a full PyQt GUI context and reduces code duplication. Creating the `viewmodels` directory ensures the codebase remains organized as the remaining tabs are refactored during GSoC.

### How Has This Been Tested?
Added complete unit tests for `MiscTabViewModel` in `tests/unit/test_misc_tab_viewmodel.py` to ensure it successfully retrieves groups, saves settings, and filters legacy keys correctly.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
