### PR TITLE
add SchedulerPauseModel: persist pauses across restarts (#2360, phase A)

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -195,7 +195,12 @@ class VortaScheduler(QtCore.QObject):
         timer.start()
 
         self.pauses[profile_id] = (until, timer)
-        SchedulerPauseModel.replace(profile=profile_id, paused_until=until).execute()
+
+        try:
+            SchedulerPauseModel.replace(profile=profile_id, paused_until=until).execute()
+        except pw.PeeweeException:
+            logger.warning('Could not store pause for profile %s.', profile_id, exc_info=True)
+
         self._mark_paused(profile, until)
 
     def _mark_paused(self, profile: BackupProfileModel, until: dt) -> None:
@@ -206,7 +211,7 @@ class VortaScheduler(QtCore.QObject):
         self.timers[profile.id] = {'type': ScheduleStatusType.PAUSED, 'dt': until}
         self.schedule_changed.emit()
 
-    def _clear_pause(self, profile_id: int) -> None:
+    def clear_pause(self, profile_id: int) -> None:
         """Drop a pause from memory, from the schedule status and from the database."""
         pause = self.pauses.pop(profile_id, None)
         if pause is not None:
@@ -216,7 +221,10 @@ class VortaScheduler(QtCore.QObject):
         if status is not None and status.get('type') is ScheduleStatusType.PAUSED:
             del self.timers[profile_id]
 
-        SchedulerPauseModel.delete().where(SchedulerPauseModel.profile == profile_id).execute()
+        try:
+            SchedulerPauseModel.delete().where(SchedulerPauseModel.profile == profile_id).execute()
+        except pw.PeeweeException:
+            logger.warning('Could not drop stored pause for profile %s.', profile_id, exc_info=True)
 
     def _restore_pauses(self) -> None:
         """Re-arm the pauses stored by a previous run, dropping the ones that already ran out."""
@@ -227,7 +235,7 @@ class VortaScheduler(QtCore.QObject):
             profile = BackupProfileModel.get_or_none(id=profile_id)
 
             if profile is None or stored.paused_until <= now:
-                self._clear_pause(profile_id)
+                self.clear_pause(profile_id)
                 continue
 
             self._set_pause(profile, stored.paused_until)
@@ -250,7 +258,7 @@ class VortaScheduler(QtCore.QObject):
         if pause is None:  # already unpaused
             return
 
-        self._clear_pause(profile_id)
+        self.clear_pause(profile_id)
 
         logger.debug(f"Unpaused {profile_id}")
 
@@ -302,7 +310,7 @@ class VortaScheduler(QtCore.QObject):
                     self._mark_paused(profile, pause_end)
                     return
                 else:
-                    self._clear_pause(profile_id)
+                    self.clear_pause(profile_id)
 
             if profile.repo is None:  # No backups without repo set
                 logger.debug(
@@ -552,6 +560,7 @@ class VortaScheduler(QtCore.QObject):
             if msg['ok']:
                 logger.info('Preparation for backup successful.')
                 msg['category'] = 'scheduled'
+                msg['trigger'] = trigger
                 job = BorgCreateJob(msg['cmd'], msg, profile.repo.id)
                 job.result.connect(self.notify)
                 self.app.jobs_manager.add_job(job)
@@ -600,6 +609,12 @@ class VortaScheduler(QtCore.QObject):
             # pause scheduler
             # if a scheduled backup fails the scheduler should pause
             # temporarily.
+            self._record_skip(
+                result['params']['profile'],
+                result['params'].get('trigger', JobModel.Trigger.SCHEDULED.value),
+                'Backup failed, scheduling paused.',
+                status=JobModel.Status.FAILED.value,
+            )
             self.pause(result['params']['profile_id'])
 
         self.set_timer_for_profile(profile_id)

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -20,7 +20,7 @@ from vorta.borg.list_repo import BorgListRepoJob
 from vorta.borg.prune import BorgPruneJob
 from vorta.i18n import translate
 from vorta.notifications import VortaNotifications
-from vorta.store.models import BackupProfileModel, EventLogModel
+from vorta.store.models import BackupProfileModel, EventLogModel, SchedulerPauseModel
 from vorta.utils import borg_compat, get_network_status_monitor
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,7 @@ class ScheduleStatusType(enum.Enum):
     UNSCHEDULED = enum.auto()  # Unknown
     TOO_FAR_AHEAD = enum.auto()  # QTimer range exceeded, date provided
     NO_PREVIOUS_BACKUP = enum.auto()  # run a manual backup first
+    PAUSED = enum.auto()  # paused after a failed or skipped run, date provided
 
 
 class ScheduleStatus(NamedTuple):
@@ -81,6 +82,8 @@ class VortaScheduler(QtCore.QObject):
             self.bus.connect(service, path, interface, name, "b", self.loginSuspendNotify)
         else:
             logger.warning('Failed to connect to DBUS interface to detect sleep/resume events')
+
+        self._restore_pauses()
 
     @QtCore.pyqtSlot(bool)
     def loginSuspendNotify(self, suspend: bool) -> None:
@@ -146,21 +149,63 @@ class VortaScheduler(QtCore.QObject):
         # remove existing schedule
         self.remove_job(profile_id)
 
-        # setting timer for reschedule is not possible if called
-        # from a non-QThread -  it won't fail but won't work
-        timer_value = max(1, (until - dt.now()).total_seconds())
-        timer = QtCore.QTimer()
-        timer.setInterval(int(timer_value * 1000) + 100)
-        timer.timeout.connect(lambda: self.set_timer_for_profile(profile_id))
-        timer.start()
-
         # set timeout/pause
         other_pause = self.pauses.get(profile_id)
         if other_pause is not None:
             logger.debug(f"Override existing timeout for profile {profile_id}")
 
-        self.pauses[profile_id] = (until, timer)
+        self._set_pause(profile, until)
         logger.debug(f"Paused {profile_id} until {until.strftime('%Y-%m-%d %H:%M:%S')}")
+
+    def _set_pause(self, profile: BackupProfileModel, until: dt) -> None:
+        """Arm the reschedule timer for a pause and store it, so it outlives the process."""
+        profile_id = profile.id
+        # setting timer for reschedule is not possible if called
+        # from a non-QThread -  it won't fail but won't work
+        timer_value = max(1, (until - dt.now()).total_seconds())
+        timer = QtCore.QTimer()
+        timer.setInterval(min(int(timer_value * 1000) + 100, 2**31 - 1))
+        timer.timeout.connect(lambda: self.set_timer_for_profile(profile_id))
+        timer.start()
+
+        self.pauses[profile_id] = (until, timer)
+        SchedulerPauseModel.replace(profile=profile_id, paused_until=until).execute()
+        self._mark_paused(profile, until)
+
+    def _mark_paused(self, profile: BackupProfileModel, until: dt) -> None:
+        """Report the pause as the schedule status, unless the profile has no schedule to block."""
+        if profile.repo is None or profile.schedule_mode == 'off':
+            return
+
+        self.timers[profile.id] = {'type': ScheduleStatusType.PAUSED, 'dt': until}
+        self.schedule_changed.emit()
+
+    def _clear_pause(self, profile_id: int) -> None:
+        """Drop a pause from memory, from the schedule status and from the database."""
+        pause = self.pauses.pop(profile_id, None)
+        if pause is not None:
+            pause[1].stop()
+
+        status = self.timers.get(profile_id)
+        if status is not None and status.get('type') is ScheduleStatusType.PAUSED:
+            del self.timers[profile_id]
+
+        SchedulerPauseModel.delete().where(SchedulerPauseModel.profile == profile_id).execute()
+
+    def _restore_pauses(self) -> None:
+        """Re-arm the pauses stored by a previous run, dropping the ones that already ran out."""
+        now = dt.now()
+
+        for stored in list(SchedulerPauseModel.select()):
+            profile_id = stored.profile_id
+            profile = BackupProfileModel.get_or_none(id=profile_id)
+
+            if profile is None or stored.paused_until <= now:
+                self._clear_pause(profile_id)
+                continue
+
+            self._set_pause(profile, stored.paused_until)
+            logger.debug(f"Restored pause for {profile_id} until {stored.paused_until:%Y-%m-%d %H:%M:%S}")
 
     def unpause(self, profile_id: int) -> None:
         """
@@ -179,9 +224,7 @@ class VortaScheduler(QtCore.QObject):
         if pause is None:  # already unpaused
             return
 
-        dummy, timer = pause
-        timer.stop()
-        del self.pauses[profile_id]
+        self._clear_pause(profile_id)
 
         logger.debug(f"Unpaused {profile_id}")
 
@@ -230,10 +273,10 @@ class VortaScheduler(QtCore.QObject):
                         profile_id,
                         pause[0].strftime('%Y-%m-%d %H:%M:%S'),
                     )
+                    self._mark_paused(profile, pause_end)
                     return
                 else:
-                    timer.stop()
-                    del self.pauses[profile_id]
+                    self._clear_pause(profile_id)
 
             if profile.repo is None:  # No backups without repo set
                 logger.debug(

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -560,7 +560,6 @@ class VortaScheduler(QtCore.QObject):
             if msg['ok']:
                 logger.info('Preparation for backup successful.')
                 msg['category'] = 'scheduled'
-                msg['trigger'] = trigger
                 job = BorgCreateJob(msg['cmd'], msg, profile.repo.id)
                 job.result.connect(self.notify)
                 self.app.jobs_manager.add_job(job)
@@ -609,12 +608,6 @@ class VortaScheduler(QtCore.QObject):
             # pause scheduler
             # if a scheduled backup fails the scheduler should pause
             # temporarily.
-            self._record_skip(
-                result['params']['profile'],
-                result['params'].get('trigger', JobModel.Trigger.SCHEDULED.value),
-                'Backup failed, scheduling paused.',
-                status=JobModel.Status.FAILED.value,
-            )
             self.pause(result['params']['profile_id'])
 
         self.set_timer_for_profile(profile_id)

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -21,7 +21,7 @@ from vorta.borg.list_repo import BorgListRepoJob
 from vorta.borg.prune import BorgPruneJob
 from vorta.i18n import translate
 from vorta.notifications import VortaNotifications
-from vorta.store.models import BackupProfileModel, EventLogModel, JobModel
+from vorta.store.models import BackupProfileModel, EventLogModel, JobModel, SchedulerPauseModel
 from vorta.utils import borg_compat, get_network_status_monitor
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ class ScheduleStatusType(enum.Enum):
     UNSCHEDULED = enum.auto()  # Unknown
     TOO_FAR_AHEAD = enum.auto()  # QTimer range exceeded, date provided
     NO_PREVIOUS_BACKUP = enum.auto()  # run a manual backup first
+    PAUSED = enum.auto()  # paused after a failed or skipped run, date provided
 
 
 class ScheduleStatus(NamedTuple):
@@ -91,6 +92,8 @@ class VortaScheduler(QtCore.QObject):
         self.wake_timer.timeout.connect(self.checkForResume)
         self.wake_timer.setInterval(WAKE_CHECK_INTERVAL_MS)
         self.wake_timer.start()
+
+        self._restore_pauses()
 
     @QtCore.pyqtSlot(bool)
     def loginSuspendNotify(self, suspend: bool) -> None:
@@ -172,21 +175,63 @@ class VortaScheduler(QtCore.QObject):
         # remove existing schedule
         self.remove_job(profile_id)
 
-        # setting timer for reschedule is not possible if called
-        # from a non-QThread -  it won't fail but won't work
-        timer_value = max(1, (until - dt.now()).total_seconds())
-        timer = QtCore.QTimer()
-        timer.setInterval(int(timer_value * 1000) + 100)
-        timer.timeout.connect(lambda: self.set_timer_for_profile(profile_id))
-        timer.start()
-
         # set timeout/pause
         other_pause = self.pauses.get(profile_id)
         if other_pause is not None:
             logger.debug(f"Override existing timeout for profile {profile_id}")
 
-        self.pauses[profile_id] = (until, timer)
+        self._set_pause(profile, until)
         logger.debug(f"Paused {profile_id} until {until.strftime('%Y-%m-%d %H:%M:%S')}")
+
+    def _set_pause(self, profile: BackupProfileModel, until: dt) -> None:
+        """Arm the reschedule timer for a pause and store it, so it outlives the process."""
+        profile_id = profile.id
+        # setting timer for reschedule is not possible if called
+        # from a non-QThread -  it won't fail but won't work
+        timer_value = max(1, (until - dt.now()).total_seconds())
+        timer = QtCore.QTimer()
+        timer.setInterval(min(int(timer_value * 1000) + 100, 2**31 - 1))
+        timer.timeout.connect(lambda: self.set_timer_for_profile(profile_id))
+        timer.start()
+
+        self.pauses[profile_id] = (until, timer)
+        SchedulerPauseModel.replace(profile=profile_id, paused_until=until).execute()
+        self._mark_paused(profile, until)
+
+    def _mark_paused(self, profile: BackupProfileModel, until: dt) -> None:
+        """Report the pause as the schedule status, unless the profile has no schedule to block."""
+        if profile.repo is None or profile.schedule_mode == 'off':
+            return
+
+        self.timers[profile.id] = {'type': ScheduleStatusType.PAUSED, 'dt': until}
+        self.schedule_changed.emit()
+
+    def _clear_pause(self, profile_id: int) -> None:
+        """Drop a pause from memory, from the schedule status and from the database."""
+        pause = self.pauses.pop(profile_id, None)
+        if pause is not None:
+            pause[1].stop()
+
+        status = self.timers.get(profile_id)
+        if status is not None and status.get('type') is ScheduleStatusType.PAUSED:
+            del self.timers[profile_id]
+
+        SchedulerPauseModel.delete().where(SchedulerPauseModel.profile == profile_id).execute()
+
+    def _restore_pauses(self) -> None:
+        """Re-arm the pauses stored by a previous run, dropping the ones that already ran out."""
+        now = dt.now()
+
+        for stored in list(SchedulerPauseModel.select()):
+            profile_id = stored.profile_id
+            profile = BackupProfileModel.get_or_none(id=profile_id)
+
+            if profile is None or stored.paused_until <= now:
+                self._clear_pause(profile_id)
+                continue
+
+            self._set_pause(profile, stored.paused_until)
+            logger.debug(f"Restored pause for {profile_id} until {stored.paused_until:%Y-%m-%d %H:%M:%S}")
 
     def unpause(self, profile_id: int) -> None:
         """
@@ -205,9 +250,7 @@ class VortaScheduler(QtCore.QObject):
         if pause is None:  # already unpaused
             return
 
-        dummy, timer = pause
-        timer.stop()
-        del self.pauses[profile_id]
+        self._clear_pause(profile_id)
 
         logger.debug(f"Unpaused {profile_id}")
 
@@ -256,10 +299,10 @@ class VortaScheduler(QtCore.QObject):
                         profile_id,
                         pause[0].strftime('%Y-%m-%d %H:%M:%S'),
                     )
+                    self._mark_paused(profile, pause_end)
                     return
                 else:
-                    timer.stop()
-                    del self.pauses[profile_id]
+                    self._clear_pause(profile_id)
 
             if profile.repo is None:  # No backups without repo set
                 logger.debug(

--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -20,6 +20,7 @@ from .models import (
     ExclusionModel,
     RepoModel,
     RepoPassword,
+    SchedulerPauseModel,
     SchemaVersion,
     SettingsModel,
     SourceFileModel,
@@ -57,6 +58,7 @@ def init_db(con: pw.SqliteDatabase | None = None) -> None:
             ArchiveModel,
             WifiSettingModel,
             EventLogModel,
+            SchedulerPauseModel,
             SchemaVersion,
             ExclusionModel,
         ]

--- a/src/vorta/store/connection.py
+++ b/src/vorta/store/connection.py
@@ -21,6 +21,7 @@ from .models import (
     JobModel,
     RepoModel,
     RepoPassword,
+    SchedulerPauseModel,
     SchemaVersion,
     SettingsModel,
     SourceFileModel,
@@ -59,6 +60,7 @@ def init_db(con: pw.SqliteDatabase | None = None) -> None:
             WifiSettingModel,
             EventLogModel,
             JobModel,
+            SchedulerPauseModel,
             SchemaVersion,
             ExclusionModel,
         ]

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -283,6 +283,16 @@ class JobModel(BaseModel):
         indexes = ((('profile', 'status', 'created_at'), False),)
 
 
+class SchedulerPauseModel(BaseModel):
+    """A scheduling pause for a profile, kept so it survives a restart."""
+
+    profile = pw.ForeignKeyField(BackupProfileModel, primary_key=True)
+    paused_until = pw.DateTimeField()
+
+    class Meta:
+        database = DB
+
+
 class SchemaVersion(BaseModel):
     """Keep DB version to apply the correct migrations."""
 

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -247,6 +247,16 @@ class EventLogModel(BaseModel):
         database = DB
 
 
+class SchedulerPauseModel(BaseModel):
+    """A scheduling pause for a profile, kept so it survives a restart."""
+
+    profile = pw.ForeignKeyField(BackupProfileModel, primary_key=True)
+    paused_until = pw.DateTimeField()
+
+    class Meta:
+        database = DB
+
+
 class SchemaVersion(BaseModel):
     """Keep DB version to apply the correct migrations."""
 

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -237,7 +237,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
             )
 
             if reply == QMessageBox.StandardButton.Yes:
-                self.app.scheduler.unpause(to_delete_id)  # Drop a pause the deleted id could outlive
+                self.app.scheduler.clear_pause(to_delete_id)  # Drop a pause the deleted id could outlive
                 to_delete.delete_instance(recursive=True)
                 self.app.scheduler.remove_job(to_delete_id)  # Remove pending jobs
                 self.profileSelector.takeItem(self.profileSelector.currentRow())

--- a/src/vorta/views/main_window.py
+++ b/src/vorta/views/main_window.py
@@ -237,6 +237,7 @@ class MainWindow(MainWindowBase, MainWindowUI):
             )
 
             if reply == QMessageBox.StandardButton.Yes:
