### PR TITLE
add ArchiveTableModel (QAbstractTableModel) spike

### DIFF
--- a/src/vorta/views/partials/archive_table_model.py
+++ b/src/vorta/views/partials/archive_table_model.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
-from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
 
 from vorta.i18n import trans_late, translate
 from vorta.store.models import ArchiveModel
-from vorta.utils import find_best_unit_for_sizes, pretty_bytes
+from vorta.utils import find_best_unit_for_sizes, pretty_bytes, uses_dark_mode
 from vorta.views.utils import get_colored_icon
 
 #: Decimal digits shown in the size column.
@@ -32,6 +32,8 @@ class ArchiveTableModel(QAbstractTableModel):
 
     #: Role returning native, comparable values for sorting via a proxy model.
     SortRole = Qt.ItemDataRole.UserRole
+    #: Role returning the backing ArchiveModel; auto-mapped through the sort proxy.
+    ArchiveRole = Qt.ItemDataRole.UserRole + 1
 
     _HEADERS = (
         trans_late('Form', 'Date'),
@@ -39,15 +41,19 @@ class ArchiveTableModel(QAbstractTableModel):
         trans_late('Form', 'Duration'),
         trans_late('Form', 'Mount Point'),
         trans_late('Form', 'Name'),
-        '',  # trigger icon column has no header label
+        trans_late('Form', 'Trigger'),
     )
 
-    def __init__(self, parent: Optional[Any] = None):
+    _TRIGGER_ICONS = {'scheduled': 'clock-o', 'user': 'user'}
+
+    def __init__(self, parent: Optional[QObject] = None):
         """Init."""
         super().__init__(parent)
         self._rows: List[ArchiveModel] = []
         self._mount_points: Dict[str, str] = {}
         self._fixed_unit: Optional[int] = None
