### PR TITLE
Wire ArchiveTableModel into ArchiveTab (QTableView migration, Phase 4 pt 1)

### DIFF
--- a/src/vorta/assets/UI/archive_tab.ui
+++ b/src/vorta/assets/UI/archive_tab.ui
@@ -129,7 +129,7 @@
           </layout>
          </item>
          <item row="0" column="0">
-          <widget class="QTableWidget" name="archiveTable">
+          <widget class="QTableView" name="archiveTable">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>1</horstretch>
@@ -145,36 +145,6 @@
            <attribute name="verticalHeaderVisible">
             <bool>false</bool>
            </attribute>
-           <column>
-            <property name="text">
-             <string>Date</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Size</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Duration</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Mount Point</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Name</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Trigger</string>
-            </property>
-           </column>
           </widget>
          </item>
          <item row="0" column="1">

--- a/src/vorta/borg/rename.py
+++ b/src/vorta/borg/rename.py
@@ -9,6 +9,10 @@ class BorgRenameJob(BorgJob):
         self.app.backup_started_event.emit()
         self.app.backup_progress_event.emit(f"[{self.params['profile_name']}] {self.tr('Renaming archive…')}")
 
+    def finished_event(self, result):
+        self.app.backup_finished_event.emit(result)
+        self.result.emit(result)
+
     def log_event(self, msg):
         self.app.backup_log_event.emit(msg)
 

--- a/src/vorta/views/archive/archive_extract.py
+++ b/src/vorta/views/archive/archive_extract.py
@@ -18,24 +18,22 @@ class ArchiveExtract:
         """
         profile = self.tab.profile()
 
-        row_selected = self.tab.archiveTable.selectionModel().selectedRows()
-        if row_selected:
-            archive_cell = self.tab.archiveTable.item(row_selected[0].row(), 4)
-            if archive_cell:
-                archive_name = archive_cell.text()
-                params = BorgListArchiveJob.prepare(profile, archive_name)
+        archives = self.tab.selected_archives()
+        if archives:
+            archive_name = archives[0].name
+            params = BorgListArchiveJob.prepare(profile, archive_name)
 
-                if not params['ok']:
-                    self.tab._set_status(params['message'])
-                    return
-                self.tab._set_status('')
-                self.tab._toggle_all_buttons(False)
+            if not params['ok']:
+                self.tab._set_status(params['message'])
+                return
+            self.tab._set_status('')
+            self.tab._toggle_all_buttons(False)
 
-                job = BorgListArchiveJob(params['cmd'], params, self.tab.profile().repo.id)
-                job.updated.connect(self.tab.mountErrors.setText)
-                job.result.connect(self.extract_list_result)
-                self.tab.app.jobs_manager.add_job(job)
-                return job
+            job = BorgListArchiveJob(params['cmd'], params, self.tab.profile().repo.id)
+            job.updated.connect(self.tab.mountErrors.setText)
+            job.result.connect(self.extract_list_result)
+            self.tab.app.jobs_manager.add_job(job)
+            return job
         else:
             self.tab._set_status(self.tab.tr('Select an archive to restore first.'))
 

--- a/src/vorta/views/archive/archive_mount.py
+++ b/src/vorta/views/archive/archive_mount.py
@@ -1,7 +1,5 @@
 import logging
 
-from PyQt6.QtWidgets import QTableWidgetItem
-
 from vorta.borg.mount import BorgMountJob
 from vorta.borg.umount import BorgUmountJob
 from vorta.i18n import translate
@@ -122,10 +120,8 @@ class ArchiveMount:
                 archive_name = result['params']['mounted_archive']
                 self.tab.mount_points[archive_name] = mount_point
 
-                # update column in table
-                row = self.tab.row_of_archive(archive_name)
-                item = QTableWidgetItem(result['cmd'][-1])
-                self.tab.archiveTable.setItem(row, 3, item)
+                # update the Mount Point column in the table
+                self.tab.update_mount_points()
 
                 # update button
                 self.bmountarchive_refresh()
@@ -175,9 +171,7 @@ class ArchiveMount:
             if archive_name:
                 # unmount single archive
                 del self.tab.mount_points[archive_name]
-                row = self.tab.row_of_archive(archive_name)
-                item = QTableWidgetItem('')
-                self.tab.archiveTable.setItem(row, 3, item)
+                self.tab.update_mount_points()
 
                 # update button
                 self.bmountarchive_refresh()

--- a/src/vorta/views/archive/archive_mount.py
+++ b/src/vorta/views/archive/archive_mount.py
@@ -120,7 +120,6 @@ class ArchiveMount:
                 archive_name = result['params']['mounted_archive']
                 self.tab.mount_points[archive_name] = mount_point
 
-                # update the Mount Point column in the table
                 self.tab.update_mount_points()
 
                 # update button

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -84,9 +84,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         self.tooltip_dict[self.bRefreshArchive] = self.bRefreshArchive.toolTip()
         self.tooltip_dict[self.compactButton] = self.compactButton.toolTip()
 
-        # Model + sort proxy. The proxy sorts on ArchiveTableModel.SortRole, which
-        # returns native comparable values (raw bytes/seconds/datetime), so non-string
-        # columns order correctly instead of lexically.
+        # Model + sort proxy (proxy sorts on SortRole for correct non-string ordering)
         self.archive_model = ArchiveTableModel(self)
         self.archive_proxy = QSortFilterProxyModel(self)
         self.archive_proxy.setSourceModel(self.archive_model)
@@ -127,7 +125,6 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         self.archiveTable.setSortingEnabled(True)
         self.archiveTable.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.archiveTable.customContextMenuRequested.connect(self.archiveitem_contextmenu)
-        # A committed in-place name edit lands in the model via setData; react to it to run the rename job.
         self.archive_model.dataChanged.connect(self.on_name_edited)
 
         # shortcuts
@@ -278,7 +275,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         # Restore states
         self.on_selection_change()
 
-    def populate_from_profile(self):
+    def populate_from_profile(self, preserve_view=False):
         """Populate archive list and prune settings from profile."""
         profile = self.profile()
         if profile.repo is not None:
@@ -295,17 +292,21 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
 
             archives = [s for s in profile.repo.archives.select().order_by(ArchiveModel.time.desc())]
 
-            # The fixed/dynamic unit choice is a user setting; read it here and inject it so
-            # the model stays DB-free.
+            # inject the user's fixed/dynamic unit setting so the model stays DB-free
             use_fixed_units = bool(SettingsModel.get(key='enable_fixed_units').value)
+
+            scroll_pos = self.archiveTable.verticalScrollBar().value() if preserve_view else 0
+
             self.archive_model.set_rows(archives, mount_points=self.mount_points, use_fixed_units=use_fixed_units)
 
-            # Show the Mount Point column only while at least one archive is mounted
-            # (same predicate as update_mount_points).
+            # show the Mount Point column only while at least one archive is mounted
             self.archiveTable.setColumnHidden(ArchiveTableModel.COL_MOUNT, not self.mount_points)
 
-            self.archiveTable.scrollToTop()
             self.archiveTable.selectionModel().clearSelection()
+            if preserve_view:
+                self.archiveTable.verticalScrollBar().setValue(scroll_pos)
+            else:
+                self.archiveTable.scrollToTop()
             if self.remaining_refresh_archives == 0:
                 self._toggle_all_buttons(enabled=True)
         else:
@@ -417,13 +418,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             self.bMountArchive.setToolTip(tooltip + " " + reason)
 
     def selected_archives(self):
-        """
-        Return the `ArchiveModel` objects backing the current selection.
-
-        This is the single place selection is resolved to archives. It reads the
-        model's `ArchiveRole`, which `QSortFilterProxyModel.data()` forwards through
-        `mapToSource`, so it returns the correct archive even after the user sorts.
-        """
+        """Return the `ArchiveModel` objects backing the current selection (sort-proxy safe)."""
         return [
             archive
             for index in self.archiveTable.selectionModel().selectedRows()
@@ -572,21 +567,12 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         profile.save()
 
     def cell_double_clicked(self, index=None):
-        """
-        Open a mounted archive's folder, or start an in-place rename.
-
-        Connected to the view's ``doubleClicked`` (passes a `QModelIndex`); also
-        invoked by the Rename button / context menu (passes the clicked bool / nothing),
-        in which case the current row's Name cell is targeted.
-        """
-        if not self.bRename.isEnabled():
-            return
-
+        """Open a mounted archive's folder, or start an in-place rename."""
         if isinstance(index, QtCore.QModelIndex) and index.isValid():
             column = index.column()
         else:
             index = self.archiveTable.currentIndex()
