### PR TITLE
ci: stable required-checks gate for branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,3 +148,22 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS, python
           version: v0.7.3  # workaround on Intel macs (GH Actions)
+
+  # Stable-named aggregate gate for branch protection. Matrix jobs above embed
+  # the Borg version in their auto-generated check names (e.g.
+  # "test-unit (3.12, ubuntu-24.04, 1.4.4)"), so requiring them directly breaks
+  # protection on every version bump. Require this job instead.
+  required-checks:
+    name: required-checks
+    if: always()
+    needs:
+      - lint
+      - test-unit
+      - test-integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
## Problem

Branch protection on `master` requires status checks by exact name. The `test-unit` / `test-integration` matrix jobs auto-generate names that embed the Borg version, e.g. `test-unit (3.12, ubuntu-24.04, 1.4.4)`. There is no way to give a matrix job a fully static per-entry name.

So protection currently still pins stale contexts (`...1.4.2`, `...1.4.3`) while the matrix runs `1.4.4`. Those checks never report under the old names and sit pending forever — PRs like #2517 can't satisfy protection without an admin override. Every Borg bump silently re-breaks the gate.

## Fix

Add a single aggregate gate job, `required-checks`, with a fixed name that `needs` lint + test-unit + test-integration. Branch protection can then require only the stable contexts (`lint`, `required-checks`), fully decoupling protection from the matrix. Future Borg bumps need no protection changes.

Inline bash decides pass/fail (no third-party action). `if: always()` ensures the gate reports even when a matrix job fails.

## Follow-up (admin, after this merges)

Once `required-checks` has reported once on `master`, update protection contexts to `["lint", "required-checks"]`.