### PR TITLE
add JobModel: persistent scheduler job store (#2360, phase 1)

### DIFF
--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -20,11 +20,10 @@ from vorta.borg.jobs_manager import JobInterface
 from vorta.i18n import trans_late, translate
 from vorta.keyring.abc import VortaKeyring
 from vorta.keyring.db import VortaDBKeyring
-from vorta.store.models import EventLogModel
+from vorta.store.models import EventLogModel, db_lock
 from vorta.utils import borg_compat, pretty_bytes
 
 keyring_lock = Lock()
-db_lock = Lock()
 logger = logging.getLogger(__name__)
 
 FakeRepo = namedtuple('Repo', ['url', 'name', 'id', 'extra_borg_arguments', 'encryption'])

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -331,6 +331,15 @@ class VortaScheduler(QtCore.QObject):
                     return  # create_backup will lead to a call to this method
                 elif profile.schedule_make_up_missed and not self._net_up and needs_network:
                     logger.debug('Skipping catchup %s (%s), the network is not available', profile.name, profile.id)
+                    with db_lock:
+                        JobModel.create(
+                            profile=profile_id,
+                            repo_url=profile.repo.url if profile.repo else None,
+                            job_type='backup',
+                            status='skipped',
+                            trigger='catchup',
+                            skip_reason='Network unavailable for catch-up.',
+                        )
 
                 # calculate next time from now
                 if profile.schedule_mode == 'interval':
@@ -433,6 +442,15 @@ class VortaScheduler(QtCore.QObject):
         # Skip if a job for this profile (repo) is already in progress
         if self.app.jobs_manager.is_worker_running(site=profile.repo.id):
             logger.debug('A job for repo %s is already active.', profile.repo.id)
+            with db_lock:
+                JobModel.create(
+                    profile=profile_id,
+                    repo_url=profile.repo.url if profile.repo else None,
+                    job_type='backup',
+                    status='skipped',
+                    trigger='scheduled',
+                    skip_reason='Repository is busy with another job.',
+                )
             self.pause(profile_id)
             return
 

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -7,13 +7,13 @@ from datetime import datetime as dt
 from datetime import timedelta
 from typing import Any, NamedTuple
 
+import peewee as pw
 from packaging import version
 from PyQt6 import QtCore, QtDBus
 from PyQt6.QtCore import QTimer
 from PyQt6.QtWidgets import QApplication
 
 from vorta import application
-from vorta.borg.borg_job import db_lock
 from vorta.borg.check import BorgCheckJob
 from vorta.borg.compact import BorgCompactJob
 from vorta.borg.create import BorgCreateJob
@@ -324,22 +324,19 @@ class VortaScheduler(QtCore.QObject):
                             profile.name,
                             profile_id,
                         )
-                        self.create_backup(profile_id)
+                        self.create_backup(profile_id, trigger=JobModel.Trigger.CATCHUP.value)
                     finally:
                         self.lock.acquire()  # with-statement will try to release
 
                     return  # create_backup will lead to a call to this method
                 elif profile.schedule_make_up_missed and not self._net_up and needs_network:
                     logger.debug('Skipping catchup %s (%s), the network is not available', profile.name, profile.id)
-                    with db_lock:
-                        JobModel.create(
-                            profile=profile_id,
-                            repo_url=profile.repo.url if profile.repo else None,
-                            job_type='backup',
-                            status='skipped',
-                            trigger='catchup',
-                            skip_reason='Network unavailable for catch-up.',
-                        )
+                    self._record_skip(
+                        profile,
+                        JobModel.Trigger.CATCHUP.value,
+                        'Network unavailable for catch-up.',
+                        scheduled_at=next_time,
+                    )
 
                 # calculate next time from now
                 if profile.schedule_mode == 'interval':
@@ -431,7 +428,37 @@ class VortaScheduler(QtCore.QObject):
             return ScheduleStatus(ScheduleStatusType.UNSCHEDULED)
         return ScheduleStatus(job['type'], time=job.get('dt'))  # type: ignore[arg-type]
 