-            column = ArchiveTableModel.COL_NAME  # button/menu rename acts on the Name cell
+            column = ArchiveTableModel.COL_NAME
 
         if not index.isValid():
             return
@@ -599,6 +585,8 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             return
 
         if column == ArchiveTableModel.COL_NAME:
+            if not self.bRename.isEnabled():
+                return
             archive = index.data(ArchiveTableModel.ArchiveRole)
             if archive is None:
                 return
@@ -607,12 +595,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             self.archiveTable.edit(index.siblingAtColumn(ArchiveTableModel.COL_NAME))
 
     def on_name_edited(self, top_left, bottom_right, roles=None):
-        """
-        Handle a committed in-place name edit (model `dataChanged` from the Name column).
-
-        `set_rows` resets the model (no `dataChanged`), so repopulation never reaches here;
-        the `is_editing` guard covers the revert path, which re-emits `dataChanged`.
-        """
+        """Handle a committed in-place name edit (model `dataChanged` from the Name column)."""
         if not self.is_editing or top_left.column() != ArchiveTableModel.COL_NAME:
             return
         self.is_editing = False
@@ -622,17 +605,14 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         new_name = archive.name if archive else ''
         profile = self.profile()
 
-        # unchanged -> nothing to do
         if new_name == original:
             return
 
-        # blank -> revert
         if not new_name:
             self._revert_name(top_left, original)
             self._set_status(self.tr('Archive name cannot be blank.'))
             return
 
-        # duplicate -> revert (single read query; kept inline per the "no thin wrapper" rule)
         if ArchiveModel.get_or_none(name=new_name, repo=profile.repo) is not None:
             self._set_status(self.tr('An archive with this name already exists.'))
             self._revert_name(top_left, original)
@@ -652,7 +632,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         self.app.jobs_manager.add_job(job)
 
     def _revert_name(self, index, original):
-        """Restore the model's name after a rejected edit; the is_editing guard stops re-entry."""
+        """Restore the model's name after a rejected edit."""
         self.archive_model.setData(index, original, Qt.ItemDataRole.EditRole)
 
     def confirm_dialog(self, title, text):
@@ -702,12 +682,12 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
                 status = self.tr('Archive deleted.')
             self._set_status(status)
 
-            # remove archives from the database, then refresh the table from the profile
+            repo = self.profile().repo
             for archive in archives:
-                archive_obj = ArchiveModel.get_or_none(name=archive)
+                archive_obj = ArchiveModel.get_or_none(name=archive, repo=repo)
                 if archive_obj:
                     archive_obj.delete_instance()
-            self.populate_from_profile()
+            self.populate_from_profile(preserve_view=True)
 
         self._toggle_all_buttons(True)
 
@@ -788,11 +768,9 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             self.renamed_archive_original_name = None
             self.populate_from_profile()
         else:
-            # Rename failed: the new name was applied to the model optimistically when the editor
-            # committed. Refresh from the DB (which still holds the original) so the table doesn't
-            # keep showing a name the repo never got. Borg's error stays in the status bar.
+            # rename failed: refresh from the DB to drop the optimistically-applied name
             self.renamed_archive_original_name = None
