### PR TITLE
Fix crash in scheduler when profile no longer exists

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -214,9 +214,9 @@ class VortaScheduler(QtCore.QObject):
         next suitable backup time.
         """
         profile = BackupProfileModel.get_or_none(id=profile_id)
-        logger.debug('Profile: %s, %d %d', str(profile), profile.schedule_fixed_hour, profile.schedule_fixed_minute)
         if profile is None:  # profile doesn't exist any more.
             return
+        logger.debug('Profile: %s, %d %d', str(profile), profile.schedule_fixed_hour, profile.schedule_fixed_minute)
 
         with self.lock:  # Acquire lock
             self.remove_job(profile_id)  # reset schedule

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -65,6 +65,18 @@ def test_manual_mode():
     assert len(scheduler.timers) == 0
 
 
+def test_set_timer_for_missing_profile():
+    """A timer firing for a deleted profile must not crash the scheduler."""
+    scheduler = VortaScheduler()
+
+    missing_id = (BackupProfileModel.select().count() or 0) + 1000
+    assert BackupProfileModel.get_or_none(id=missing_id) is None
+
+    # Should return quietly instead of raising AttributeError on None.
+    scheduler.set_timer_for_profile(missing_id)
+    assert len(scheduler.timers) == 0
+
+
 def test_simple_schedule(clockmock):
     """Test a simple scheduling including `next_job` and `remove_job`."""
     scheduler = VortaScheduler()


### PR DESCRIPTION
### Description
`VortaScheduler.set_timer_for_profile()` looks up the profile with `BackupProfileModel.get_or_none(id=profile_id)`, which returns `None` when the profile no longer exists. There is already a `if profile is None: return` guard, but the `logger.debug(...)` line above it dereferences `profile.schedule_fixed_hour` / `profile.schedule_fixed_minute` first, so a missing profile crashes before the guard runs:

```
AttributeError: 'NoneType' object has no attribute 'schedule_fixed_hour'
```

This moves the debug log below the `None` check so the guard takes effect.

### Related Issue
#2522

### Motivation and Context
A scheduled timer can fire for a `profile_id` whose profile was deleted, which raised an unhandled `AttributeError` and broke scheduling. The fix lets the existing guard return cleanly in that case.

### How Has This Been Tested?
Added `test_set_timer_for_missing_profile`, which calls `set_timer_for_profile()` with an id that has no matching profile and asserts it returns without raising and adds no timer. Tested on Linux.

### Screenshots (if appropriate):

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/