-    def create_backup(self, profile_id: int) -> None:
+    def _record_skip(
+        self,
+        profile: BackupProfileModel,
+        trigger: str,
+        reason: str,
+        status: str = JobModel.Status.SKIPPED.value,
+        scheduled_at: dt | None = None,
+    ) -> None:
+        """Record a job outcome, deduplicated on the occurrence when one is known."""
+        lookup = {
+            'profile': str(profile.id),
+            'trigger': trigger,
+            'status': status,
+            'scheduled_at': scheduled_at,
+        }
+        details = {
+            'profile_name': profile.name,
+            'repo_url': profile.repo.url if profile.repo else None,
+            'job_type': JobModel.Type.BACKUP.value,
+            'reason': reason,
+        }
+
+        try:
+            if scheduled_at is None:
+                JobModel.create(**lookup, **details)
+            else:
+                JobModel.get_or_create(**lookup, defaults=details)
+        except pw.PeeweeException:
+            logger.warning('Could not record job for profile %s.', profile.id, exc_info=True)
+
+    def create_backup(self, profile_id: int, trigger: str = JobModel.Trigger.SCHEDULED.value) -> None:
         notifier = VortaNotifications.pick()
         profile = BackupProfileModel.get_or_none(id=profile_id)
 
@@ -442,15 +469,7 @@ class VortaScheduler(QtCore.QObject):
         # Skip if a job for this profile (repo) is already in progress
         if self.app.jobs_manager.is_worker_running(site=profile.repo.id):
             logger.debug('A job for repo %s is already active.', profile.repo.id)
-            with db_lock:
-                JobModel.create(
-                    profile=profile_id,
-                    repo_url=profile.repo.url if profile.repo else None,
-                    job_type='backup',
-                    status='skipped',
-                    trigger='scheduled',
-                    skip_reason='Repository is busy with another job.',
-                )
+            self._record_skip(profile, trigger, 'Repository is busy with another job.')
             self.pause(profile_id)
             return
 
@@ -480,17 +499,11 @@ class VortaScheduler(QtCore.QObject):
                         translate('messages', msg['message']),
                         level='error',
                     )
+                    status = JobModel.Status.FAILED.value
                 else:
                     logger.info('Backup skipped: %s', msg['message'])
-                with db_lock:
-                    JobModel.create(
-                        profile=profile_id,
-                        repo_url=profile.repo.url if profile.repo else None,
-                        job_type='backup',
-                        status='skipped',
-                        trigger='scheduled',
-                        skip_reason=msg['message'],
-                    )
+                    status = JobModel.Status.SKIPPED.value
+                self._record_skip(profile, trigger, msg['message'], status=status)
                 self.pause(profile_id)
 
     def notify(self, result: dict[str, Any]) -> None:

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -13,6 +13,7 @@ from PyQt6.QtCore import QTimer
 from PyQt6.QtWidgets import QApplication
 
 from vorta import application
+from vorta.borg.borg_job import db_lock
 from vorta.borg.check import BorgCheckJob
 from vorta.borg.compact import BorgCompactJob
 from vorta.borg.create import BorgCreateJob
@@ -20,7 +21,7 @@ from vorta.borg.list_repo import BorgListRepoJob
 from vorta.borg.prune import BorgPruneJob
 from vorta.i18n import translate
 from vorta.notifications import VortaNotifications
-from vorta.store.models import BackupProfileModel, EventLogModel
+from vorta.store.models import BackupProfileModel, EventLogModel, JobModel
 from vorta.utils import borg_compat, get_network_status_monitor
 
 logger = logging.getLogger(__name__)
@@ -463,6 +464,15 @@ class VortaScheduler(QtCore.QObject):
                     )
                 else:
                     logger.info('Backup skipped: %s', msg['message'])
+                with db_lock:
+                    JobModel.create(
+                        profile=profile_id,
+                        repo_url=profile.repo.url if profile.repo else None,
+                        job_type='backup',
+                        status='skipped',
+                        trigger='scheduled',
+                        skip_reason=msg['message'],
+                    )
                 self.pause(profile_id)
 
     def notify(self, result: dict[str, Any]) -> None:

--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -86,6 +86,9 @@ def init_db(con: pw.SqliteDatabase | None = None) -> None:
         entry.not_in(last_scheduled_backups_per_profile),
     ).execute()
 
+    # Delete old job records after 6 months. Nothing derives scheduling state from them.
+    JobModel.delete().where(JobModel.created_at < six_months_ago).execute()
+
     # Migrations
     current_schema, created = SchemaVersion.get_or_create(id=1, defaults={'version': SCHEMA_VERSION})
     current_schema.save()

--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -18,6 +18,7 @@ from .models import (
     BackupProfileModel,
     EventLogModel,
     ExclusionModel,
+    JobModel,
     RepoModel,
     RepoPassword,
     SchemaVersion,
@@ -57,6 +58,7 @@ def init_db(con: pw.SqliteDatabase | None = None) -> None:
             ArchiveModel,
             WifiSettingModel,
             EventLogModel,
+            JobModel,
             SchemaVersion,
             ExclusionModel,
         ]

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -10,6 +10,7 @@ import json
 import logging
 from datetime import datetime
 from enum import Enum