-            self.populate_from_profile()
+            self.populate_from_profile(preserve_view=True)
 
     def toggle_compact_button_visibility(self):
         """

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -3,7 +3,7 @@ import sys
 from typing import Dict, Optional
 
 from PyQt6 import QtCore, uic
-from PyQt6.QtCore import QItemSelectionModel, QMimeData, QPoint, QSortFilterProxyModel, Qt, pyqtSlot
+from PyQt6.QtCore import QItemSelectionModel, QMimeData, QPoint, Qt, pyqtSlot
 from PyQt6.QtGui import QDesktopServices, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
@@ -39,7 +39,7 @@ from vorta.views.archive.archive_mount import ArchiveMount
 from vorta.views.base_tab import BaseTab
 from vorta.views.dialogs.archive import diff_result
 from vorta.views.dialogs.archive.diff_result import DiffResultDialog, DiffTree
-from vorta.views.partials.archive_table_model import SIZE_DECIMAL_DIGITS, ArchiveTableModel
+from vorta.views.partials.archive_table_model import SIZE_DECIMAL_DIGITS, ArchiveSortProxyModel, ArchiveTableModel
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/archive_tab.ui')
@@ -86,9 +86,8 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
 
         # Model + sort proxy (proxy sorts on SortRole for correct non-string ordering)
         self.archive_model = ArchiveTableModel(self)
-        self.archive_proxy = QSortFilterProxyModel(self)
+        self.archive_proxy = ArchiveSortProxyModel(self)
         self.archive_proxy.setSourceModel(self.archive_model)
-        self.archive_proxy.setSortRole(ArchiveTableModel.SortRole)
         self.archiveTable.setModel(self.archive_proxy)
 
         header = self.archiveTable.horizontalHeader()

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -1,10 +1,9 @@
 import logging
 import sys
-from datetime import timedelta
 from typing import Dict, Optional
 
 from PyQt6 import QtCore, uic
-from PyQt6.QtCore import QItemSelectionModel, QMimeData, QPoint, Qt, pyqtSlot
+from PyQt6.QtCore import QItemSelectionModel, QMimeData, QPoint, QSortFilterProxyModel, Qt, pyqtSlot
 from PyQt6.QtGui import QDesktopServices, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
@@ -15,7 +14,6 @@ from PyQt6.QtWidgets import (
     QMessageBox,
     QStyledItemDelegate,
     QTableView,
-    QTableWidgetItem,
     QWidget,
 )
 
@@ -32,28 +30,22 @@ from vorta.i18n.richtext import escape, format_richtext, link
 from vorta.store.models import ArchiveModel, SettingsModel
 from vorta.utils import (
     borg_compat,
-    find_best_unit_for_sizes,
     format_archive_name,
     get_asset,
     get_mount_points,
-    pretty_bytes,
 )
 from vorta.views.archive.archive_extract import ArchiveExtract
 from vorta.views.archive.archive_mount import ArchiveMount
 from vorta.views.base_tab import BaseTab
 from vorta.views.dialogs.archive import diff_result
 from vorta.views.dialogs.archive.diff_result import DiffResultDialog, DiffTree
-from vorta.views.source_tab import SizeItem
+from vorta.views.partials.archive_table_model import SIZE_DECIMAL_DIGITS, ArchiveTableModel
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/archive_tab.ui')
 ArchiveTabUI, ArchiveTabBase = uic.loadUiType(uifile)
 
 logger = logging.getLogger(__name__)
-
-
-#: The number of decimal digits to show in the size column
-SIZE_DECIMAL_DIGITS = 1
 
 
 # from https://stackoverflow.com/questions/63177587/pyqt-tableview-align-icons-to-center
@@ -92,17 +84,26 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         self.tooltip_dict[self.bRefreshArchive] = self.bRefreshArchive.toolTip()
         self.tooltip_dict[self.compactButton] = self.compactButton.toolTip()
 
+        # Model + sort proxy. The proxy sorts on ArchiveTableModel.SortRole, which
+        # returns native comparable values (raw bytes/seconds/datetime), so non-string
+        # columns order correctly instead of lexically.
+        self.archive_model = ArchiveTableModel(self)
+        self.archive_proxy = QSortFilterProxyModel(self)
+        self.archive_proxy.setSourceModel(self.archive_model)
+        self.archive_proxy.setSortRole(ArchiveTableModel.SortRole)
+        self.archiveTable.setModel(self.archive_proxy)
+
         header = self.archiveTable.horizontalHeader()
         header.setVisible(True)
-        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Interactive)
-        header.setSectionResizeMode(4, QHeaderView.ResizeMode.Stretch)
-        header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(ArchiveTableModel.COL_TIME, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(ArchiveTableModel.COL_SIZE, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(ArchiveTableModel.COL_DURATION, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(ArchiveTableModel.COL_MOUNT, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(ArchiveTableModel.COL_NAME, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(ArchiveTableModel.COL_TRIGGER, QHeaderView.ResizeMode.ResizeToContents)
 
         delegate = IconDelegate(self.archiveTable)
-        self.archiveTable.setItemDelegateForColumn(5, delegate)
+        self.archiveTable.setItemDelegateForColumn(ArchiveTableModel.COL_TRIGGER, delegate)
 
         self.mount_help_text = trans_late('Form', 'To mount archives, first install "FUSE for macOS" from %1.')
         self.mount_help_link_text = trans_late('Form', 'here')
@@ -122,12 +123,12 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         self.archiveTable.setWordWrap(False)
         self.archiveTable.setTextElideMode(QtCore.Qt.TextElideMode.ElideLeft)
         self.archiveTable.setAlternatingRowColors(True)
-        self.archiveTable.cellDoubleClicked.connect(self.cell_double_clicked)
+        self.archiveTable.doubleClicked.connect(self.cell_double_clicked)
         self.archiveTable.setSortingEnabled(True)
         self.archiveTable.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.archiveTable.customContextMenuRequested.connect(self.archiveitem_contextmenu)
-        edit_delegate = self.archiveTable.itemDelegate()
-        edit_delegate.closeEditor.connect(self.on_editing_finished)
+        # A committed in-place name edit lands in the model via setData; react to it to run the rename job.
+        self.archive_model.dataChanged.connect(self.on_name_edited)
 
         # shortcuts
         shortcut_copy = QShortcut(QKeySequence.StandardKey.Copy, self.archiveTable)
@@ -294,61 +295,22 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
 
             archives = [s for s in profile.repo.archives.select().order_by(ArchiveModel.time.desc())]
 
-            # if no archive's name can be found in self.mount_points, then hide the mount point column
-            if not any(a.name in self.mount_points for a in archives):
-                self.archiveTable.hideColumn(3)
-            else:
-                self.archiveTable.showColumn(3)
+            # The fixed/dynamic unit choice is a user setting; read it here and inject it so
+            # the model stays DB-free.
+            use_fixed_units = bool(SettingsModel.get(key='enable_fixed_units').value)
+            self.archive_model.set_rows(archives, mount_points=self.mount_points, use_fixed_units=use_fixed_units)
 
-            sorting = self.archiveTable.isSortingEnabled()
-            self.archiveTable.setSortingEnabled(False)
-            best_unit = find_best_unit_for_sizes((a.size for a in archives), precision=SIZE_DECIMAL_DIGITS)
-            for row, archive in enumerate(archives):
-                self.archiveTable.insertRow(row)
+            # Show the Mount Point column only while at least one archive is mounted
+            # (same predicate as update_mount_points).
+            self.archiveTable.setColumnHidden(ArchiveTableModel.COL_MOUNT, not self.mount_points)
 
-                formatted_time = archive.time.strftime('%Y-%m-%d %H:%M')
-                self.archiveTable.setItem(row, 0, QTableWidgetItem(formatted_time))
-
-                # format units based on user settings for 'dynamic' or 'fixed' units
-                fixed_unit = best_unit if SettingsModel.get(key='enable_fixed_units').value else None
-                size = pretty_bytes(archive.size, fixed_unit=fixed_unit, precision=SIZE_DECIMAL_DIGITS)
-                self.archiveTable.setItem(row, 1, SizeItem(size))
-
-                if archive.duration is not None:
-                    formatted_duration = str(timedelta(seconds=round(archive.duration)))
-                else:
-                    formatted_duration = ''
-
-                self.archiveTable.setItem(row, 2, QTableWidgetItem(formatted_duration))
-
-                mount_point = self.mount_points.get(archive.name)
-                if mount_point is not None:
-                    item = QTableWidgetItem(mount_point)
-                    self.archiveTable.setItem(row, 3, item)
-
-                self.archiveTable.setItem(row, 4, QTableWidgetItem(archive.name))
-
-                if archive.trigger == 'scheduled':
-                    item = QTableWidgetItem(get_colored_icon('clock-o'), '')
-                    item.setToolTip(self.tr('Scheduled'))
-                    self.archiveTable.setItem(row, 5, item)
-                elif archive.trigger == 'user':
-                    item = QTableWidgetItem(get_colored_icon('user'), '')
-                    item.setToolTip(self.tr('User initiated'))
-                    item.setTextAlignment(Qt.AlignmentFlag.AlignRight)
-                    self.archiveTable.setItem(row, 5, item)
-
-            self.archiveTable.setRowCount(len(archives))
-            self.archiveTable.setSortingEnabled(sorting)
-            item = self.archiveTable.item(0, 0)
-            self.archiveTable.scrollToItem(item)
-
+            self.archiveTable.scrollToTop()
             self.archiveTable.selectionModel().clearSelection()
             if self.remaining_refresh_archives == 0:
                 self._toggle_all_buttons(enabled=True)
         else:
             self.mount_points = {}
-            self.archiveTable.setRowCount(0)
+            self.archive_model.set_rows([])
             self.toolBox.setItemText(0, self.tr('Archives'))
             self._toggle_all_buttons(enabled=False)
 
@@ -369,6 +331,11 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
                     widget.blockSignals(False)
         finally:
             self.prune_keep_within.blockSignals(False)
+
+    def update_mount_points(self):
+        """Push the current mount paths into the model and toggle the Mount Point column."""
+        self.archive_model.set_mount_points(self.mount_points)
+        self.archiveTable.setColumnHidden(ArchiveTableModel.COL_MOUNT, not self.mount_points)
 
     def on_selection_change(self, selected=None, deselected=None):
         """
