### PR TITLE
refactor(source): convert source files table to QTableView + QAbstractTableModel

### DIFF
--- a/src/vorta/assets/UI/source_tab.ui
+++ b/src/vorta/assets/UI/source_tab.ui
@@ -58,7 +58,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QTableWidget" name="sourceFilesWidget">
+       <widget class="QTableView" name="sourceFilesWidget">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -71,9 +71,9 @@
         <property name="selectionBehavior">
          <enum>QAbstractItemView::SelectRows</enum>
         </property>
-        <attribute name="horizontalHeaderVisible">
-         <bool>false</bool>
-        </attribute>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
         <attribute name="horizontalHeaderHighlightSections">
          <bool>false</bool>
         </attribute>
@@ -83,21 +83,6 @@
         <attribute name="verticalHeaderHighlightSections">
          <bool>false</bool>
         </attribute>
-        <column>
-         <property name="text">
-          <string>Path</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Size</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>File Count</string>
-         </property>
-        </column>
        </widget>
       </item>
       <item>

--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -35,7 +35,8 @@ from vorta.views.archive.archive_maintenance import ArchiveMaintenance
 from vorta.views.archive.archive_mount import ArchiveMount
 from vorta.views.archive.archive_rename import ArchiveRename
 from vorta.views.base_tab import BaseTab
-from vorta.views.partials.archive_table_model import SIZE_DECIMAL_DIGITS, ArchiveSortProxyModel, ArchiveTableModel
+from vorta.views.partials.archive_table_model import ArchiveTableModel
+from vorta.views.partials.sort_proxy import SortProxyModel
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/archive_tab.ui')
@@ -86,7 +87,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
 
         # Model + sort proxy (proxy sorts on SortRole for correct non-string ordering)
         self.archive_model = ArchiveTableModel(self)
-        self.archive_proxy = ArchiveSortProxyModel(self)
+        self.archive_proxy = SortProxyModel(self)
         self.archive_proxy.setSourceModel(self.archive_model)
         self.archiveTable.setModel(self.archive_proxy)
 

--- a/src/vorta/views/partials/archive_table_model.py
+++ b/src/vorta/views/partials/archive_table_model.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
-from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, QSortFilterProxyModel, Qt
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
 from PyQt6.QtGui import QIcon
 
 from vorta.i18n import trans_late, translate
@@ -194,16 +194,3 @@ class ArchiveTableModel(QAbstractTableModel):
         if orientation == Qt.Orientation.Horizontal and 0 <= section < len(self._HEADERS):
             return translate('Form', self._HEADERS[section])
         return None
-
-
-class ArchiveSortProxyModel(QSortFilterProxyModel):
-    """Sort proxy that compares `SortRole` keys in Python to avoid Qt's 32-bit int truncation."""
-
-    def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:
-        lv = left.data(ArchiveTableModel.SortRole)
-        rv = right.data(ArchiveTableModel.SortRole)
-        if lv is None:
-            return True
-        if rv is None:
-            return False
-        return lv < rv

--- a/src/vorta/views/partials/sort_proxy.py
+++ b/src/vorta/views/partials/sort_proxy.py
@@ -1,7 +1,4 @@
-"""
-Shared numeric-safe sort proxy for `QAbstractTableModel`-backed tables.
-
-"""
+"""Shared numeric-safe sort proxy for `QAbstractTableModel`-backed tables."""
 
 from PyQt6.QtCore import QModelIndex, QSortFilterProxyModel, Qt
 

--- a/src/vorta/views/partials/sort_proxy.py
+++ b/src/vorta/views/partials/sort_proxy.py
@@ -1,0 +1,19 @@
+"""
+Shared numeric-safe sort proxy for `QAbstractTableModel`-backed tables.
+
+"""
+
+from PyQt6.QtCore import QModelIndex, QSortFilterProxyModel, Qt
+
+
+class SortProxyModel(QSortFilterProxyModel):
+    """Sort proxy comparing `Qt.UserRole` keys in Python to avoid Qt's 32-bit int truncation."""
+
+    def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:
+        lv = left.data(Qt.ItemDataRole.UserRole)
+        rv = right.data(Qt.ItemDataRole.UserRole)
+        if lv is None:
+            return rv is not None
+        if rv is None:
+            return False
+        return lv < rv