+from threading import Lock
 from typing import Any
 
 import peewee as pw
@@ -19,6 +20,7 @@ from vorta.utils import slugify
 from vorta.views.utils import get_exclusion_presets
 
 DB = pw.Proxy()
+db_lock = Lock()
 logger = logging.getLogger(__name__)
 
 
@@ -250,18 +252,35 @@ class EventLogModel(BaseModel):
 class JobModel(BaseModel):
     """Lifecycle record of a scheduled background job."""
 
+    class Status(Enum):
+        SCHEDULED = 'scheduled'
+        RUNNING = 'running'
+        COMPLETED = 'completed'
+        FAILED = 'failed'
+        SKIPPED = 'skipped'
+        INTERRUPTED = 'interrupted'
+
+    class Type(Enum):
+        BACKUP = 'backup'
+
+    class Trigger(Enum):
+        SCHEDULED = 'scheduled'
+        CATCHUP = 'catchup'
+
     profile = pw.CharField(null=True)
+    profile_name = pw.CharField(null=True)
     repo_url = pw.CharField(null=True)
-    job_type = pw.CharField(default='backup')
-    status = pw.CharField(default='scheduled')
+    job_type = pw.CharField(default=Type.BACKUP.value)
+    status = pw.CharField(default=Status.SCHEDULED.value)
     trigger = pw.CharField(null=True)
     scheduled_at = pw.DateTimeField(null=True)
-    skip_reason = pw.CharField(null=True)
-    event_log = pw.ForeignKeyField(EventLogModel, null=True, backref='job')
+    reason = pw.CharField(null=True)
+    event_log = pw.ForeignKeyField(EventLogModel, null=True, backref='jobs')
     created_at = pw.DateTimeField(default=datetime.now)
 
     class Meta:
         database = DB
+        indexes = ((('profile', 'status', 'created_at'), False),)
 
 
 class SchemaVersion(BaseModel):

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -250,8 +250,8 @@ class EventLogModel(BaseModel):
 class JobModel(BaseModel):
     """Lifecycle record of a scheduled background job."""
 
-    profile = pw.ForeignKeyField(BackupProfileModel, backref='jobs')
-    repo = pw.ForeignKeyField(RepoModel, null=True, backref='jobs')
+    profile = pw.CharField(null=True)
+    repo_url = pw.CharField(null=True)
     job_type = pw.CharField(default='backup')
     status = pw.CharField(default='scheduled')
     trigger = pw.CharField(null=True)

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -247,6 +247,23 @@ class EventLogModel(BaseModel):
         database = DB
 
 