@@ -449,6 +416,20 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             tooltip = self.bMountArchive.toolTip()
             self.bMountArchive.setToolTip(tooltip + " " + reason)
 
+    def selected_archives(self):
+        """
+        Return the `ArchiveModel` objects backing the current selection.
+
+        This is the single place selection is resolved to archives. It reads the
+        model's `ArchiveRole`, which `QSortFilterProxyModel.data()` forwards through
+        `mapToSource`, so it returns the correct archive even after the user sorts.
+        """
+        return [
+            archive
+            for index in self.archiveTable.selectionModel().selectedRows()
+            if (archive := index.data(ArchiveTableModel.ArchiveRole)) is not None
+        ]
+
     def archive_copy(self, index=None):
         """
         Copy an archive name to the clipboard.
@@ -463,10 +444,12 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
 
             index = indexes[0]
 
-        archive_name = self.archiveTable.item(index.row(), 4).text()
+        archive = index.data(ArchiveTableModel.ArchiveRole)
+        if archive is None:
+            return
 
         data = QMimeData()
-        data.setText(archive_name)
+        data.setText(archive.name)
 
         QApplication.clipboard().setMimeData(data)
 
@@ -491,12 +474,9 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             return
 
         # Conditions are met (borg binary available, etc)
-        row_selected = self.archiveTable.selectionModel().selectedRows()
-        if row_selected:
-            archive_cell = self.archiveTable.item(row_selected[0].row(), 4)
-            if archive_cell:
-                archive_name = archive_cell.text()
-                params['cmd'][-1] += f'::{archive_name}'
+        archives = self.selected_archives()
+        if archives:
+            params['cmd'][-1] += f'::{archives[0].name}'
 
         job = BorgCheckJob(params['cmd'], params, self.profile().repo.id)
         job.updated.connect(self._set_status)
@@ -558,25 +538,20 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             self.populate_from_profile()
 
     def refresh_archive_info(self):
-        selected_archives = self.archiveTable.selectionModel().selectedRows()
-
-        archive_names = []
-        for index in selected_archives:
-            archive_names.append(self.archiveTable.item(index.row(), 4).text())
+        archive_names = [archive.name for archive in self.selected_archives()]
 
         self.remaining_refresh_archives = len(archive_names)  # number of archives to refresh
         self._toggle_all_buttons(False)
         for archive_name in archive_names:
-            if archive_name is not None:
-                params = BorgInfoArchiveJob.prepare(self.profile(), archive_name)
-                if params['ok']:
-                    job = BorgInfoArchiveJob(params['cmd'], params, self.profile().repo.id)
-                    job.updated.connect(self._set_status)
-                    job.result.connect(self.info_result)
-                    self.app.jobs_manager.add_job(job)
-                else:
-                    self._set_status(params['message'])
-                    return
+            params = BorgInfoArchiveJob.prepare(self.profile(), archive_name)
+            if params['ok']:
+                job = BorgInfoArchiveJob(params['cmd'], params, self.profile().repo.id)
+                job.updated.connect(self._set_status)
+                job.result.connect(self.info_result)
+                self.app.jobs_manager.add_job(job)
+            else:
+                self._set_status(params['message'])
+                return
 
     def info_result(self, result):
         self.remaining_refresh_archives -= 1
@@ -586,12 +561,8 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             self.populate_from_profile()
 
     def selected_archive_name(self):
-        row_selected = self.archiveTable.selectionModel().selectedRows()
-        if row_selected:
-            archive_cell = self.archiveTable.item(row_selected[0].row(), 4)
-            if archive_cell:
-                return archive_cell.text()
-        return None
+        archives = self.selected_archives()
+        return archives[0].name if archives else None
 
     def save_prune_setting(self, new_value=None):
         profile = self.profile()
@@ -600,88 +571,89 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         profile.prune_keep_within = self.prune_keep_within.text()
         profile.save()
 
-    def cell_double_clicked(self, row=None, column=None):
+    def cell_double_clicked(self, index=None):
+        """
+        Open a mounted archive's folder, or start an in-place rename.
+
+        Connected to the view's ``doubleClicked`` (passes a `QModelIndex`); also
+        invoked by the Rename button / context menu (passes the clicked bool / nothing),
+        in which case the current row's Name cell is targeted.
+        """
         if not self.bRename.isEnabled():
             return
 
-        if not row or not column:
-            row = self.archiveTable.currentRow()
-            column = self.archiveTable.currentColumn()
+        if isinstance(index, QtCore.QModelIndex) and index.isValid():
+            column = index.column()
+        else:
+            index = self.archiveTable.currentIndex()
+            column = ArchiveTableModel.COL_NAME  # button/menu rename acts on the Name cell
 
-        if column == 3:
-            archive_name = self.selected_archive_name()
-            if not archive_name:
-                return
+        if not index.isValid():
+            return
 
-            mount_point = self.mount_points.get(archive_name)
-
+        if column == ArchiveTableModel.COL_MOUNT:
+            archive = index.data(ArchiveTableModel.ArchiveRole)
+            mount_point = self.mount_points.get(archive.name) if archive else None
             if mount_point is not None:
                 QDesktopServices.openUrl(QtCore.QUrl(f'file:///{mount_point}'))
+            return
 
-        if column == 4:
-            item = self.archiveTable.item(row, column)
-            self.renamed_archive_original_name = item.text()
+        if column == ArchiveTableModel.COL_NAME:
+            archive = index.data(ArchiveTableModel.ArchiveRole)
+            if archive is None:
+                return
+            self.renamed_archive_original_name = archive.name
             self.is_editing = True
-            item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsEditable)
-            self.archiveTable.editItem(item)
+            self.archiveTable.edit(index.siblingAtColumn(ArchiveTableModel.COL_NAME))
 
-    def on_editing_finished(self, editor, hint):
-        """Called when the user finishes editing a cell (By pressing Enter or clicking away)."""
-        if not self.is_editing:
+    def on_name_edited(self, top_left, bottom_right, roles=None):
+        """
+        Handle a committed in-place name edit (model `dataChanged` from the Name column).
+
+        `set_rows` resets the model (no `dataChanged`), so repopulation never reaches here;
+        the `is_editing` guard covers the revert path, which re-emits `dataChanged`.
+        """
+        if not self.is_editing or top_left.column() != ArchiveTableModel.COL_NAME:
             return
+        self.is_editing = False
 
-        row = self.archiveTable.currentRow()
-        column = self.archiveTable.currentColumn()
-
-        self.cell_changed(row, column)
-
-    def cell_changed(self, row, column):
-        # return if this is not a name change
-        if column != 4 or not self.is_editing:
-            return
-
-        item = self.archiveTable.item(row, column)
-        new_name = item.text()
+        archive = top_left.data(ArchiveTableModel.ArchiveRole)
+        original = self.renamed_archive_original_name
+        new_name = archive.name if archive else ''
         profile = self.profile()
 
-        # if the name hasn't changed or if this slot is called when first repopulating the table, do nothing.
-        if new_name == self.renamed_archive_original_name:
-            self.is_editing = False
+        # unchanged -> nothing to do
+        if new_name == original:
             return
 
-        # if new name is blank, revert to the original name
+        # blank -> revert
         if not new_name:
-            item.setText(self.renamed_archive_original_name)
+            self._revert_name(top_left, original)
             self._set_status(self.tr('Archive name cannot be blank.'))
-            self.is_editing = False
             return
 
-        # check if the new name already exists
-        new_name_exists = ArchiveModel.get_or_none(name=new_name, repo=profile.repo)
-        if new_name_exists is not None:
+        # duplicate -> revert (single read query; kept inline per the "no thin wrapper" rule)
+        if ArchiveModel.get_or_none(name=new_name, repo=profile.repo) is not None:
             self._set_status(self.tr('An archive with this name already exists.'))
-            item.setText(self.renamed_archive_original_name)
-            self.is_editing = False
+            self._revert_name(top_left, original)
             return
 
-        params = BorgRenameJob.prepare(profile, self.renamed_archive_original_name, new_name)
+        params = BorgRenameJob.prepare(profile, original, new_name)
         if not params['ok']:
             self._set_status(params['message'])
-            self.is_editing = False
+            self._revert_name(top_left, original)
             return
 
         self._set_status(self.tr('Renaming archive...'))
-        job = BorgRenameJob(params['cmd'], params, self.profile().repo.id)
+        job = BorgRenameJob(params['cmd'], params, profile.repo.id)
         job.updated.connect(self._set_status)
         job.result.connect(self.rename_result)
         self._toggle_all_buttons(False)
         self.app.jobs_manager.add_job(job)
-        self.is_editing = False
 
-    def row_of_archive(self, archive_name):
-        items = self.archiveTable.findItems(archive_name, QtCore.Qt.MatchFlag.MatchExactly)
-        rows = [item.row() for item in items if item.column() == 4]
-        return rows[0] if rows else None
+    def _revert_name(self, index, original):
+        """Restore the model's name after a rejected edit; the is_editing guard stops re-entry."""
+        self.archive_model.setData(index, original, Qt.ItemDataRole.EditRole)
 
     def confirm_dialog(self, title, text):
         msg = QMessageBox()