--- a/src/vorta/views/partials/source_files_table_model.py
+++ b/src/vorta/views/partials/source_files_table_model.py
@@ -1,0 +1,172 @@
+"""Qt table model exposing `SourceFileModel` rows to the SourceTab `QTableView`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set
+
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
+
+from vorta.i18n import trans_late, translate
+from vorta.store.models import SourceFileModel
+from vorta.utils import pretty_bytes, uses_dark_mode
+from vorta.views.utils import get_colored_icon
+
+
+class SourceFilesModel(QAbstractTableModel):
+    """Table model for backup source rows; rows update in place during size recalculation."""
+
+    COL_PATH = 0
+    COL_SIZE = 1
+    COL_FILES = 2
+
+    #: Role returning native, comparable values for sorting via a proxy model.
+    SortRole = Qt.ItemDataRole.UserRole
+    #: Role returning the backing SourceFileModel; auto-mapped through the sort proxy.
+    SourceRole = Qt.ItemDataRole.UserRole + 1
+
+    _HEADERS = (
+        trans_late('Form', 'Path'),
+        trans_late('Form', 'Size'),
+        trans_late('Form', 'File Count'),
+    )
+
+    _CALCULATING = trans_late('SourceTab', 'Calculating…')
+
+    def __init__(self, parent: Optional[QObject] = None):
+        """Init."""
+        super().__init__(parent)
+        self._rows: List[SourceFileModel] = []
+        self._calculating: Set[str] = set()
+        self._icon_cache: Dict[str, Any] = {}  # themed icons; invalidated on dark-mode switch
+        self._icon_cache_dark: Optional[bool] = None
+
+    def set_rows(self, rows: List[SourceFileModel]) -> None:
+        """Replace the model contents and notify attached views."""
+        self.beginResetModel()
+        self._rows = list(rows)
+        self._calculating.clear()
+        self.endResetModel()
+
+    def add_source(self, source: SourceFileModel) -> int:
+        """Append ``source`` as a new row and return its row index."""
+        row = len(self._rows)
+        self.beginInsertRows(QModelIndex(), row, row)
+        self._rows.append(source)
+        self.endInsertRows()
+        return row
+
+    def source_at(self, row: int) -> Optional[SourceFileModel]:
+        """Return the `SourceFileModel` backing ``row``, or None if out of range."""
+        if 0 <= row < len(self._rows):
+            return self._rows[row]
+        return None
+
+    def mark_calculating(self, path: str) -> None:
+        """Show ``Calculating…`` for the row matching ``path`` until results arrive."""
+        self._calculating.add(path)
+        row = self._row_for_path(path)
+        if row is not None:
+            self.dataChanged.emit(self.index(row, self.COL_SIZE), self.index(row, self.COL_FILES))
+
+    def set_path_info(self, path: str, data_size: int, files_count: int, is_dir: bool) -> Optional[SourceFileModel]:
+        """Apply recalculated size/count to the row matching ``path`` and return it.
+
+        Keyed on ``path`` rather than a stored row index; returns None when no row matches
+        (e.g. the source was removed mid-calculation, #1080 / #2435) so the caller skips persistence.
+        """
+        self._calculating.discard(path)
+        row = self._row_for_path(path)
+        if row is None:
+            return None
+        source = self._rows[row]
+        source.dir_size = data_size
+        source.dir_files_count = files_count
+        source.path_isdir = is_dir
+        self.dataChanged.emit(self.index(row, self.COL_PATH), self.index(row, self.COL_FILES))
+        return source
+
+    def _row_for_path(self, path: str) -> Optional[int]:
+        for row, source in enumerate(self._rows):
+            if source.dir == path:
+                return row
+        return None
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return len(self._rows)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return len(self._HEADERS)
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
+        if not index.isValid():
+            return None
+
+        source = self._rows[index.row()]
+        column = index.column()
+
+        if role == Qt.ItemDataRole.DisplayRole:
+            return self._display_data(source, column)
+        if role == self.SortRole:
+            return self._sort_data(source, column)
+        if role == self.SourceRole:
+            return source  # proxy-safe accessor: the proxy forwards data() through mapToSource
+        if role == Qt.ItemDataRole.ToolTipRole and column == self.COL_PATH:
+            return source.dir
+        if role == Qt.ItemDataRole.DecorationRole and column == self.COL_PATH:
+            return self._path_icon(source)
+        if role == Qt.ItemDataRole.TextAlignmentRole and column == self.COL_SIZE:
+            return Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        return None
+
+    def _display_data(self, source: SourceFileModel, column: int) -> Any:
+        if column == self.COL_PATH:
+            return source.dir
+        if column == self.COL_SIZE:
+            if source.dir in self._calculating:
+                return translate('SourceTab', self._CALCULATING)
+            if source.dir_size > -1:
+                return pretty_bytes(source.dir_size)
+            return ''
+        if column == self.COL_FILES:
+            if source.dir in self._calculating:
+                return translate('SourceTab', self._CALCULATING)
+            if source.path_isdir and source.dir_files_count > -1:
+                return str(source.dir_files_count)
+            return ''
+        return None
+
+    def _sort_data(self, source: SourceFileModel, column: int) -> Any:
+        """Native comparable value used by the sort proxy."""
+        if column == self.COL_PATH:
+            return source.dir
+        if column == self.COL_SIZE:
+            return source.dir_size
+        if column == self.COL_FILES:
+            return source.dir_files_count if source.path_isdir else -1
+        return None
+
+    def _path_icon(self, source: SourceFileModel) -> Any:
+        icon_name = 'folder' if source.path_isdir else 'file'
+        dark = uses_dark_mode()
+        if dark != self._icon_cache_dark:
+            self._icon_cache.clear()
+            self._icon_cache_dark = dark
+        if icon_name not in self._icon_cache:
+            self._icon_cache[icon_name] = get_colored_icon(icon_name)
+        return self._icon_cache[icon_name]
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == Qt.Orientation.Horizontal and 0 <= section < len(self._HEADERS):
+            return translate('Form', self._HEADERS[section])
+        return None

--- a/src/vorta/views/partials/source_files_table_model.py
+++ b/src/vorta/views/partials/source_files_table_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Set
 
-from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, QSortFilterProxyModel, Qt
 
 from vorta.i18n import trans_late, translate
 from vorta.store.models import SourceFileModel
@@ -170,3 +170,16 @@ class SourceFilesModel(QAbstractTableModel):
         if orientation == Qt.Orientation.Horizontal and 0 <= section < len(self._HEADERS):
             return translate('Form', self._HEADERS[section])
         return None
+
+
+class SortProxyModel(QSortFilterProxyModel):
+    """Sort proxy comparing `SortRole` keys in Python to avoid Qt's 32-bit int truncation."""
+
+    def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:
+        lv = left.data(SourceFilesModel.SortRole)
+        rv = right.data(SourceFilesModel.SortRole)
+        if lv is None:
+            return True
+        if rv is None:
+            return False
+        return lv < rv

--- a/src/vorta/views/partials/source_files_table_model.py
+++ b/src/vorta/views/partials/source_files_table_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Set
 
 from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
+from PyQt6.QtGui import QIcon
 
 from vorta.i18n import trans_late, translate
 from vorta.store.models import SourceFileModel
@@ -37,7 +38,7 @@ class SourceFilesModel(QAbstractTableModel):
         super().__init__(parent)
         self._rows: List[SourceFileModel] = []
         self._calculating: Set[str] = set()
-        self._icon_cache: Dict[str, Any] = {}  # themed icons; invalidated on dark-mode switch
+        self._icon_cache: Dict[str, QIcon] = {}  # themed icons; invalidated on dark-mode switch
         self._icon_cache_dark: Optional[bool] = None
 
     def set_rows(self, rows: List[SourceFileModel]) -> None:
@@ -66,7 +67,11 @@ class SourceFilesModel(QAbstractTableModel):
         self._calculating.add(path)
         row = self._row_for_path(path)
         if row is not None:
-            self.dataChanged.emit(self.index(row, self.COL_SIZE), self.index(row, self.COL_FILES))
+            self.dataChanged.emit(
+                self.index(row, self.COL_SIZE),
+                self.index(row, self.COL_FILES),
+                [Qt.ItemDataRole.DisplayRole],
+            )
 
     def set_path_info(self, path: str, data_size: int, files_count: int, is_dir: bool) -> Optional[SourceFileModel]:
         """Apply recalculated size/count to the row matching ``path`` and return it.
@@ -82,7 +87,11 @@ class SourceFilesModel(QAbstractTableModel):
         source.dir_size = data_size
         source.dir_files_count = files_count
         source.path_isdir = is_dir
-        self.dataChanged.emit(self.index(row, self.COL_PATH), self.index(row, self.COL_FILES))
+        self.dataChanged.emit(
+            self.index(row, self.COL_PATH),
+            self.index(row, self.COL_FILES),
+            [Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.DecorationRole],
+        )
         return source
 
     def _row_for_path(self, path: str) -> Optional[int]:

--- a/src/vorta/views/partials/source_files_table_model.py
+++ b/src/vorta/views/partials/source_files_table_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Set
 
-from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, QSortFilterProxyModel, Qt
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
 
 from vorta.i18n import trans_late, translate
 from vorta.store.models import SourceFileModel
@@ -170,16 +170,3 @@ class SourceFilesModel(QAbstractTableModel):
         if orientation == Qt.Orientation.Horizontal and 0 <= section < len(self._HEADERS):
             return translate('Form', self._HEADERS[section])
         return None
-
-
-class SortProxyModel(QSortFilterProxyModel):
-    """Sort proxy comparing `SortRole` keys in Python to avoid Qt's 32-bit int truncation."""
-
-    def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:
-        lv = left.data(SourceFilesModel.SortRole)
-        rv = right.data(SourceFilesModel.SortRole)
-        if lv is None:
-            return True
-        if rv is None:
-            return False
-        return lv < rv

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -3,7 +3,7 @@ from pathlib import PurePath
 
 from peewee import fn
 from PyQt6 import QtCore, QtGui, uic
-from PyQt6.QtCore import QFileInfo, QMimeData, QPoint, Qt, QUrl, pyqtSlot
+from PyQt6.QtCore import QFileInfo, QMimeData, QPoint, QSortFilterProxyModel, Qt, QUrl, pyqtSlot
 from PyQt6.QtGui import QShortcut
 from PyQt6.QtWidgets import (
     QApplication,
@@ -22,6 +22,7 @@ from vorta.utils import (
 )
 from vorta.views.base_tab import BaseTab
 from vorta.views.dialogs.archive.exclude import ExcludeDialog
+from vorta.views.partials.source_files_table_model import SourceFilesModel
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/source_tab.ui')
@@ -30,13 +31,9 @@ SourceUI, SourceBase = uic.loadUiType(uifile)
 logger = logging.getLogger(__name__)
 
 
-class SourceColumn:
-    Path = 0
-    Size = 1
-    FilesCount = 2
-
-
 class SizeItem(QTableWidgetItem):
+    """Right-aligned, size-aware sortable cell, still consumed by archive_tab's QTableWidget."""
+
     def __init__(self, s):
         super().__init__(s)
         self.setTextAlignment(Qt.AlignmentFlag.AlignVCenter + Qt.AlignmentFlag.AlignRight)
@@ -53,20 +50,6 @@ class SizeItem(QTableWidgetItem):
             ]
 
 
-class FilesCount(QTableWidgetItem):
-    def __lt__(self, other):
-        # Verify that conversion is only performed on valid integers
-        # If one of the 2 elements is no number, put these elements at the end
-        # This is important if the text is "Calculating..." or ""
-        if self.text().isdigit() and other.text().isdigit():
-            return int(self.text()) < int(other.text())  # Compare & return result
-        else:
-            if not self.text().isdigit():
-                return 1  # Move one down if current item has no valid count
-            if not other.text().isdigit():
-                return 0
-
-
 class SourceTab(BaseTab, SourceBase, SourceUI):
     updateThreads = []
 
@@ -75,15 +58,20 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         self.setupUi(parent)
 
         # Prepare source files view
+        self.source_model = SourceFilesModel(self)
+        self.source_proxy = QSortFilterProxyModel(self)
+        self.source_proxy.setSourceModel(self.source_model)
+        self.source_proxy.setSortRole(SourceFilesModel.SortRole)
+        self.sourceFilesWidget.setModel(self.source_proxy)
+
         header = self.sourceFilesWidget.horizontalHeader()
         header.setVisible(True)
         header.setSortIndicatorShown(1)
 
-        header.setSectionResizeMode(SourceColumn.Path, QHeaderView.ResizeMode.Stretch)
-        header.setSectionResizeMode(SourceColumn.Size, QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(SourceColumn.FilesCount, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(SourceFilesModel.COL_PATH, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(SourceFilesModel.COL_SIZE, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(SourceFilesModel.COL_FILES, QHeaderView.ResizeMode.ResizeToContents)
 
-        self.sourceFilesWidget.setSortingEnabled(True)
         self.sourceFilesWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.sourceFilesWidget.customContextMenuRequested.connect(self.sourceitem_contextmenu)
         self.sourceFilesWidget.setAlternatingRowColors(True)
@@ -111,15 +99,7 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         self.addButton.setIcon(get_colored_icon('plus'))
         self.removeButton.setIcon(get_colored_icon('minus'))
         self.updateButton.setIcon(get_colored_icon('refresh'))
-
-        for row in range(self.sourceFilesWidget.rowCount()):
-            path_item = self.sourceFilesWidget.item(row, SourceColumn.Path)
-            db_item = SourceFileModel.get(dir=path_item.text(), profile=self.profile())
-
-            if db_item.path_isdir:
-                path_item.setIcon(get_colored_icon('folder'))
-            else:
-                path_item.setIcon(get_colored_icon('file'))
+        self.sourceFilesWidget.viewport().update()  # model rebuilds themed row icons lazily
 
     @pyqtSlot(QPoint)
     def sourceitem_contextmenu(self, pos: QPoint):
@@ -141,64 +121,35 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         menu.popup(self.sourceFilesWidget.viewport().mapToGlobal(pos))
 
     def set_path_info(self, path, data_size, files_count):
-        # disable sorting temporarily
-        sorting = self.sourceFilesWidget.isSortingEnabled()
-        self.sourceFilesWidget.setSortingEnabled(False)
-
-        items = self.sourceFilesWidget.findItems(path, QtCore.Qt.MatchFlag.MatchExactly)
         # Conversion int->str->int needed because QT limits int to 32-bit
         data_size = int(data_size)
         files_count = int(files_count)
 
-        for item in items:
-            try:
-                db_item = SourceFileModel.get(dir=path, profile=self.profile())
-            except SourceFileModel.DoesNotExist:
-                continue
+        # Returns None if the source was removed while recalculating (#1080 / #2435).
+        source = self.source_model.set_path_info(path, data_size, files_count, QFileInfo(path).isDir())
+        if source is not None:
+            source.save()
+            self.update_total_size()
+        self._discard_update_thread(path)
 
-            if QFileInfo(path).isDir():
-                self.sourceFilesWidget.item(item.row(), SourceColumn.FilesCount).setText(format(files_count))
-                db_item.path_isdir = True
-                self.sourceFilesWidget.item(item.row(), SourceColumn.Path).setIcon(get_colored_icon('folder'))
-            else:
-                # No files count, if entry itself is a file
-                self.sourceFilesWidget.item(item.row(), SourceColumn.FilesCount).setText("")
-                db_item.path_isdir = False
-                self.sourceFilesWidget.item(item.row(), SourceColumn.Path).setIcon(get_colored_icon('file'))
-
-            self.sourceFilesWidget.item(item.row(), SourceColumn.Size).setText(pretty_bytes(data_size))
-
-            db_item.dir_size = data_size
-            db_item.dir_files_count = files_count
-            db_item.save()
-        # Remove thread from list when it's done
-        for thrd in self.updateThreads:
+    def _discard_update_thread(self, path):
+        for thrd in self.updateThreads[:]:
             if thrd.objectName() == path:
+                try:
+                    thrd.signal.disconnect(self.set_path_info)
+                except (RuntimeError, TypeError):
+                    pass
                 self.updateThreads.remove(thrd)
 
-        # enable sorting again
-        self.sourceFilesWidget.setSortingEnabled(sorting)
-        self.update_total_size()
+    def update_path_info(self, path: str):
+        """Mark ``path`` as calculating and spawn the worker that fills in its size/count.
 
-    def update_path_info(self, index_row: int):
+        `set_path_info` applies the result, keyed on ``path`` rather than a row index so a
+        row removed mid-calculation is skipped (#1080 / #2435).
         """
-        Update the information for the source in the given table row.
+        logger.debug(f"Updating source {path}.")  # Debug #1080
 
-        This displays `Calculating...` in the updated rows and creates a
-        `FilePathInfoAsync` instance to get the new information.
-        The method `set_path_info` will update the row with the information
-        provided by this instance.
-
-        Parameters
-        ----------
-        index_row : int
-            The index of the row to update.
-        """
-        logger.debug(f"Updating source in row {index_row}.")  # Debug #1080
-
-        path = self.sourceFilesWidget.item(index_row, SourceColumn.Path).text()
-        self.sourceFilesWidget.item(index_row, SourceColumn.Size).setText(self.tr("Calculating…"))
-        self.sourceFilesWidget.item(index_row, SourceColumn.FilesCount).setText(self.tr("Calculating…"))
+        self.source_model.mark_calculating(path)
         getDir = FilePathInfoAsync(path, self.profile().get_combined_exclusion_string())
         getDir.signal.connect(self.set_path_info)
         getDir.setObjectName(path)
@@ -206,58 +157,26 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         getDir.start()
 
     def add_source_to_table(self, source, update_data=None):
-        # disable sorting temporarily
-        sorting = self.sourceFilesWidget.isSortingEnabled()
-        self.sourceFilesWidget.setSortingEnabled(False)
-
         if update_data is None:
             update_data = SettingsModel.get(key="get_srcpath_datasize").value
 
-        index_row = self.sourceFilesWidget.rowCount()
-        self.sourceFilesWidget.setRowCount(self.sourceFilesWidget.rowCount() + 1)
-        # Insert all items on current row, add tooltip containing the path name
-        new_item = QTableWidgetItem(source.dir)
-        new_item.setToolTip(source.dir)
-        self.sourceFilesWidget.setItem(index_row, SourceColumn.Path, new_item)
-        self.sourceFilesWidget.setItem(index_row, SourceColumn.Size, SizeItem(""))
-        self.sourceFilesWidget.setItem(index_row, SourceColumn.FilesCount, FilesCount(""))
-
-        logger.debug(f"Added item number {index_row}" + f" from {self.sourceFilesWidget.rowCount()}")
+        self.source_model.add_source(source)
 
         if update_data:
-            self.update_path_info(index_row)
-
-            # Debug #1080
-            logger.debug("Updated info for previously added item.")
-
-        else:  # Use cached data from DB
-            if source.dir_size > -1:
-                self.sourceFilesWidget.item(index_row, SourceColumn.Size).setText(pretty_bytes(source.dir_size))
-
-                if source.path_isdir:
-                    self.sourceFilesWidget.item(index_row, SourceColumn.FilesCount).setText(
-                        format(source.dir_files_count)
-                    )
-                    self.sourceFilesWidget.item(index_row, SourceColumn.Path).setIcon(get_colored_icon('folder'))
-                else:
-                    self.sourceFilesWidget.item(index_row, SourceColumn.Path).setIcon(get_colored_icon('file'))
-
-        # enable sorting again
-        self.sourceFilesWidget.setSortingEnabled(sorting)
+            self.update_path_info(source.dir)
+            logger.debug("Updated info for previously added item.")  # Debug #1080
 
     def populate_from_profile(self):
         profile = self.profile()
-        self.sourceFilesWidget.setRowCount(0)  # Clear rows
-
-        for source in SourceFileModel.select().where(SourceFileModel.profile == profile):
-            self.add_source_to_table(source, False)
+        sources = list(SourceFileModel.select().where(SourceFileModel.profile == profile))
+        self.source_model.set_rows(sources)
         self.update_total_size()
         # Fetch the Sort by Column and order
         sourcetab_sort_column = int(SettingsModel.get(key='sourcetab_sort_column').str_value)
         sourcetab_sort_order = int(SettingsModel.get(key='sourcetab_sort_order').str_value)
 
         # Sort items as per settings
-        self.sourceFilesWidget.sortItems(sourcetab_sort_column, Qt.SortOrder(sourcetab_sort_order))
+        self.sourceFilesWidget.sortByColumn(sourcetab_sort_column, Qt.SortOrder(sourcetab_sort_order))
 
     def update_sort_order(self, column: int, order: int):
         """Save selected sort by column and order to settings"""
@@ -270,16 +189,16 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
 
     def sources_update(self):
         """
-        Update each row in the sources table.
+        Update each source in the sources table.
 
-        Calls `update_path_info` for each row. to do the job.
+        Calls `update_path_info` for each source to do the job.
         """
-        row_count = self.sourceFilesWidget.rowCount()
+        row_count = self.source_model.rowCount()
 
         logger.debug(f"Updating sources ({row_count})")  # Debug #1080
 
-        for row in range(0, row_count):
-            self.update_path_info(row)  # Update data for each entry
+        for row in range(row_count):
+            self.update_path_info(self.source_model.source_at(row).dir)
 
     def source_add(self):
         # Selected paths from file dialog
@@ -310,7 +229,10 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
 
             index = indexes[0]
 
-        path = PurePath(self.sourceFilesWidget.item(index.row(), SourceColumn.Path).text())
+        source = index.data(SourceFilesModel.SourceRole)
+        if source is None:
+            return
+        path = PurePath(source.dir)
 
         data = QMimeData()
         data.setUrls([QUrl(path.as_uri())])
@@ -320,29 +242,17 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
 
     def source_remove(self):
         indexes = self.sourceFilesWidget.selectionModel().selectedRows()
-        profile = self.profile()
-        # sort indexes, starting with lowest
-        indexes.sort()
-        # remove each selected row, starting with the highest index (otherwise, higher indexes become invalid)
-        for index in reversed(indexes):
-            path = self.sourceFilesWidget.item(index.row(), SourceColumn.Path).text()
-            db_item = SourceFileModel.get(
-                dir=path,
-                profile=profile,
-            )
-            db_item.delete_instance()
-            self.sourceFilesWidget.removeRow(index.row())
-
-            for thrd in self.updateThreads[:]:
-                if thrd.objectName() == path:
-                    try:
-                        thrd.signal.disconnect(self.set_path_info)
-                    except (RuntimeError, TypeError):
-                        pass
-                    self.updateThreads.remove(thrd)
-
-            logger.debug(f"Removed source in row {index.row()}")
-        self.update_total_size()
+        if not indexes:
+            return
+        # Resolve the backing sources up front; row indices shift once rows are removed.
+        sources = [index.data(SourceFilesModel.SourceRole) for index in indexes]
+        for source in sources:
+            if source is None:
+                continue
+            source.delete_instance()
+            self._discard_update_thread(source.dir)
+            logger.debug(f"Removed source {source.dir}")
+        self.populate_from_profile()
 
     def update_total_size(self):
         """

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -3,7 +3,7 @@ from pathlib import PurePath
 
 from peewee import fn
 from PyQt6 import QtCore, QtGui, uic
-from PyQt6.QtCore import QFileInfo, QMimeData, QPoint, QSortFilterProxyModel, Qt, QUrl, pyqtSlot
+from PyQt6.QtCore import QFileInfo, QMimeData, QPoint, Qt, QUrl, pyqtSlot
 from PyQt6.QtGui import QShortcut
 from PyQt6.QtWidgets import (
     QApplication,
@@ -22,7 +22,7 @@ from vorta.utils import (
 )
 from vorta.views.base_tab import BaseTab
 from vorta.views.dialogs.archive.exclude import ExcludeDialog
-from vorta.views.partials.source_files_table_model import SourceFilesModel
+from vorta.views.partials.source_files_table_model import SortProxyModel, SourceFilesModel
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/source_tab.ui')
@@ -59,9 +59,8 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
 
         # Prepare source files view
         self.source_model = SourceFilesModel(self)
-        self.source_proxy = QSortFilterProxyModel(self)
+        self.source_proxy = SortProxyModel(self)
         self.source_proxy.setSourceModel(self.source_model)
-        self.source_proxy.setSortRole(SourceFilesModel.SortRole)
         self.sourceFilesWidget.setModel(self.source_proxy)
 
         header = self.sourceFilesWidget.horizontalHeader()

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -44,7 +44,6 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         self.sourceFilesWidget.setModel(self.source_proxy)
 
         header = self.sourceFilesWidget.horizontalHeader()
-        header.setVisible(True)
         header.setSortIndicatorShown(1)
 
         header.setSectionResizeMode(SourceFilesModel.COL_PATH, QHeaderView.ResizeMode.Stretch)
@@ -127,6 +126,9 @@ class SourceTab(BaseTab, SourceBase, SourceUI):
         row removed mid-calculation is skipped (#1080 / #2435).
         """
         logger.debug(f"Updating source {path}.")  # Debug #1080
+
+        if any(thrd.objectName() == path for thrd in self.updateThreads):
+            return
 
         self.source_model.mark_calculating(path)
         getDir = FilePathInfoAsync(path, self.profile().get_combined_exclusion_string())

--- a/src/vorta/views/source_tab.py
+++ b/src/vorta/views/source_tab.py
@@ -9,7 +9,6 @@ from PyQt6.QtWidgets import (
     QApplication,
     QHeaderView,
     QMenu,
-    QTableWidgetItem,
 )
 
 from vorta.filedialog import VortaFileSelector
@@ -18,11 +17,11 @@ from vorta.utils import (
     FilePathInfoAsync,
     get_asset,
     pretty_bytes,
-    sort_sizes,
 )
 from vorta.views.base_tab import BaseTab
 from vorta.views.dialogs.archive.exclude import ExcludeDialog
-from vorta.views.partials.source_files_table_model import SortProxyModel, SourceFilesModel
+from vorta.views.partials.sort_proxy import SortProxyModel
+from vorta.views.partials.source_files_table_model import SourceFilesModel
 from vorta.views.utils import get_colored_icon
 
 uifile = get_asset('UI/source_tab.ui')
@@ -31,31 +30,12 @@ SourceUI, SourceBase = uic.loadUiType(uifile)
 logger = logging.getLogger(__name__)
 
 
-class SizeItem(QTableWidgetItem):
-    """Right-aligned, size-aware sortable cell, still consumed by archive_tab's QTableWidget."""
-
-    def __init__(self, s):
-        super().__init__(s)
-        self.setTextAlignment(Qt.AlignmentFlag.AlignVCenter + Qt.AlignmentFlag.AlignRight)
-
-    def __lt__(self, other):
-        if other.text() == '':
-            return False
-        elif self.text() == '':
-            return True
-        else:
-            return sort_sizes([self.text(), other.text()]) == [
-                self.text(),
-                other.text(),
-            ]
-
-
 class SourceTab(BaseTab, SourceBase, SourceUI):
-    updateThreads = []
-
     def __init__(self, parent=None, profile_provider=None):
         super().__init__(parent=parent, profile_provider=profile_provider)
         self.setupUi(parent)
+
+        self.updateThreads = []
 
         # Prepare source files view
         self.source_model = SourceFilesModel(self)

--- a/tests/unit/test_archive_table_model.py
+++ b/tests/unit/test_archive_table_model.py
@@ -3,7 +3,8 @@ from datetime import datetime as dt
 from PyQt6.QtCore import QModelIndex, Qt
 
 from vorta.store.models import ArchiveModel
-from vorta.views.partials.archive_table_model import ArchiveSortProxyModel, ArchiveTableModel
+from vorta.views.partials.archive_table_model import ArchiveTableModel
+from vorta.views.partials.sort_proxy import SortProxyModel
 
 
 def _archive(name, time, size=1000, duration=60, trigger='user'):
@@ -104,7 +105,7 @@ def test_sort_role_orders_sizes_numerically():
             _archive('2G', dt(2024, 1, 3), size=2 * gib),
         ]
     )
-    proxy = ArchiveSortProxyModel()
+    proxy = SortProxyModel()
     proxy.setSourceModel(model)
     proxy.sort(ArchiveTableModel.COL_SIZE, Qt.SortOrder.AscendingOrder)
 

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -18,7 +18,7 @@ def source_env(qapp, qtbot):
     tab = main.sourceTab
 
     qtbot.waitUntil(tab.isVisible, **pytest._wait_defaults)  # wait for the tab
-    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() >= 0, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.model().rowCount() >= 0, **pytest._wait_defaults)
     yield main, tab
 
     qapp.processEvents()  # cleanup
@@ -33,16 +33,16 @@ def test_source_add_remove(qapp, qtbot, mocker, source_env):
     mocker.patch('vorta.filedialog.VortaFileSelector.get_paths', return_value=[os.path.join(TEST_TEMP_DIR, 'test')])
     mocker.patch('os.access', return_value=True)
 
-    initial_count = tab.sourceFilesWidget.rowCount()
+    initial_count = tab.sourceFilesWidget.model().rowCount()
 
     # test add
     tab.source_add()
-    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() > initial_count, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.model().rowCount() > initial_count, **pytest._wait_defaults)
 
     # test remove
     tab.sourceFilesWidget.selectRow(initial_count)  # Select the new row
     qtbot.mouseClick(tab.removeButton, QtCore.Qt.MouseButton.LeftButton)
-    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == initial_count, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.model().rowCount() == initial_count, **pytest._wait_defaults)
 
 
 @pytest.mark.skip(reason="prone to failure due to background thread")
@@ -55,7 +55,7 @@ def test_sources_update(qapp, qtbot, mocker, source_env):
 
     # test that `update_path_info()` has been called for each source path
     qtbot.mouseClick(tab.updateButton, QtCore.Qt.MouseButton.LeftButton)
-    assert tab.sourceFilesWidget.rowCount() == 1
+    assert tab.sourceFilesWidget.model().rowCount() == 1
     assert update_path_info_spy.call_count == 1
 
     # add a new source and reset mock
@@ -65,12 +65,12 @@ def test_sources_update(qapp, qtbot, mocker, source_env):
         return_value=[TEST_TEMP_DIR, os.path.join(TEST_TEMP_DIR, 'another')],
     )
     tab.source_add()
-    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.model().rowCount() == 2, **pytest._wait_defaults)
     update_path_info_spy.reset_mock()
 
     # retest that `update_path_info()` has been called for each source path
     qtbot.mouseClick(tab.updateButton, QtCore.Qt.MouseButton.LeftButton)