+class JobModel(BaseModel):
+    """Lifecycle record of a scheduled background job."""
+
+    profile = pw.ForeignKeyField(BackupProfileModel, backref='jobs')
+    repo = pw.ForeignKeyField(RepoModel, null=True, backref='jobs')
+    job_type = pw.CharField(default='backup')
+    status = pw.CharField(default='scheduled')
+    trigger = pw.CharField(null=True)
+    scheduled_at = pw.DateTimeField(null=True)
+    skip_reason = pw.CharField(null=True)
+    event_log = pw.ForeignKeyField(EventLogModel, null=True, backref='job')
+    created_at = pw.DateTimeField(default=datetime.now)
+
+    class Meta:
+        database = DB
+
+
 class SchemaVersion(BaseModel):
     """Keep DB version to apply the correct migrations."""
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@ from vorta.store.models import (
     ArchiveModel,
     BackupProfileModel,
     EventLogModel,
+    JobModel,
     RepoModel,
     RepoPassword,
     SchemaVersion,
@@ -59,6 +60,7 @@ models = [
     ArchiveModel,
     WifiSettingModel,
     EventLogModel,
+    JobModel,
     SchemaVersion,
 ]
 

--- a/tests/unit/test_job_model.py
+++ b/tests/unit/test_job_model.py
@@ -1,10 +1,24 @@
+from datetime import datetime, timedelta
+
+import vorta.store.connection
 from vorta.store.models import EventLogModel, JobModel
 
 
 def test_job_links_to_event_log():
     """A job's execution result is reached through the event_log relation."""
     log = EventLogModel.create(category='scheduled', subcommand='create')
-    job = JobModel.create(profile=1, status='done', event_log=log)
+    job = JobModel.create(profile=1, status=JobModel.Status.COMPLETED.value, event_log=log)
 
     assert job.event_log.id == log.id
-    assert list(log.job)[0].id == job.id
+    assert [j.id for j in log.jobs] == [job.id]
+
+
+def test_old_jobs_are_purged_on_init():
+    """Job records older than six months are dropped when the DB is opened."""
+    old = JobModel.create(profile=1, created_at=datetime.now() - timedelta(days=200))
+    recent = JobModel.create(profile=1, created_at=datetime.now() - timedelta(days=20))
+
+    vorta.store.connection.init_db()
+
+    assert JobModel.get_or_none(id=old.id) is None
+    assert JobModel.get_or_none(id=recent.id) is not None

--- a/tests/unit/test_job_model.py
+++ b/tests/unit/test_job_model.py
@@ -1,0 +1,10 @@
+from vorta.store.models import EventLogModel, JobModel
+
+
+def test_job_links_to_event_log():
+    """A job's execution result is reached through the event_log relation."""
+    log = EventLogModel.create(category='scheduled', subcommand='create')
+    job = JobModel.create(profile=1, status='done', event_log=log)
+
+    assert job.event_log.id == log.id
+    assert list(log.job)[0].id == job.id

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -9,7 +9,7 @@ from pytest import mark
 import vorta.borg
 import vorta.scheduler
 from vorta.scheduler import ScheduleStatus, ScheduleStatusType, VortaScheduler
-from vorta.store.models import BackupProfileModel, EventLogModel
+from vorta.store.models import BackupProfileModel, EventLogModel, JobModel
 
 PROFILE_NAME = 'Default'
 FIXED_SCHEDULE = 'fixed'
@@ -273,3 +273,24 @@ def test_create_backup_no_error_notification_on_info_level(qapp, qtbot, mocker, 
     # The error notification should be suppressed for an expected skip.
     assert mock_notifier.deliver.call_count == 1
     assert mock_notifier.deliver.call_args.kwargs.get('level') != 'error'
+
+
+def test_create_backup_records_skip_reason(qapp, qtbot, mocker):
+    """A skipped scheduled backup is recorded as a JobModel row with its reason."""
+    mocker.patch(
+        'vorta.scheduler.BorgCreateJob.prepare',
+        return_value={
+            'ok': False,
+            'message': 'Current Wifi is not allowed.',
+            'level': 'info',
+        },
+    )
+    jobs_before = JobModel.select().count()
+
+    qapp.scheduler.create_backup(1)
+
+    assert JobModel.select().count() == jobs_before + 1
+    job = JobModel.select().order_by(JobModel.id.desc()).get()
+    assert job.status == 'skipped'
+    assert job.skip_reason == 'Current Wifi is not allowed.'
+    assert str(job.profile) == '1'

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -294,3 +294,16 @@ def test_create_backup_records_skip_reason(qapp, qtbot, mocker):
     assert job.status == 'skipped'
     assert job.skip_reason == 'Current Wifi is not allowed.'
     assert str(job.profile) == '1'
+
+
+def test_create_backup_records_skip_when_repo_busy(qapp, mocker):
+    """A scheduled run blocked by a busy repo is recorded as a skipped JobModel row."""
+    mocker.patch.object(qapp.jobs_manager, 'is_worker_running', return_value=True)
+    jobs_before = JobModel.select().count()
+
+    qapp.scheduler.create_backup(1)
+
+    assert JobModel.select().count() == jobs_before + 1
+    job = JobModel.select().order_by(JobModel.id.desc()).get()
+    assert job.status == 'skipped'
+    assert job.skip_reason == 'Repository is busy with another job.'

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -291,9 +291,29 @@ def test_create_backup_records_skip_reason(qapp, qtbot, mocker):
 
     assert JobModel.select().count() == jobs_before + 1
     job = JobModel.select().order_by(JobModel.id.desc()).get()
-    assert job.status == 'skipped'
-    assert job.skip_reason == 'Current Wifi is not allowed.'
-    assert str(job.profile) == '1'
+    assert job.status == JobModel.Status.SKIPPED.value
+    assert job.reason == 'Current Wifi is not allowed.'
+    assert job.profile == '1'
+    assert job.profile_name == PROFILE_NAME
+
+
+def test_create_backup_records_failure_not_skip(qapp, qtbot, mocker):
+    """An unexpected prepare() failure is recorded as failed, not skipped."""
+    mocker.patch(
+        'vorta.scheduler.BorgCreateJob.prepare',
+        return_value={
+            'ok': False,
+            'message': 'Add a backup repository first.',
+        },
+    )
+    jobs_before = JobModel.select().count()
+
+    qapp.scheduler.create_backup(1)
+
+    assert JobModel.select().count() == jobs_before + 1
+    job = JobModel.select().order_by(JobModel.id.desc()).get()
+    assert job.status == JobModel.Status.FAILED.value
+    assert job.reason == 'Add a backup repository first.'
 
 
 def test_create_backup_records_skip_when_repo_busy(qapp, mocker):
@@ -305,5 +325,55 @@ def test_create_backup_records_skip_when_repo_busy(qapp, mocker):
 
     assert JobModel.select().count() == jobs_before + 1
     job = JobModel.select().order_by(JobModel.id.desc()).get()
-    assert job.status == 'skipped'
-    assert job.skip_reason == 'Repository is busy with another job.'
+    assert job.status == JobModel.Status.SKIPPED.value
+    assert job.reason == 'Repository is busy with another job.'
+
+
+def test_create_backup_keeps_the_catchup_trigger(qapp, mocker):
+    """A catch-up run that gets skipped is not recorded as an ordinary scheduled run."""
+    mocker.patch.object(qapp.jobs_manager, 'is_worker_running', return_value=True)
+
+    qapp.scheduler.create_backup(1, trigger=JobModel.Trigger.CATCHUP.value)
+
+    job = JobModel.select().order_by(JobModel.id.desc()).get()
+    assert job.trigger == JobModel.Trigger.CATCHUP.value
+
+
+def test_set_timer_records_skip_when_network_down_for_catchup(clockmock):
+    """A catch-up run blocked by a down network is recorded as a skipped JobModel row."""
+    scheduler = VortaScheduler()
+    scheduler._net_up = False
+
+    time = dt(2020, 5, 6, 4, 30)
+    clockmock.now.return_value = time
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_make_up_missed = True
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.schedule_interval_unit = 'hours'
+    profile.schedule_interval_count = 3
+    profile.save()
+
+    last_run = time - td(hours=6)
+    EventLogModel.create(
+        subcommand='create',
+        profile=profile.id,
+        returncode=0,
+        category='scheduled',
+        start_time=last_run,
+        end_time=last_run,
+    )
+    jobs_before = JobModel.select().count()
+
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert JobModel.select().count() == jobs_before + 1
+    job = JobModel.select().order_by(JobModel.id.desc()).get()
+    assert job.status == JobModel.Status.SKIPPED.value
+    assert job.trigger == JobModel.Trigger.CATCHUP.value
+    assert job.reason == 'Network unavailable for catch-up.'
+    assert job.scheduled_at == last_run + td(hours=3)
+
+    # Re-evaluating the same missed run must not add a second row.
+    scheduler.set_timer_for_profile(profile.id)
+    assert JobModel.select().count() == jobs_before + 1


### PR DESCRIPTION
### Description

First PR of the scheduler refactor (#2360), split into small stacked PRs. The full breakdown is on the issue.

This adds `JobModel` together with its first consumer, so the table arrives with a real write path rather than as a bare schema.

`JobModel` records intent: what the scheduler meant to do, including the runs that never reach borg and so never produce a log line. `EventLogModel` stays the record of what executed, linked through the `event_log` FK. `profile` and `repo_url` are plain strings mirroring `EventLogModel`, with `profile_name` stored next to the id so the history still names the profile after someone deletes it.

No migration. `connection.py` builds tables with `create_tables()`, which is safe by default, so the table shows up on fresh and existing DBs alike.

### What writes to it

Three call sites go through `VortaScheduler._record_skip`:

- borg's prepare step fails in `create_backup`
- the repo is busy with another job
- the network is down for a catch-up run in `set_timer_for_profile`

A real error records `status='failed'`. The expected cases (no WiFi, metered connection, busy repo) record `status='skipped'`.

The catch-up site passes the missed occurrence as `scheduled_at` and writes through `get_or_create`. A network that stays down overnight then leaves one row per missed run instead of one per timer tick.

`init_db` deletes job rows older than six months, next to the existing `EventLogModel` sweep.

`db_lock` moved from `vorta.borg.borg_job` to `vorta/store/models.py`, which is why `borg_job.py` turns up in the diff.

### Not written yet

`event_log` and the `scheduled`, `running` and `interrupted` statuses have no producer in this PR. They arrive with the run-lifecycle and crash-recovery phases in the #2360 breakdown, so there is nothing to go hunting for here.