@@ -697,11 +669,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         # Since this function modify the UI, we can't put the whole function in a JobQueue.
 
         # determine selected archives
-        archives = []
-        for index in self.archiveTable.selectionModel().selectedRows():
-            archive_cell = self.archiveTable.item(index.row(), 4)
-            if archive_cell:
-                archives.append(archive_cell.text())
+        archives = [archive.name for archive in self.selected_archives()]
 
         if not archives:
             self._set_status(self.tr("No archive selected"))
@@ -734,13 +702,12 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
                 status = self.tr('Archive deleted.')
             self._set_status(status)
 
-            # remove rows from list and database
+            # remove archives from the database, then refresh the table from the profile
             for archive in archives:
-                for entry in self.archiveTable.findItems(archive, QtCore.Qt.MatchFlag.MatchExactly):
-                    self.archiveTable.removeRow(entry.row())
                 archive_obj = ArchiveModel.get_or_none(name=archive)
                 if archive_obj:
                     archive_obj.delete_instance()
+            self.populate_from_profile()
 
         self._toggle_all_buttons(True)
 
@@ -751,11 +718,11 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         Exactly two archives must be selected in `archiveTable`. This is
         usually enforced by `on_selection_change`.
         """
-        selected_archives = self.archiveTable.selectionModel().selectedRows()
+        archives = self.selected_archives()
         profile = self.profile()
 
-        name1 = self.archiveTable.item(selected_archives[0].row(), 4).text()
-        name2 = self.archiveTable.item(selected_archives[1].row(), 4).text()
+        name1 = archives[0].name
+        name2 = archives[1].name
 
         archive1, archive2 = (
             profile.repo.archives.select()
@@ -821,7 +788,11 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
             self.renamed_archive_original_name = None
             self.populate_from_profile()
         else:
-            self._toggle_all_buttons(True)
+            # Rename failed: the new name was applied to the model optimistically when the editor
+            # committed. Refresh from the DB (which still holds the original) so the table doesn't
+            # keep showing a name the repo never got. Borg's error stays in the status bar.
+            self.renamed_archive_original_name = None
+            self.populate_from_profile()
 
     def toggle_compact_button_visibility(self):
         """

--- a/src/vorta/views/partials/archive_table_model.py
+++ b/src/vorta/views/partials/archive_table_model.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
+from PyQt6.QtGui import QIcon
 
 from vorta.i18n import trans_late, translate
 from vorta.store.models import ArchiveModel
@@ -52,7 +53,7 @@ class ArchiveTableModel(QAbstractTableModel):
         self._rows: List[ArchiveModel] = []
         self._mount_points: Dict[str, str] = {}
         self._fixed_unit: Optional[int] = None