-    assert tab.sourceFilesWidget.rowCount() == 2
+    assert tab.sourceFilesWidget.model().rowCount() == 2
     assert update_path_info_spy.call_count == 2
 
 
@@ -83,9 +83,9 @@ def test_source_copy(qapp, qtbot, mocker, source_env):
     mocker.patch('os.access', return_value=True)
     mocker.patch('vorta.filedialog.VortaFileSelector.get_paths', return_value=[TEST_TEMP_DIR])
 
-    initial_count = tab.sourceFilesWidget.rowCount()
+    initial_count = tab.sourceFilesWidget.model().rowCount()
     tab.source_add()
-    qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() > initial_count, **pytest._wait_defaults)
+    qtbot.waitUntil(lambda: tab.sourceFilesWidget.model().rowCount() > initial_count, **pytest._wait_defaults)
 
     tab.sourceFilesWidget.selectRow(initial_count)
     tab.source_copy()
@@ -119,9 +119,9 @@ def test_source_copy(qapp, qtbot, mocker, source_env):
 
 #     if valid:
 #         assert not hasattr(tab, '_msg')
-#         qtbot.waitUntil(lambda: tab.sourceFilesWidget.rowCount() == 2, **pytest._wait_defaults)
-#         assert tab.sourceFilesWidget.rowCount() == 2
+#         qtbot.waitUntil(lambda: tab.sourceFilesWidget.model().rowCount() == 2, **pytest._wait_defaults)
+#         assert tab.sourceFilesWidget.model().rowCount() == 2
 #     else:
 #         qtbot.waitUntil(lambda: hasattr(tab, "_msg"), **pytest._wait_defaults)
 #         assert tab._msg.text().startswith("Some of your sources are invalid")