+                self.app.scheduler.unpause(to_delete_id)  # Drop a pause the deleted id could outlive
                 to_delete.delete_instance(recursive=True)
                 self.app.scheduler.remove_job(to_delete_id)  # Remove pending jobs
                 self.profileSelector.takeItem(self.profileSelector.currentRow())

--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -115,6 +115,9 @@ class SchedulePage(BaseTab, SchedulePageBase, SchedulePageUI):
         ):
             time = QDateTime.fromMSecsSinceEpoch(int(status.time.timestamp() * 1000))
             text = get_locale().toString(time, QLocale.FormatType.LongFormat)
+        elif status.type == ScheduleStatusType.PAUSED:
+            time = QDateTime.fromMSecsSinceEpoch(int(status.time.timestamp() * 1000))
+            text = self.tr('Paused until %s') % get_locale().toString(time, QLocale.FormatType.LongFormat)
         elif status.type == ScheduleStatusType.NO_PREVIOUS_BACKUP:
             text = self.tr('Run a manual backup first')
         else:

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -4,12 +4,14 @@ from functools import wraps
 from unittest.mock import MagicMock
 
 import pytest
+from PyQt6 import QtCore
+from PyQt6.QtWidgets import QDialogButtonBox, QMessageBox
 from pytest import mark
 
 import vorta.borg
 import vorta.scheduler
 from vorta.scheduler import ScheduleStatus, ScheduleStatusType, VortaScheduler