-        self._icon_cache: Dict[str, Any] = {}  # themed icons; invalidated on dark-mode switch
+        self._icon_cache: Dict[str, QIcon] = {}  # themed icons; invalidated on dark-mode switch
         self._icon_cache_dark: Optional[bool] = None
 
     def set_rows(
@@ -171,7 +172,11 @@ class ArchiveTableModel(QAbstractTableModel):
         return flags
 
     def setData(self, index: QModelIndex, value: Any, role: int = Qt.ItemDataRole.EditRole) -> bool:
-        """Store an in-place edited archive name; the view performs the real rename."""
+        """Store an in-place edited archive name; the view performs the real rename.
+
+        This overwrites ``row.name`` before the rename runs; the view relies on having
+        stashed ``renamed_archive_original_name`` at edit-start to recover the old name.
+        """
         if not index.isValid() or role != Qt.ItemDataRole.EditRole or index.column() != self.COL_NAME:
             return False
         self._rows[index.row()].name = value

--- a/src/vorta/views/partials/archive_table_model.py
+++ b/src/vorta/views/partials/archive_table_model.py
@@ -75,11 +75,13 @@ class ArchiveTableModel(QAbstractTableModel):
             self._fixed_unit = None
         self.endResetModel()
 
-    def archive_at(self, row: int) -> Optional[ArchiveModel]:
-        """Return the `ArchiveModel` backing ``row``, or None if out of range."""
-        if 0 <= row < len(self._rows):
-            return self._rows[row]
-        return None
+    def set_mount_points(self, mount_points: Optional[Dict[str, str]] = None) -> None:
+        """Update mount paths and refresh the Mount Point column in place (no full reset)."""
+        self._mount_points = dict(mount_points or {})
+        if self._rows:
+            top = self.index(0, self.COL_MOUNT)
+            bottom = self.index(len(self._rows) - 1, self.COL_MOUNT)
+            self.dataChanged.emit(top, bottom, [Qt.ItemDataRole.DisplayRole])
 
     def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
         if parent.isValid():

--- a/src/vorta/views/partials/archive_table_model.py
+++ b/src/vorta/views/partials/archive_table_model.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
-from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, QSortFilterProxyModel, Qt
 from PyQt6.QtGui import QIcon
 
 from vorta.i18n import trans_late, translate
@@ -194,3 +194,16 @@ class ArchiveTableModel(QAbstractTableModel):
         if orientation == Qt.Orientation.Horizontal and 0 <= section < len(self._HEADERS):
             return translate('Form', self._HEADERS[section])
         return None
+
+
+class ArchiveSortProxyModel(QSortFilterProxyModel):
+    """Sort proxy that compares `SortRole` keys in Python to avoid Qt's 32-bit int truncation."""
+
+    def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:
+        lv = left.data(ArchiveTableModel.SortRole)
+        rv = right.data(ArchiveTableModel.SortRole)
+        if lv is None:
+            return True
+        if rv is None:
+            return False
+        return lv < rv

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -260,7 +260,7 @@ def archive_env(qapp, qtbot):
     tab: ArchiveTab = main.archiveTab
     main.tabWidget.setCurrentIndex(3)
     tab.refresh_archive_list()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() > 0, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.archiveTable.model().rowCount() > 0, **pytest._wait_defaults)
     return main, tab
 
 

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -116,7 +116,7 @@ def test_archive_delete(qapp, qtbot, mocker, archive_env):
     """Test for archive deletion"""
     main, tab = archive_env
 
-    archivesCount = tab.archiveTable.rowCount()
+    archivesCount = tab.archiveTable.model().rowCount()
 
     mocker.patch.object(vorta.views.archive_tab.ArchiveTab, 'confirm_dialog', lambda x, y, z: True)
 
@@ -125,7 +125,7 @@ def test_archive_delete(qapp, qtbot, mocker, archive_env):
     qtbot.waitUntil(lambda: 'Archive deleted.' in main.progressText.text(), **pytest._wait_defaults)
 
     assert ArchiveModel.select().count() == archivesCount - 1
-    assert tab.archiveTable.rowCount() == archivesCount - 1
+    assert tab.archiveTable.model().rowCount() == archivesCount - 1
 
 
 def test_archive_rename(qapp, qtbot, mocker, archive_env):

--- a/tests/integration/test_repo.py
+++ b/tests/integration/test_repo.py
@@ -19,5 +19,5 @@ def test_create(qapp, qtbot, archive_env):
     assert EventLogModel.select().count() == 2
     assert ArchiveModel.select().count() == 7
     assert main.createStartBtn.isEnabled()
-    assert main.archiveTab.archiveTable.rowCount() == 7
+    assert main.archiveTab.archiveTable.model().rowCount() == 7
     assert main.scheduleTab.logPage.logPage.model().rowCount() == 2

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -218,5 +218,5 @@ def archive_env(qapp, qtbot):
     tab: ArchiveTab = main.archiveTab
     main.tabWidget.setCurrentIndex(3)
     tab.populate_from_profile()
-    qtbot.waitUntil(lambda: tab.archiveTable.rowCount() == 2, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.archiveTable.model().rowCount() == 2, **pytest._wait_defaults)
     return main, tab

--- a/tests/unit/test_archive_table_model.py
+++ b/tests/unit/test_archive_table_model.py
@@ -170,6 +170,30 @@ def test_trigger_icon_and_tooltip():
     assert tooltip(2) is None
 
 
+def test_trigger_icon_cache_hits_and_rebuilds_on_theme_switch(mocker):
+    """The themed icon is cached per name and the cache is rebuilt when dark mode flips (P2)."""
+    icons = mocker.patch(
+        'vorta.views.partials.archive_table_model.get_colored_icon',
+        side_effect=lambda name: object(),
+    )
+    dark = mocker.patch('vorta.views.partials.archive_table_model.uses_dark_mode', return_value=False)
+
+    model = ArchiveTableModel()
+    model.set_rows([_archive('s', dt(2024, 1, 1), trigger='scheduled')])
+
+    def deco():
+        return model.data(model.index(0, ArchiveTableModel.COL_TRIGGER), Qt.ItemDataRole.DecorationRole)
+
+    first = deco()
+    assert deco() is first
+    assert icons.call_count == 1
+
+    dark.return_value = True
+    second = deco()
+    assert second is not first
+    assert icons.call_count == 2
+
+
 def test_header_data_returns_column_labels():
     """Horizontal headers expose the canonical labels, matching the legacy .ui."""
     model = ArchiveTableModel()

--- a/tests/unit/test_archive_table_model.py
+++ b/tests/unit/test_archive_table_model.py
@@ -3,7 +3,7 @@ from datetime import datetime as dt
 from PyQt6.QtCore import QModelIndex, Qt
 
 from vorta.store.models import ArchiveModel
-from vorta.views.partials.archive_table_model import ArchiveTableModel
+from vorta.views.partials.archive_table_model import ArchiveSortProxyModel, ArchiveTableModel
 
 
 def _archive(name, time, size=1000, duration=60, trigger='user'):
@@ -95,12 +95,21 @@ def test_sort_role_returns_native_comparable_values():
 
 def test_sort_role_orders_sizes_numerically():
     """Raw size sort keys order correctly where display strings would not."""