-#         assert tab.sourceFilesWidget.rowCount() == 1
+#         assert tab.sourceFilesWidget.model().rowCount() == 1

--- a/tests/unit/test_source.py
+++ b/tests/unit/test_source.py
@@ -5,6 +5,9 @@ from PyQt6 import QtCore
 from PyQt6.QtWidgets import QMessageBox
 from test_constants import TEST_TEMP_DIR
 
+from vorta.store.models import SourceFileModel
+from vorta.views.partials.source_files_table_model import SourceFilesModel
+
 
 @pytest.fixture()
 def source_env(qapp, qtbot):
@@ -90,6 +93,27 @@ def test_source_copy(qapp, qtbot, mocker, source_env):
     tab.sourceFilesWidget.selectRow(initial_count)
     tab.source_copy()
     assert mock_clipboard.call_count == 1
+
+
+def test_source_remove_under_sort(qapp, qtbot, source_env):
+    """Removing the first visual row after sorting deletes the correct DB record (proxy mapToSource)."""
+    main, tab = source_env
+    profile = tab.profile()
+
+    SourceFileModel.delete().where(SourceFileModel.profile == profile).execute()
+    small = SourceFileModel.create(dir='/vorta/small', profile=profile, dir_size=1024, path_isdir=True)
+    big = SourceFileModel.create(dir='/vorta/big', profile=profile, dir_size=8 * 1024**3, path_isdir=True)
+    tab.populate_from_profile()
+    assert tab.sourceFilesWidget.model().rowCount() == 2
+
+    # Sort by size descending → the largest source is visual row 0.
+    tab.source_proxy.sort(SourceFilesModel.COL_SIZE, QtCore.Qt.SortOrder.DescendingOrder)
+    tab.sourceFilesWidget.selectRow(0)
+
+    tab.source_remove()
+
+    assert SourceFileModel.get_or_none(id=big.id) is None
+    assert SourceFileModel.get_or_none(id=small.id) is not None
 
 
 # This test is for the paste_text() feature that was removed. Kept here for reference or possible future use.