+        self._icon_cache: Dict[str, Any] = {}  # themed icons; invalidated on dark-mode switch
+        self._icon_cache_dark: Optional[bool] = None
 
     def set_rows(
         self,
@@ -98,6 +104,8 @@ class ArchiveTableModel(QAbstractTableModel):
             return row.name  # pre-fill the rename editor with the current name
         if role == self.SortRole:
             return self._sort_data(row, column)
+        if role == self.ArchiveRole:
+            return row  # proxy-safe accessor: the proxy forwards data() through mapToSource
         if role == Qt.ItemDataRole.DecorationRole and column == self.COL_TRIGGER:
             return self._trigger_icon(row)
         if role == Qt.ItemDataRole.ToolTipRole and column == self.COL_TRIGGER:
@@ -136,11 +144,16 @@ class ArchiveTableModel(QAbstractTableModel):
         return None
 
     def _trigger_icon(self, row: ArchiveModel) -> Any:
-        if row.trigger == 'scheduled':
-            return get_colored_icon('clock-o')
-        if row.trigger == 'user':
-            return get_colored_icon('user')
-        return None
+        icon_name = self._TRIGGER_ICONS.get(row.trigger)
+        if icon_name is None:
+            return None
+        dark = uses_dark_mode()
+        if dark != self._icon_cache_dark:  # theme switched: themed icons are stale
+            self._icon_cache.clear()
+            self._icon_cache_dark = dark
+        if icon_name not in self._icon_cache:
+            self._icon_cache[icon_name] = get_colored_icon(icon_name)
+        return self._icon_cache[icon_name]
 
     def _trigger_tooltip(self, row: ArchiveModel) -> Any:
         if row.trigger == 'scheduled':

--- a/src/vorta/views/partials/archive_table_model.py
+++ b/src/vorta/views/partials/archive_table_model.py
@@ -1,0 +1,176 @@
+"""
+Qt table model exposing `ArchiveModel` rows to the ArchiveTab `QTableView`.
+
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Dict, List, Optional
+
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt
+
+from vorta.i18n import trans_late, translate
+from vorta.store.models import ArchiveModel
+from vorta.utils import find_best_unit_for_sizes, pretty_bytes
+from vorta.views.utils import get_colored_icon
+
+#: Decimal digits shown in the size column.
+SIZE_DECIMAL_DIGITS = 1
+
+
+class ArchiveTableModel(QAbstractTableModel):
+    """Table model for backup archive rows; the name column is editable for in-place rename."""
+
+    # Column indices in render order (matching the legacy QTableWidget layout).
+    COL_TIME = 0
+    COL_SIZE = 1
+    COL_DURATION = 2
+    COL_MOUNT = 3
+    COL_NAME = 4
+    COL_TRIGGER = 5
+
+    #: Role returning native, comparable values for sorting via a proxy model.
+    SortRole = Qt.ItemDataRole.UserRole
+
+    _HEADERS = (
+        trans_late('Form', 'Date'),
+        trans_late('Form', 'Size'),
+        trans_late('Form', 'Duration'),
+        trans_late('Form', 'Mount Point'),
+        trans_late('Form', 'Name'),
+        '',  # trigger icon column has no header label
+    )
+
+    def __init__(self, parent: Optional[Any] = None):
+        """Init."""
+        super().__init__(parent)
+        self._rows: List[ArchiveModel] = []
+        self._mount_points: Dict[str, str] = {}
+        self._fixed_unit: Optional[int] = None
+
+    def set_rows(
+        self,
+        rows: List[ArchiveModel],
+        mount_points: Optional[Dict[str, str]] = None,
+        use_fixed_units: bool = False,
+    ) -> None:
+        """Replace the model contents and notify attached views.
+
+        ``mount_points`` maps archive name to its current mount path; ``use_fixed_units``
+        (injected by the view) pins all rows to one shared size unit.
+        """
+        self.beginResetModel()
+        self._rows = list(rows)
+        self._mount_points = dict(mount_points or {})
+        if use_fixed_units:
+            self._fixed_unit = find_best_unit_for_sizes((r.size for r in self._rows), precision=SIZE_DECIMAL_DIGITS)
+        else:
+            self._fixed_unit = None
+        self.endResetModel()
+
+    def archive_at(self, row: int) -> Optional[ArchiveModel]:
+        """Return the `ArchiveModel` backing ``row``, or None if out of range."""
+        if 0 <= row < len(self._rows):
+            return self._rows[row]
+        return None
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return len(self._rows)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return len(self._HEADERS)
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
+        if not index.isValid():
+            return None
+
+        row = self._rows[index.row()]
+        column = index.column()
+
+        if role == Qt.ItemDataRole.DisplayRole:
+            return self._display_data(row, column)
+        if role == Qt.ItemDataRole.EditRole and column == self.COL_NAME:
+            return row.name  # pre-fill the rename editor with the current name
+        if role == self.SortRole:
+            return self._sort_data(row, column)
+        if role == Qt.ItemDataRole.DecorationRole and column == self.COL_TRIGGER:
+            return self._trigger_icon(row)
+        if role == Qt.ItemDataRole.ToolTipRole and column == self.COL_TRIGGER:
+            return self._trigger_tooltip(row)
+        return None
+
+    def _display_data(self, row: ArchiveModel, column: int) -> Any:
+        if column == self.COL_TIME:
+            return row.time.strftime('%Y-%m-%d %H:%M')
+        if column == self.COL_SIZE:
+            return pretty_bytes(row.size, fixed_unit=self._fixed_unit, precision=SIZE_DECIMAL_DIGITS)
+        if column == self.COL_DURATION:
+            if row.duration is None:
+                return ''
+            return str(timedelta(seconds=round(row.duration)))
+        if column == self.COL_MOUNT:
+            return self._mount_points.get(row.name, '')
+        if column == self.COL_NAME:
+            return row.name
+        return None  # trigger column is icon-only
+
+    def _sort_data(self, row: ArchiveModel, column: int) -> Any:
+        """Native comparable value used by the sort proxy."""
+        if column == self.COL_TIME:
+            return row.time
+        if column == self.COL_SIZE:
+            return row.size or 0
+        if column == self.COL_DURATION:
+            return row.duration or 0
+        if column == self.COL_MOUNT:
+            return self._mount_points.get(row.name, '')
+        if column == self.COL_NAME:
+            return row.name
+        if column == self.COL_TRIGGER:
+            return row.trigger or ''
+        return None
+
+    def _trigger_icon(self, row: ArchiveModel) -> Any:
+        if row.trigger == 'scheduled':
+            return get_colored_icon('clock-o')
+        if row.trigger == 'user':
+            return get_colored_icon('user')
+        return None
+
+    def _trigger_tooltip(self, row: ArchiveModel) -> Any:
+        if row.trigger == 'scheduled':
+            return translate('ArchiveTab', 'Scheduled')
+        if row.trigger == 'user':
+            return translate('ArchiveTab', 'User initiated')
+        return None
+
+    def flags(self, index: QModelIndex) -> Qt.ItemFlag:
+        flags = super().flags(index)
+        if index.isValid() and index.column() == self.COL_NAME:
+            flags |= Qt.ItemFlag.ItemIsEditable
+        return flags
+
+    def setData(self, index: QModelIndex, value: Any, role: int = Qt.ItemDataRole.EditRole) -> bool:
+        """Store an in-place edited archive name; the view performs the real rename."""
+        if not index.isValid() or role != Qt.ItemDataRole.EditRole or index.column() != self.COL_NAME:
+            return False
+        self._rows[index.row()].name = value
+        self.dataChanged.emit(index, index, [Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole])
+        return True
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == Qt.Orientation.Horizontal and 0 <= section < len(self._HEADERS):
+            return translate('Form', self._HEADERS[section])
+        return None

--- a/tests/unit/test_archive_table_model.py
+++ b/tests/unit/test_archive_table_model.py
@@ -136,6 +136,16 @@ def test_set_data_rejects_non_name_column_or_wrong_role():
     assert model.setData(model.index(0, ArchiveTableModel.COL_NAME), 'y', Qt.ItemDataRole.DisplayRole) is False
 
 
+def test_archive_role_returns_backing_object():
+    """ArchiveRole exposes the ArchiveModel so callers read it through the (auto-mapping) proxy."""
+    model = ArchiveTableModel()
+    only = _archive('only', dt(2024, 1, 1))
+    model.set_rows([only])
+
+    for column in range(model.columnCount()):
+        assert model.data(model.index(0, column), ArchiveTableModel.ArchiveRole) is only
+
+
 def test_archive_at_returns_object_or_none():
     """archive_at returns the backing ArchiveModel and None when out of range."""
     model = ArchiveTableModel()
@@ -172,7 +182,7 @@ def test_trigger_icon_and_tooltip():
 
 
 def test_header_data_returns_column_labels():
-    """Horizontal headers expose the canonical labels; the icon column is blank."""
+    """Horizontal headers expose the canonical labels, matching the legacy .ui."""
     model = ArchiveTableModel()
     assert (
         model.headerData(ArchiveTableModel.COL_TIME, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) == 'Date'
@@ -180,7 +190,10 @@ def test_header_data_returns_column_labels():
     assert (
         model.headerData(ArchiveTableModel.COL_NAME, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) == 'Name'
     )
-    assert model.headerData(ArchiveTableModel.COL_TRIGGER, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) == ''
+    assert (
+        model.headerData(ArchiveTableModel.COL_TRIGGER, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
+        == 'Trigger'
+    )
     assert model.headerData(0, Qt.Orientation.Vertical, Qt.ItemDataRole.DisplayRole) is None
 
 

--- a/tests/unit/test_archive_table_model.py
+++ b/tests/unit/test_archive_table_model.py
@@ -1,0 +1,193 @@
+from datetime import datetime as dt
+
+from PyQt6.QtCore import QModelIndex, Qt
+
+from vorta.store.models import ArchiveModel
+from vorta.views.partials.archive_table_model import ArchiveTableModel
+
+
+def _archive(name, time, size=1000, duration=60, trigger='user'):
+    """Build an in-memory ArchiveModel (not persisted) for feeding the model."""
+    return ArchiveModel(name=name, time=time, size=size, duration=duration, trigger=trigger, snapshot_id='x')
+
+
+def test_model_is_empty_before_set_rows():
+    """Column count is intrinsic; row count starts at zero."""
+    model = ArchiveTableModel()
+    assert model.rowCount() == 0
+    assert model.columnCount() == 6
+
+
+def test_set_rows_populates_and_preserves_order():
+    """`set_rows` replaces the contents and keeps the given row order."""
+    model = ArchiveTableModel()
+    model.set_rows(
+        [
+            _archive('a', dt(2024, 1, 3)),
+            _archive('b', dt(2024, 1, 1)),
+            _archive('c', dt(2024, 1, 2)),
+        ]
+    )
+
+    assert model.rowCount() == 3
+    names = [model.data(model.index(r, ArchiveTableModel.COL_NAME)) for r in range(3)]
+    assert names == ['a', 'b', 'c']
+
+
+def test_display_data_formats_each_column():
+    """`data()` formats time/size/duration and exposes name; trigger is icon-only."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('my-archive', dt(2024, 1, 15, 10, 30), size=1500, duration=90, trigger='user')])
+
+    def cell(column):
+        return model.data(model.index(0, column), Qt.ItemDataRole.DisplayRole)
+
+    assert cell(ArchiveTableModel.COL_TIME) == '2024-01-15 10:30'
+    assert cell(ArchiveTableModel.COL_SIZE) == '1.5 KB'
+    assert cell(ArchiveTableModel.COL_DURATION) == '0:01:30'
+    assert cell(ArchiveTableModel.COL_MOUNT) == ''
+    assert cell(ArchiveTableModel.COL_NAME) == 'my-archive'
+    assert cell(ArchiveTableModel.COL_TRIGGER) is None
+
+
+def test_mount_point_is_shown_when_present():
+    """The mount column reflects the mount_points map passed to set_rows."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('m', dt(2024, 1, 1))], mount_points={'m': '/mnt/x'})
+    assert model.data(model.index(0, ArchiveTableModel.COL_MOUNT)) == '/mnt/x'
+
+
+def test_duration_none_renders_empty():
+    """A null duration renders as an empty string."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('d', dt(2024, 1, 1), duration=None)])
+    assert model.data(model.index(0, ArchiveTableModel.COL_DURATION)) == ''
+
+
+def test_fixed_units_share_one_unit_across_rows():
+    """With use_fixed_units, every row uses the same unit; dynamic sizes each independently."""
+    model = ArchiveTableModel()
+    rows = [_archive('small', dt(2024, 1, 1), size=2000), _archive('big', dt(2024, 1, 2), size=5_000_000_000)]
+
+    model.set_rows(rows, use_fixed_units=True)
+    fixed = [model.data(model.index(r, ArchiveTableModel.COL_SIZE)) for r in range(2)]
+    assert fixed == ['2.0 KB', '5000000.0 KB']  # both rows pinned to the same shared unit
+
+    model.set_rows(rows, use_fixed_units=False)
+    assert model.data(model.index(1, ArchiveTableModel.COL_SIZE)) == '5.0 GB'  # dynamic: own best unit
+
+
+def test_sort_role_returns_native_comparable_values():
+    """SortRole yields raw values so columns sort numerically/chronologically, not by text."""
+    model = ArchiveTableModel()
+    t = dt(2024, 1, 15, 10, 30)
+    model.set_rows([_archive('z-name', t, size=2048, duration=12.5, trigger='scheduled')])
+
+    def sort_value(column):
+        return model.data(model.index(0, column), ArchiveTableModel.SortRole)
+
+    assert sort_value(ArchiveTableModel.COL_TIME) == t
+    assert sort_value(ArchiveTableModel.COL_SIZE) == 2048
+    assert sort_value(ArchiveTableModel.COL_DURATION) == 12.5
+    assert sort_value(ArchiveTableModel.COL_NAME) == 'z-name'
+    assert sort_value(ArchiveTableModel.COL_TRIGGER) == 'scheduled'
+
+
+def test_sort_role_orders_sizes_numerically():
+    """Raw size sort keys order correctly where display strings would not."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('big', dt(2024, 1, 1), size=2048), _archive('small', dt(2024, 1, 2), size=999)])
+
+    keys = [model.data(model.index(r, ArchiveTableModel.COL_SIZE), ArchiveTableModel.SortRole) for r in range(2)]
+    assert keys == [2048, 999]
+    assert keys[1] < keys[0]  # 999 < 2048, even though '999 B' > '2.0 kB' as text
+
+
+def test_only_name_column_is_editable():
+    """The name column is editable; the others are not."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('n', dt(2024, 1, 1))])
+
+    name_flags = model.flags(model.index(0, ArchiveTableModel.COL_NAME))
+    time_flags = model.flags(model.index(0, ArchiveTableModel.COL_TIME))
+    assert name_flags & Qt.ItemFlag.ItemIsEditable
+    assert not (time_flags & Qt.ItemFlag.ItemIsEditable)
+
+
+def test_set_data_updates_name_and_emits_datachanged():
+    """Editing the name updates the backing row and notifies views."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('old', dt(2024, 1, 1))])
+
+    received = []
+    model.dataChanged.connect(lambda tl, br, roles=[]: received.append((tl.row(), tl.column())))
+
+    assert model.setData(model.index(0, ArchiveTableModel.COL_NAME), 'new') is True
+    assert model.archive_at(0).name == 'new'
+    assert received == [(0, ArchiveTableModel.COL_NAME)]
+
+
+def test_set_data_rejects_non_name_column_or_wrong_role():
+    """setData only accepts EditRole writes to the name column."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('x', dt(2024, 1, 1))])
+
+    assert model.setData(model.index(0, ArchiveTableModel.COL_TIME), 'y') is False
+    assert model.setData(model.index(0, ArchiveTableModel.COL_NAME), 'y', Qt.ItemDataRole.DisplayRole) is False
+
+
+def test_archive_at_returns_object_or_none():
+    """archive_at returns the backing ArchiveModel and None when out of range."""
+    model = ArchiveTableModel()
+    only = _archive('only', dt(2024, 1, 1))
+    model.set_rows([only])
+
+    assert model.archive_at(0) is only
+    assert model.archive_at(5) is None
+    assert model.archive_at(-1) is None
+
+
+def test_trigger_icon_and_tooltip():
+    """The trigger column exposes an icon and tooltip per trigger kind."""
+    model = ArchiveTableModel()
+    model.set_rows(
+        [
+            _archive('s', dt(2024, 1, 1), trigger='scheduled'),
+            _archive('u', dt(2024, 1, 2), trigger='user'),
+            _archive('n', dt(2024, 1, 3), trigger=None),
+        ]
+    )
+
+    def deco(row):
+        return model.data(model.index(row, ArchiveTableModel.COL_TRIGGER), Qt.ItemDataRole.DecorationRole)
+
+    def tooltip(row):
+        return model.data(model.index(row, ArchiveTableModel.COL_TRIGGER), Qt.ItemDataRole.ToolTipRole)
+
+    assert deco(0) is not None and deco(1) is not None
+    assert deco(2) is None
+    assert tooltip(0) == 'Scheduled'
+    assert tooltip(1) == 'User initiated'
+    assert tooltip(2) is None
+
+
+def test_header_data_returns_column_labels():
+    """Horizontal headers expose the canonical labels; the icon column is blank."""
+    model = ArchiveTableModel()
+    assert (
+        model.headerData(ArchiveTableModel.COL_TIME, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) == 'Date'
+    )
+    assert (
+        model.headerData(ArchiveTableModel.COL_NAME, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) == 'Name'
+    )
+    assert model.headerData(ArchiveTableModel.COL_TRIGGER, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole) == ''
+    assert model.headerData(0, Qt.Orientation.Vertical, Qt.ItemDataRole.DisplayRole) is None
+
+
+def test_data_returns_none_for_invalid_index_or_unsupported_role():
+    """Invalid indices and unhandled roles yield None."""
+    model = ArchiveTableModel()
+    model.set_rows([_archive('x', dt(2024, 1, 1))])
+
+    assert model.data(QModelIndex()) is None
+    assert model.data(model.index(0, ArchiveTableModel.COL_TIME), Qt.ItemDataRole.EditRole) is None


### PR DESCRIPTION
  A **small spike** of the Archive table as a `QAbstractTableModel`, opened as a **draft** to confirm the shape before going deep on the view rewiring (as offered in the Phase 5 #2361 thread).

  Adds, and **nothing else** (the live Archive tab is untouched):
  - `src/vorta/views/partials/archive_table_model.py` ,`ArchiveTableModel`, mirroring the existing `EventLogTableModel`. Owns the per-row presentation currently inline in `ArchiveTab.populate_from_profile`: time/size/duration formatting, trigger icon + tooltip, raw **sort-role** keys, an editable **name** column, plus `set_rows(...)` and `archive_at(row)`.
  - `tests/unit/test_archive_table_model.py`  15 isolated unit tests (content + ordering, sort role, fixed/dynamic units, editable flag, setData/dataChanged, icons/tooltips,headers).

  Deliberately deferred to the wiring PR:
  - Swap `QTableWidget` → `QTableView` and call `model.set_rows(...)` from `populate_from_profile`.
  - **Sorting:** an `ArchiveSortProxyModel(QSortFilterProxyModel)` overriding `lessThan()` (matching `treemodel.py`), reading the model's `SortRole`.
  - Re-routing the ~10 `archiveTable.item(row, col)` reads to `model.archive_at(row)`.
  - Migrating in-place rename + selection/double-click/delete handling.

  Conventions: no DB reads in the model (the `enable_fixed_units` setting is injected by the view via `set_rows(..., use_fixed_units=...)`); translation contexts reuse existing catalog entries (`Form` headers, `ArchiveTab` tooltips).

  ### Related Issue
  
  Phase 5 of the views refactor (#2361)  the redirect to `QAbstractTableModel` + `views/partials/`.

  ### Motivation and Context

  Per the Phase 5 redirect, tabular views (Archive, Log) should become `QAbstractTableModel` + `QTableView` rather than ViewModels. **_This spike extracts the Archive table's presentation logic into a self-contained, idiomatic model so the shape can be reviewed before the larger `archive_tab.py` migration_**.

  ### How Has This Been Tested?
  
  `uv run nox -r -- tests/unit/test_archive_table_model.py` . The model is exercised directly in isolation (no widget). No behavior change to the live app, since the model isn't wired in yet.
  
  ### Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
  ### Checklist:

  - [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  
  *I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*
  
  [dco]: https://developercertificate.org/