+    gib = 1024**3
     model = ArchiveTableModel()
-    model.set_rows([_archive('big', dt(2024, 1, 1), size=2048), _archive('small', dt(2024, 1, 2), size=999)])
+    model.set_rows(
+        [
+            _archive('10G', dt(2024, 1, 1), size=10 * gib),
+            _archive('500M', dt(2024, 1, 2), size=500 * 1024**2),
+            _archive('2G', dt(2024, 1, 3), size=2 * gib),
+        ]
+    )
+    proxy = ArchiveSortProxyModel()
+    proxy.setSourceModel(model)
+    proxy.sort(ArchiveTableModel.COL_SIZE, Qt.SortOrder.AscendingOrder)
 
-    keys = [model.data(model.index(r, ArchiveTableModel.COL_SIZE), ArchiveTableModel.SortRole) for r in range(2)]
-    assert keys == [2048, 999]
-    assert keys[1] < keys[0]  # 999 < 2048, even though '999 B' > '2.0 kB' as text
+    order = [proxy.data(proxy.index(r, ArchiveTableModel.COL_NAME)) for r in range(proxy.rowCount())]
+    assert order == ['500M', '2G', '10G']
 
 
 def test_only_name_column_is_editable():

--- a/tests/unit/test_archive_table_model.py
+++ b/tests/unit/test_archive_table_model.py
@@ -123,7 +123,7 @@ def test_set_data_updates_name_and_emits_datachanged():
     model.dataChanged.connect(lambda tl, br, roles=[]: received.append((tl.row(), tl.column())))
 
     assert model.setData(model.index(0, ArchiveTableModel.COL_NAME), 'new') is True
-    assert model.archive_at(0).name == 'new'
+    assert model.data(model.index(0, ArchiveTableModel.COL_NAME), ArchiveTableModel.ArchiveRole).name == 'new'
     assert received == [(0, ArchiveTableModel.COL_NAME)]
 
 
@@ -144,17 +144,6 @@ def test_archive_role_returns_backing_object():
 
     for column in range(model.columnCount()):
         assert model.data(model.index(0, column), ArchiveTableModel.ArchiveRole) is only
-
-
-def test_archive_at_returns_object_or_none():
-    """archive_at returns the backing ArchiveModel and None when out of range."""
-    model = ArchiveTableModel()
-    only = _archive('only', dt(2024, 1, 1))
-    model.set_rows([only])
-
-    assert model.archive_at(0) is only
-    assert model.archive_at(5) is None
-    assert model.archive_at(-1) is None
 
 
 def test_trigger_icon_and_tooltip():

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -173,7 +173,7 @@ def test_archive_delete(qapp, qtbot, mocker, borg_json_output, archive_env):
     tab.delete_action()
     qtbot.waitUntil(lambda: 'Archive deleted.' in main.progressText.text(), **pytest._wait_defaults)
     assert ArchiveModel.select().count() == 1
-    assert tab.archiveTable.rowCount() == 1
+    assert tab.archiveTable.model().rowCount() == 1
 
 
 def test_archive_copy(qapp, qtbot, monkeypatch, mocker, archive_env):
@@ -196,6 +196,41 @@ def test_archive_copy(qapp, qtbot, monkeypatch, mocker, archive_env):
     assert clipboard_spy.call_count == 2
     actual_data = clipboard_spy.call_args[0][0]  # retrieves the QMimeData() object used in method call
     assert actual_data.text() == "test-archive1"
+
+
+def test_selection_maps_through_sort_proxy(qapp, qtbot, archive_env):
+    """R1: selected_archives() returns the archive shown at the selected row, even after sorting."""
+    main, tab = archive_env
+    view = tab.archiveTable
+    col_name = vorta.views.archive_tab.ArchiveTableModel.COL_NAME
+
+    # Sort by Name descending so the proxy's row order differs from the source order.
+    view.sortByColumn(col_name, QtCore.Qt.SortOrder.DescendingOrder)
+
+    view.selectRow(0)
+    displayed_name = view.model().index(0, col_name).data()
+    selected = tab.selected_archives()
+
+    assert len(selected) == 1
+    # If the helper used the proxy row as a source row, this would resolve to the wrong archive.
+    assert selected[0].name == displayed_name
+
+
+def test_rename_failure_reverts_optimistic_name(qapp, qtbot, archive_env):
+    """A failed rename must not leave the optimistically-applied name in the table (D1)."""
+    main, tab = archive_env
+    model = tab.archive_model
+    col = vorta.views.archive_tab.ArchiveTableModel.COL_NAME
+
+    original = model.data(model.index(0, col))
+    # Simulate the editor having committed a new name optimistically.
+    model.setData(model.index(0, col), 'optimistic-name')
+    assert model.data(model.index(0, col)) == 'optimistic-name'
+
+    # Borg reports the rename failed -> the table must refresh back to the DB's original name.
+    tab.rename_result({'returncode': 2})
+
+    assert model.data(model.index(0, col)) == original
 
 
 def test_refresh_archive_info(qapp, qtbot, mocker, borg_json_output, archive_env):