-from vorta.store.models import BackupProfileModel, EventLogModel
+from vorta.store.models import BackupProfileModel, EventLogModel, SchedulerPauseModel
 
 PROFILE_NAME = 'Default'
 FIXED_SCHEDULE = 'fixed'
@@ -75,6 +77,97 @@ def test_set_timer_for_missing_profile():
     # Should return quietly instead of raising AttributeError on None.
     scheduler.set_timer_for_profile(missing_id)
     assert len(scheduler.timers) == 0
+
+
+def test_pause_survives_restart():
+    """A pause is restored when the scheduler is recreated, and unpause clears it."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    VortaScheduler().pause(profile.id)
+    stored = SchedulerPauseModel.get_or_none(profile=profile.id)
+    assert stored is not None
+
+    restarted = VortaScheduler()
+    assert restarted.paused(profile.id)
+    assert restarted.next_job_for_profile(profile.id) == ScheduleStatus(ScheduleStatusType.PAUSED, stored.paused_until)
+
+    restarted.unpause(profile.id)
+    assert restarted.next_job_for_profile(profile.id).type is not ScheduleStatusType.PAUSED
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_expired_pause_dropped_on_restart(clockmock):
+    """A pause that ran out while Vorta was closed must not keep blocking the schedule."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    SchedulerPauseModel.replace(profile=profile.id, paused_until=dt(2020, 5, 6, 4, 30)).execute()
+    clockmock.now.return_value = dt(2020, 5, 6, 5, 30)
+
+    scheduler = VortaScheduler()
+
+    assert not scheduler.paused(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_pause_cleared_when_it_runs_out(clockmock):
+    """A pause running out while Vorta stays open clears the row and reschedules."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+    scheduler = VortaScheduler()
+    scheduler.pause(profile.id)
+
+    clockmock.now.return_value = dt(2020, 5, 6, 6, 30)
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert not scheduler.paused(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_deleting_a_paused_profile_clears_the_pause(qapp, qtbot, mocker):
+    """SQLite reuses ids, so a new profile must not inherit a deleted one's pause."""
+    main = qapp.main_window
+    main.profile_add_action()
+    qtbot.keyClicks(main.window.profileNameField, 'Paused Profile')
+    qtbot.mouseClick(
+        main.window.buttonBox.button(QDialogButtonBox.StandardButton.Save), QtCore.Qt.MouseButton.LeftButton
+    )
+
+    profile = BackupProfileModel.get(name='Paused Profile')
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+    qapp.scheduler.pause(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is not None
+
+    mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.StandardButton.Yes)
+    qtbot.mouseClick(main.profileDeleteButton, QtCore.Qt.MouseButton.LeftButton)
+
+    assert not qapp.scheduler.paused(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_paused_manual_profile_reports_unscheduled():
+    """Switching a paused profile to manual reports no schedule, not a pause."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    scheduler = VortaScheduler()
+    scheduler.pause(profile.id)
+
+    profile.schedule_mode = MANUAL_SCHEDULE
+    profile.save()
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert scheduler.paused(profile.id)
+    assert scheduler.next_job_for_profile(profile.id).type is ScheduleStatusType.UNSCHEDULED
+    assert VortaScheduler().next_job_for_profile(profile.id).type is ScheduleStatusType.UNSCHEDULED
 
 
 def test_simple_schedule(clockmock):

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -175,6 +175,7 @@ def test_deleting_a_paused_profile_clears_the_pause(qapp, qtbot, mocker):
 
     prepare_mock = mocker.patch('vorta.scheduler.BorgCreateJob.prepare')
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.StandardButton.Yes)
+    mocker.patch.object(qapp.scheduler, '_net_up', True)
     qtbot.mouseClick(main.profileDeleteButton, QtCore.Qt.MouseButton.LeftButton)
 
     # The overdue occurrence must not start a backup on the profile being deleted.
@@ -461,34 +462,6 @@ def test_create_backup_keeps_the_catchup_trigger(qapp, mocker):
 
     job = JobModel.select().order_by(JobModel.id.desc()).get()
     assert job.trigger == JobModel.Trigger.CATCHUP.value
-
-
-def test_failed_backup_records_the_pause(qapp):
-    """The pause after a failed run is the fourth skip point, and keeps the run's trigger."""
-    profile = BackupProfileModel.get(name=PROFILE_NAME)
-    profile.schedule_mode = INTERVAL_SCHEDULE
-    profile.save()
-    jobs_before = JobModel.select().count()
-
-    scheduler = VortaScheduler()
-    scheduler.notify(
-        {
-            'returncode': 2,
-            'params': {
-                'profile': profile,
-                'profile_id': profile.id,
-                'profile_name': profile.name,
-                'trigger': JobModel.Trigger.CATCHUP.value,
-            },
-        }
-    )
-
-    assert JobModel.select().count() == jobs_before + 1
-    job = JobModel.select().order_by(JobModel.id.desc()).get()
-    assert job.status == JobModel.Status.FAILED.value
-    assert job.trigger == JobModel.Trigger.CATCHUP.value
-    assert job.reason == 'Backup failed, scheduling paused.'
-    assert scheduler.paused(profile.id)
 
 
 def test_set_timer_records_skip_when_network_down_for_catchup(clockmock):

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -153,14 +153,32 @@ def test_deleting_a_paused_profile_clears_the_pause(qapp, qtbot, mocker):
     )
 
     profile = BackupProfileModel.get(name='Paused Profile')
+    profile.repo = BackupProfileModel.get(name=PROFILE_NAME).repo
     profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.schedule_interval_unit = 'hours'
+    profile.schedule_interval_count = 3
+    profile.schedule_make_up_missed = True
     profile.save()
+
+    last_run = dt.now() - td(hours=6)
+    EventLogModel.create(
+        subcommand='create',
+        profile=profile.id,
+        returncode=0,
+        category='scheduled',
+        start_time=last_run,
+        end_time=last_run,
+    )
+
     qapp.scheduler.pause(profile.id)
     assert SchedulerPauseModel.get_or_none(profile=profile.id) is not None
 
+    prepare_mock = mocker.patch('vorta.scheduler.BorgCreateJob.prepare')
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.StandardButton.Yes)
     qtbot.mouseClick(main.profileDeleteButton, QtCore.Qt.MouseButton.LeftButton)
 