--- a/tests/unit/test_source_files_table_model.py
+++ b/tests/unit/test_source_files_table_model.py
@@ -1,0 +1,199 @@
+from PyQt6.QtCore import QModelIndex, Qt
+
+from vorta.store.models import SourceFileModel
+from vorta.views.partials.source_files_table_model import SourceFilesModel
+
+
+def _source(dir, dir_size=-1, dir_files_count=-1, path_isdir=False):
+    """Build an in-memory SourceFileModel (not persisted) for feeding the model."""
+    return SourceFileModel(dir=dir, dir_size=dir_size, dir_files_count=dir_files_count, path_isdir=path_isdir)
+
+
+def test_model_is_empty_before_set_rows():
+    """Column count is intrinsic; row count starts at zero."""
+    model = SourceFilesModel()
+    assert model.rowCount() == 0
+    assert model.columnCount() == 3
+
+
+def test_set_rows_populates_and_preserves_order():
+    """`set_rows` replaces the contents and keeps the given row order."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/a'), _source('/b'), _source('/c')])
+
+    assert model.rowCount() == 3
+    paths = [model.data(model.index(r, SourceFilesModel.COL_PATH)) for r in range(3)]
+    assert paths == ['/a', '/b', '/c']
+
+
+def test_display_data_for_calculated_directory():
+    """A calculated directory shows its path, pretty size, and file count."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/data', dir_size=1500, dir_files_count=12, path_isdir=True)])
+
+    def cell(column):
+        return model.data(model.index(0, column), Qt.ItemDataRole.DisplayRole)
+
+    assert cell(SourceFilesModel.COL_PATH) == '/data'
+    assert cell(SourceFilesModel.COL_SIZE) == '1.5 KB'
+    assert cell(SourceFilesModel.COL_FILES) == '12'
+
+
+def test_file_entry_has_no_file_count():
+    """A single file shows its size but no file count."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/f.txt', dir_size=1500, dir_files_count=99, path_isdir=False)])
+    assert model.data(model.index(0, SourceFilesModel.COL_FILES)) == ''
+    assert model.data(model.index(0, SourceFilesModel.COL_SIZE)) == '1.5 KB'
+
+
+def test_uncalculated_source_renders_empty_size_and_count():
+    """A freshly added source (size/count -1) renders blank cells, not numbers."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/new', path_isdir=True)])
+    assert model.data(model.index(0, SourceFilesModel.COL_SIZE)) == ''
+    assert model.data(model.index(0, SourceFilesModel.COL_FILES)) == ''
+
+
+def test_mark_calculating_shows_placeholder_then_clears():
+    """`mark_calculating` shows the placeholder; `set_path_info` replaces it with results."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/d', path_isdir=True)])
+
+    model.mark_calculating('/d')
+    assert model.data(model.index(0, SourceFilesModel.COL_SIZE)) == 'Calculating…'
+    assert model.data(model.index(0, SourceFilesModel.COL_FILES)) == 'Calculating…'
+
+    model.set_path_info('/d', 1500, 7, True)
+    assert model.data(model.index(0, SourceFilesModel.COL_SIZE)) == '1.5 KB'
+    assert model.data(model.index(0, SourceFilesModel.COL_FILES)) == '7'
+
+
+def test_set_path_info_updates_backing_row_and_emits():
+    """`set_path_info` writes through to the backing row and notifies views."""
+    model = SourceFilesModel()
+    source = _source('/d', path_isdir=True)
+    model.set_rows([source])
+
+    received = []
+    model.dataChanged.connect(lambda tl, br, roles=[]: received.append((tl.row(), br.column())))
+
+    assert model.set_path_info('/d', 2048, 3, True) is source
+    assert source.dir_size == 2048
+    assert source.dir_files_count == 3
+    assert received == [(0, SourceFilesModel.COL_FILES)]
+
+
+def test_set_path_info_for_unknown_path_is_a_noop():
+    """A result arriving for a row removed mid-calculation is silently dropped (#1080 / #2435)."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/kept', path_isdir=True)])
+
+    assert model.set_path_info('/gone', 1000, 5, True) is None  # must not raise; caller skips save
+    assert model.rowCount() == 1
+    assert model.data(model.index(0, SourceFilesModel.COL_PATH)) == '/kept'
+
+
+def test_add_source_appends_and_returns_row():
+    """`add_source` appends a row and returns its index."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/a')])
+
+    row = model.add_source(_source('/b'))
+    assert row == 1
+    assert model.rowCount() == 2
+    assert model.data(model.index(1, SourceFilesModel.COL_PATH)) == '/b'
+
+
+def test_sort_role_returns_native_comparable_values():
+    """SortRole yields raw values so size/count sort numerically, not by text."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/z', dir_size=2048, dir_files_count=9, path_isdir=True)])
+
+    def sort_value(column):
+        return model.data(model.index(0, column), SourceFilesModel.SortRole)
+
+    assert sort_value(SourceFilesModel.COL_PATH) == '/z'
+    assert sort_value(SourceFilesModel.COL_SIZE) == 2048
+    assert sort_value(SourceFilesModel.COL_FILES) == 9
+
+
+def test_sort_role_orders_sizes_numerically():
+    """Raw size sort keys order correctly where display strings would not."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/big', dir_size=2048), _source('/small', dir_size=999)])
+
+    keys = [model.data(model.index(r, SourceFilesModel.COL_SIZE), SourceFilesModel.SortRole) for r in range(2)]
+    assert keys == [2048, 999]
+    assert keys[1] < keys[0]  # 999 < 2048, even though '999 B' > '2.0 KB' as text
+
+
+def test_file_count_sort_key_is_negative_for_files():
+    """Files (no count) sort below any directory by using a -1 count key."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/dir', dir_files_count=0, path_isdir=True), _source('/file', path_isdir=False)])
+
+    keys = [model.data(model.index(r, SourceFilesModel.COL_FILES), SourceFilesModel.SortRole) for r in range(2)]
+    assert keys == [0, -1]
+
+
+def test_source_role_returns_backing_object():
+    """SourceRole exposes the SourceFileModel so callers read it through the (auto-mapping) proxy."""
+    model = SourceFilesModel()
+    only = _source('/only')
+    model.set_rows([only])
+
+    for column in range(model.columnCount()):
+        assert model.data(model.index(0, column), SourceFilesModel.SourceRole) is only
+
+
+def test_source_at_returns_object_or_none():
+    """source_at returns the backing SourceFileModel and None when out of range."""
+    model = SourceFilesModel()
+    only = _source('/only')
+    model.set_rows([only])
+
+    assert model.source_at(0) is only
+    assert model.source_at(5) is None
+    assert model.source_at(-1) is None
+
+
+def test_path_tooltip_and_decoration():
+    """The path column exposes its full path as a tooltip and a folder/file icon."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/dir', path_isdir=True), _source('/file', path_isdir=False)])
+
+    assert model.data(model.index(0, SourceFilesModel.COL_PATH), Qt.ItemDataRole.ToolTipRole) == '/dir'
+    assert model.data(model.index(0, SourceFilesModel.COL_PATH), Qt.ItemDataRole.DecorationRole) is not None
+    assert model.data(model.index(1, SourceFilesModel.COL_PATH), Qt.ItemDataRole.DecorationRole) is not None
+
+
+def test_size_column_is_right_aligned():
+    """The size column keeps the legacy right alignment."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/a', dir_size=1500, path_isdir=True)])
+
+    align = model.data(model.index(0, SourceFilesModel.COL_SIZE), Qt.ItemDataRole.TextAlignmentRole)
+    assert align == Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+
+
+def test_header_data_returns_column_labels():
+    """Horizontal headers expose the canonical labels, matching the legacy .ui."""
+    model = SourceFilesModel()
+
+    def header(column):
+        return model.headerData(column, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
+
+    assert header(SourceFilesModel.COL_PATH) == 'Path'
+    assert header(SourceFilesModel.COL_SIZE) == 'Size'
+    assert header(SourceFilesModel.COL_FILES) == 'File Count'
+    assert model.headerData(0, Qt.Orientation.Vertical, Qt.ItemDataRole.DisplayRole) is None
+
+
+def test_data_returns_none_for_invalid_index_or_unsupported_role():
+    """Invalid indices and unhandled roles yield None."""
+    model = SourceFilesModel()
+    model.set_rows([_source('/x')])
+
+    assert model.data(QModelIndex()) is None
+    assert model.data(model.index(0, SourceFilesModel.COL_PATH), Qt.ItemDataRole.EditRole) is None

--- a/tests/unit/test_source_files_table_model.py
+++ b/tests/unit/test_source_files_table_model.py
@@ -1,7 +1,7 @@
 from PyQt6.QtCore import QModelIndex, Qt
 
 from vorta.store.models import SourceFileModel
-from vorta.views.partials.source_files_table_model import SourceFilesModel
+from vorta.views.partials.source_files_table_model import SortProxyModel, SourceFilesModel
 
 
 def _source(dir, dir_size=-1, dir_files_count=-1, path_isdir=False):
@@ -120,12 +120,21 @@ def test_sort_role_returns_native_comparable_values():
 
 def test_sort_role_orders_sizes_numerically():
     """Raw size sort keys order correctly where display strings would not."""
+    gib = 1024**3
     model = SourceFilesModel()
-    model.set_rows([_source('/big', dir_size=2048), _source('/small', dir_size=999)])
+    model.set_rows(
+        [
+            _source('/10G', dir_size=10 * gib),
+            _source('/500M', dir_size=500 * 1024**2),
+            _source('/2G', dir_size=2 * gib),
+        ]
+    )
+    proxy = SortProxyModel()
+    proxy.setSourceModel(model)
+    proxy.sort(SourceFilesModel.COL_SIZE, Qt.SortOrder.AscendingOrder)
 
-    keys = [model.data(model.index(r, SourceFilesModel.COL_SIZE), SourceFilesModel.SortRole) for r in range(2)]
-    assert keys == [2048, 999]
-    assert keys[1] < keys[0]  # 999 < 2048, even though '999 B' > '2.0 KB' as text
+    order = [proxy.data(proxy.index(r, SourceFilesModel.COL_PATH)) for r in range(proxy.rowCount())]
+    assert order == ['/500M', '/2G', '/10G']
 
 
 def test_file_count_sort_key_is_negative_for_files():

--- a/tests/unit/test_source_files_table_model.py
+++ b/tests/unit/test_source_files_table_model.py
@@ -1,7 +1,8 @@
 from PyQt6.QtCore import QModelIndex, Qt
 
 from vorta.store.models import SourceFileModel
-from vorta.views.partials.source_files_table_model import SortProxyModel, SourceFilesModel
+from vorta.views.partials.sort_proxy import SortProxyModel
+from vorta.views.partials.source_files_table_model import SourceFilesModel
 
 
 def _source(dir, dir_size=-1, dir_files_count=-1, path_isdir=False):
@@ -138,7 +139,7 @@ def test_sort_role_orders_sizes_numerically():
 
 
 def test_file_count_sort_key_is_negative_for_files():
-    """Files (no count) sort below any directory by using a -1 count key."""
+    """Files (no count) use a -1 sort key, ordering them before any directory in ascending sort."""
     model = SourceFilesModel()
     model.set_rows([_source('/dir', dir_files_count=0, path_isdir=True), _source('/file', path_isdir=False)])
 


### PR DESCRIPTION
### Description

Migrates the Source tab's file list from an item-based `QTableWidget` to a `QTableView` backed by a dedicated `QAbstractTableModel` (`SourceFilesModel` in `views/partials/`).

`source_tab.py` shrinks substantially: the imperative "disable sort → setItem loop → re-enable sort" choreography in `add_source_to_table`, `set_path_info`, `update_path_info`, and `populate_from_profile` is replaced by model calls. Per-row size/count recalculation now updates the backing `SourceFileModel` in place and emits `dataChanged`, instead of poking `QTableWidgetItem`s by row index.

### Related Issue

Part of #2361 (finish the views refactor / Phase 5 table-model migration).

### Motivation and Context

`QTableWidget` couples data and presentation and forces row-index bookkeeping, which is exactly what caused the historical mid-recalculation crash (#1080 / #2435). Moving to `QTableView` + `QAbstractTableModel` makes the model the single source of truth and lets sort/selection compose through a `QSortFilterProxyModel`.

Key design points:

- **Numeric-safe sorting via a shared `SortProxyModel`.** The model exposes raw comparable values (`dir_size` as int, file-count as int) under a `SortRole` (`Qt.UserRole`); `SortProxyModel.lessThan` compares those keys in Python so sizes ≥ 2 GiB don't hit Qt's C++ 32-bit `int` truncation. The old `SizeItem`/`FilesCount` `__lt__` hacks are gone.
- **Selection via a `SourceRole` (`UserRole + 1`)**, returned from `data()`. Callers resolve the backing object with `index.data(SourceRole)` on *proxy* indices, which `QSortFilterProxyModel` auto-forwards through `mapToSource`.
- **Themed path icons are cached** on the model, keyed on dark-mode state and invalidated on theme switch, rather than re-rendered from disk on every paint.
- **Path keying** for recalculation results: `set_path_info` matches on `dir` and returns `None` when the source was removed mid-calculation, so the caller skips persistence.
- **i18n preserved**: headers keep the `.ui`'s `Form` context (and "Calculating…" its `SourceTab` context), so existing catalog entries are reused.

### Rebased on #2519 — shared sort proxy + `SizeItem` removed

#2519 (Archive tab, Phase 4 pt 1) merged first, so this PR is rebased onto it and folds in the cleanup that merge triggered:

- **Extracted one shared sort proxy** into `views/partials/sort_proxy.py`: a single generic `SortProxyModel` keying off `Qt.UserRole`, now used by both the Archive and Source tables. This removes the near-duplicate per-model proxy classes (`ArchiveSortProxyModel` and this PR's original `SortProxyModel`) before the remaining tab migrations spawn a third copy. It also fixes the both-`None` strict-weak-ordering nit deferred from #2519 (`if lv is None: return rv is not None`).
- **Deleted the now-dead `SizeItem`** class and its orphaned imports (`QTableWidgetItem`, `sort_sizes`) from `source_tab.py` — `archive_tab.py` no longer references it after #2519.
- **Dropped a dead `SIZE_DECIMAL_DIGITS` import** left in `archive_tab.py` by #2519.
- Moved `updateThreads` from a class attribute to an instance attribute so worker lists aren't shared across `SourceTab` instances.

### How Has This Been Tested?

- New `tests/unit/test_source_files_table_model.py`, including a > 2 GiB size-sort regression test that runs through `SortProxyModel`.
- Existing `tests/unit/test_source.py` updated; `tests/unit/test_archive_table_model.py` switched to the shared proxy.

### Types of changes
- [x] Refactor (non-breaking change; no user-facing behavior change)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