@@ -223,9 +258,10 @@ def test_inline_archive_rename(qapp, qtbot, mocker, borg_json_output, archive_en
     popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
     mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
 
-    # Trigger inline editing programmatically (more reliable than double-click simulation)
-    item = tab.archiveTable.item(0, 4)
-    tab.archiveTable.editItem(item)
+    # Trigger inline editing through the real entry point so is_editing / original name are set.
+    index = tab.archiveTable.model().index(0, 4)
+    tab.archiveTable.setCurrentIndex(index)
+    tab.cell_double_clicked(index)
 
     # Wait for edit mode to activate
     qtbot.waitUntil(lambda: tab.archiveTable.viewport().focusWidget() is not None, **pytest._wait_defaults)

--- a/tests/unit/test_archives.py
+++ b/tests/unit/test_archives.py
@@ -10,6 +10,7 @@ import vorta.borg
 import vorta.utils
 import vorta.views.archive_tab
 from vorta.store.models import ArchiveModel, BackupProfileModel
+from vorta.views.partials.archive_table_model import ArchiveTableModel
 
 
 class MockFileDialog:
@@ -202,9 +203,9 @@ def test_selection_maps_through_sort_proxy(qapp, qtbot, archive_env):
     """R1: selected_archives() returns the archive shown at the selected row, even after sorting."""
     main, tab = archive_env
     view = tab.archiveTable
-    col_name = vorta.views.archive_tab.ArchiveTableModel.COL_NAME
+    col_name = ArchiveTableModel.COL_NAME
 
-    # Sort by Name descending so the proxy's row order differs from the source order.
+    # sort so the proxy's row order differs from the source order
     view.sortByColumn(col_name, QtCore.Qt.SortOrder.DescendingOrder)
 
     view.selectRow(0)
@@ -212,7 +213,6 @@ def test_selection_maps_through_sort_proxy(qapp, qtbot, archive_env):
     selected = tab.selected_archives()
 
     assert len(selected) == 1
-    # If the helper used the proxy row as a source row, this would resolve to the wrong archive.
     assert selected[0].name == displayed_name
 
 
@@ -220,14 +220,12 @@ def test_rename_failure_reverts_optimistic_name(qapp, qtbot, archive_env):
     """A failed rename must not leave the optimistically-applied name in the table (D1)."""
     main, tab = archive_env
     model = tab.archive_model
-    col = vorta.views.archive_tab.ArchiveTableModel.COL_NAME
+    col = ArchiveTableModel.COL_NAME
 
     original = model.data(model.index(0, col))
-    # Simulate the editor having committed a new name optimistically.
     model.setData(model.index(0, col), 'optimistic-name')
     assert model.data(model.index(0, col)) == 'optimistic-name'
 
-    # Borg reports the rename failed -> the table must refresh back to the DB's original name.
     tab.rename_result({'returncode': 2})
 
     assert model.data(model.index(0, col)) == original

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -82,12 +82,11 @@ def test_enable_fixed_units(qapp, qtbot, mocker):
     tab = qapp.main_window.archiveTab
     setting = "Use the same unit of measurement for archive sizes"
 
-    # set mocks. Size formatting now lives in the table model, so patch pretty_bytes there.
+    # set mocks (size formatting now lives in the table model)
     mock_setting = mocker.patch.object(vorta.views.archive_tab.SettingsModel, "get", return_value=Mock(value=True))
     mock_pretty_bytes = mocker.patch.object(vorta.views.partials.archive_table_model, "pretty_bytes")
 
     def render_size():
-        """Force the model to format the first size cell, which calls pretty_bytes."""
         index = tab.archiveTable.model().index(0, ArchiveTableModel.COL_SIZE)
         index.data(QtCore.Qt.ItemDataRole.DisplayRole)
 

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -9,7 +9,9 @@ from PyQt6.QtGui import QCloseEvent
 from PyQt6.QtWidgets import QCheckBox, QFormLayout, QMessageBox
 
 import vorta.store.models
+import vorta.views.partials.archive_table_model
 from vorta.store.models import SettingsModel
+from vorta.views.partials.archive_table_model import ArchiveTableModel
 
 
 def test_toggle_all_settings(qapp, qtbot):
@@ -80,14 +82,20 @@ def test_enable_fixed_units(qapp, qtbot, mocker):
     tab = qapp.main_window.archiveTab
     setting = "Use the same unit of measurement for archive sizes"
 
-    # set mocks
+    # set mocks. Size formatting now lives in the table model, so patch pretty_bytes there.
     mock_setting = mocker.patch.object(vorta.views.archive_tab.SettingsModel, "get", return_value=Mock(value=True))
-    mock_pretty_bytes = mocker.patch.object(vorta.views.archive_tab, "pretty_bytes")
+    mock_pretty_bytes = mocker.patch.object(vorta.views.partials.archive_table_model, "pretty_bytes")
 
-    # with setting enabled, fixed units should be determined and passed to pretty_bytes as an 'int'
+    def render_size():
+        """Force the model to format the first size cell, which calls pretty_bytes."""
+        index = tab.archiveTable.model().index(0, ArchiveTableModel.COL_SIZE)
+        index.data(QtCore.Qt.ItemDataRole.DisplayRole)
+
+    # with setting enabled, a fixed unit is determined and passed to pretty_bytes as an 'int'
     tab.populate_from_profile()
+    render_size()
     mock_pretty_bytes.assert_called()
-    kwargs_list = mock_pretty_bytes.call_args_list[0].kwargs
+    kwargs_list = mock_pretty_bytes.call_args.kwargs
     assert 'fixed_unit' in kwargs_list
     assert isinstance(kwargs_list['fixed_unit'], int)
 
@@ -97,8 +105,9 @@ def test_enable_fixed_units(qapp, qtbot, mocker):
 
     # with setting disabled, pretty_bytes should be called with fixed units set to 'None'
     tab.populate_from_profile()
+    render_size()
     mock_pretty_bytes.assert_called()
-    kwargs_list = mock_pretty_bytes.call_args_list[0].kwargs
+    kwargs_list = mock_pretty_bytes.call_args.kwargs
     assert 'fixed_unit' in kwargs_list
     assert kwargs_list['fixed_unit'] is None
 

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -284,7 +284,7 @@ def test_create(qapp, borg_json_output, mocker, qtbot):
     assert ArchiveModel.select().count() == 3
     assert RepoModel.get(id=1).unique_size == 15520474
     assert main.createStartBtn.isEnabled()
-    assert main.archiveTab.archiveTable.rowCount() == 3
+    assert main.archiveTab.archiveTable.model().rowCount() == 3
     assert main.scheduleTab.logPage.logPage.model().rowCount() == 1
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Wires the `ArchiveTableModel` from #2517 into `ArchiveTab`, migrating the Archive tab from item-based `QTableWidget` to `QTableView` + `QSortFilterProxyModel`.Part of #2361 Phase 4.

  **⚠️  Stacked on #2517** : the diff currently includes the spike commits. Only the top 2 commits are new here; those review needed are:
  - `3088310` Wire ArchiveTableModel into ArchiveTab
  - `2d61227` Scope delete to repo, preserve scroll on refresh, ungate mount-open

  Once #2517 lands I'll rebase onto master and the spike commits drop out.

Key changes:
  - `.ui`: `QTableWidget` → `QTableView`; sort via `QSortFilterProxyModel` + `setSortRole(SortRole)` so non-string columns order by raw value, not lexically.
  - Selection resolved through a single `selected_archives()` helper reading  `ArchiveRole`  : proxy-safe, so actions hit the right archive after sorting. All read sites (incl. `archive_extract`/`archive_mount`) route through it.
  - In-place rename via `view.edit()` + model `dataChanged`; `NoEditTriggers` makes the explicit edit the only editor entry.
  - Delete / failed rename refresh via `populate_from_profile(preserve_view=True)` (keeps scroll offset instead of jumping to top); delete query scoped to repo.

### Related Issue
#2361 (Phase 4). Builds on #2517.

### Motivation and Context
 The item-based `QTableWidget` mixed data, formatting, and sort keys into widget items, which made sorting fragile (durations >24h sorted lexically, e.g. `'1 day, …'`) and selection-after-sort error-prone. Moving to a `QAbstractTableModel` + sort proxy separates data from presentation, fixes the sort-key bugs, and makes selection robust under sorting via a custom data role.


### How Has This Been Tested?
`make test-unit` (Borg 1.2.4) green, plus new tests for selection-after-sort and rename-failure revert. Manually checked sort → delete/rename hit the right archive.


### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

<!--
This template is sourced from the awesome https://github.com/TalAter/open-source-templates
-->