+    # The overdue occurrence must not start a backup on the profile being deleted.
+    prepare_mock.assert_not_called()
     assert not qapp.scheduler.paused(profile.id)
     assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
 
@@ -443,6 +461,34 @@ def test_create_backup_keeps_the_catchup_trigger(qapp, mocker):
 
     job = JobModel.select().order_by(JobModel.id.desc()).get()
     assert job.trigger == JobModel.Trigger.CATCHUP.value
+
+
+def test_failed_backup_records_the_pause(qapp):
+    """The pause after a failed run is the fourth skip point, and keeps the run's trigger."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+    jobs_before = JobModel.select().count()
+
+    scheduler = VortaScheduler()
+    scheduler.notify(
+        {
+            'returncode': 2,
+            'params': {
+                'profile': profile,
+                'profile_id': profile.id,
+                'profile_name': profile.name,
+                'trigger': JobModel.Trigger.CATCHUP.value,
+            },
+        }
+    )
+
+    assert JobModel.select().count() == jobs_before + 1
+    job = JobModel.select().order_by(JobModel.id.desc()).get()
+    assert job.status == JobModel.Status.FAILED.value
+    assert job.trigger == JobModel.Trigger.CATCHUP.value
+    assert job.reason == 'Backup failed, scheduling paused.'
+    assert scheduler.paused(profile.id)
 
 
 def test_set_timer_records_skip_when_network_down_for_catchup(clockmock):

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -4,12 +4,14 @@ from functools import wraps
 from unittest.mock import MagicMock
 
 import pytest
+from PyQt6 import QtCore
+from PyQt6.QtWidgets import QDialogButtonBox, QMessageBox
 from pytest import mark
 
 import vorta.borg
 import vorta.scheduler
 from vorta.scheduler import ScheduleStatus, ScheduleStatusType, VortaScheduler
-from vorta.store.models import BackupProfileModel, EventLogModel, JobModel
+from vorta.store.models import BackupProfileModel, EventLogModel, JobModel, SchedulerPauseModel
 
 PROFILE_NAME = 'Default'
 FIXED_SCHEDULE = 'fixed'
@@ -88,6 +90,97 @@ def test_set_timer_for_missing_profile():
     # Should return quietly instead of raising AttributeError on None.
     scheduler.set_timer_for_profile(missing_id)
     assert len(scheduler.timers) == 0
+
+
+def test_pause_survives_restart():
+    """A pause is restored when the scheduler is recreated, and unpause clears it."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    VortaScheduler().pause(profile.id)
+    stored = SchedulerPauseModel.get_or_none(profile=profile.id)
+    assert stored is not None
+
+    restarted = VortaScheduler()
+    assert restarted.paused(profile.id)
+    assert restarted.next_job_for_profile(profile.id) == ScheduleStatus(ScheduleStatusType.PAUSED, stored.paused_until)
+
+    restarted.unpause(profile.id)
+    assert restarted.next_job_for_profile(profile.id).type is not ScheduleStatusType.PAUSED
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_expired_pause_dropped_on_restart(clockmock):
+    """A pause that ran out while Vorta was closed must not keep blocking the schedule."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    SchedulerPauseModel.replace(profile=profile.id, paused_until=dt(2020, 5, 6, 4, 30)).execute()
+    clockmock.now.return_value = dt(2020, 5, 6, 5, 30)
+
+    scheduler = VortaScheduler()
+
+    assert not scheduler.paused(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_pause_cleared_when_it_runs_out(clockmock):
+    """A pause running out while Vorta stays open clears the row and reschedules."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+    scheduler = VortaScheduler()
+    scheduler.pause(profile.id)
+
+    clockmock.now.return_value = dt(2020, 5, 6, 6, 30)
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert not scheduler.paused(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_deleting_a_paused_profile_clears_the_pause(qapp, qtbot, mocker):
+    """SQLite reuses ids, so a new profile must not inherit a deleted one's pause."""
+    main = qapp.main_window
+    main.profile_add_action()
+    qtbot.keyClicks(main.window.profileNameField, 'Paused Profile')
+    qtbot.mouseClick(
+        main.window.buttonBox.button(QDialogButtonBox.StandardButton.Save), QtCore.Qt.MouseButton.LeftButton
+    )
+
+    profile = BackupProfileModel.get(name='Paused Profile')
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+    qapp.scheduler.pause(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is not None
+
+    mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.StandardButton.Yes)
+    qtbot.mouseClick(main.profileDeleteButton, QtCore.Qt.MouseButton.LeftButton)
+
+    assert not qapp.scheduler.paused(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
+def test_paused_manual_profile_reports_unscheduled():
+    """Switching a paused profile to manual reports no schedule, not a pause."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    scheduler = VortaScheduler()
+    scheduler.pause(profile.id)
+
+    profile.schedule_mode = MANUAL_SCHEDULE
+    profile.save()
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert scheduler.paused(profile.id)
+    assert scheduler.next_job_for_profile(profile.id).type is ScheduleStatusType.UNSCHEDULED
+    assert VortaScheduler().next_job_for_profile(profile.id).type is ScheduleStatusType.UNSCHEDULED
 
 
 def test_simple_schedule(clockmock):


### PR DESCRIPTION
### Description
When a scheduled backup can't run (repo busy, network gone), the scheduler pauses that profile for up to an hour instead of retrying in a loop. Two problems with that. The schedule page reads "None scheduled" the whole time, so the user has no idea why backups stopped or when they resume. And the pause only lives in memory, so restarting Vorta throws the backoff away and goes straight back at whatever was broken. #2360 lists the second one under the jobs store.

### What's in it

- `SchedulerPauseModel`: the profile FK as primary key plus `paused_until`, one row per profile.
- `_set_pause` / `_clear_pause` / `_restore_pauses()`, the last dropping anything that expired while Vorta was closed
- `ScheduleStatusType.PAUSED` and a "Paused until 14:32" label.

Independent of #2530, so it sits on master and the two can land in either order. No migration.

Completes Phase A of the renewed plan.

### Calls I'd like you to check

1. **Own table, not a column on `BackupProfileModel`.** `profile_export.py` serialises with `model_to_dict`, so a column would export a stale pause to whoever imports the profile.
2. **Own table, not a `JobModel` row.** You asked for only skipped/interrupted/completed in the store, and a live pause is none of those. Cheap to change now, awkward after a release.
3. **The label ships here, not in Phase D.** `paused()` had no production caller before this, so persisting the state alone would have bought nothing. Lifts back out if you'd rather it waited for the Jobs view.

### Known gaps

- A pause still isn't recorded as a skip. It's a fourth skip point `_record_skip` doesn't cover, and it needs both branches in one tree, **_so it goes in whichever lands second._**
- Nothing ends a pause early. `unpause()` only fires from a successful *scheduled* backup, and manual backups never connect `scheduler.notify`. Want a successful manual run to unpause, or an action next to the label?
- While a remote repo's network is down, `reload_all_timers` clears the label back to "None scheduled" even though the pause is still in effect. It comes back on the next reload, and `set_timer_for_profile` **gets restructured** in the Phase B split anyway, so I left it. 