### PR TITLE
Add Borg 1.2 JSON output samples and regression test

### DIFF
--- a/tests/unit/borg_json_output/create_12_stderr.json
+++ b/tests/unit/borg_json_output/create_12_stderr.json
@@ -1,0 +1,8 @@
+{"original_size": 321757264, "compressed_size": 302994872, "deduplicated_size": 0, "nfiles": 1010, "path": "Users/user/Documents/plan.pdf", "time": 1654700723.321005, "type": "archive_progress", "finished": false}
+{"type": "file_status", "status": "M", "path": "/Users/user/Documents/plan.pdf"}
+{"original_size": 473579978, "compressed_size": 444583871, "deduplicated_size": 0, "nfiles": 1567, "path": "Users/user/Documents/report.pdf", "time": 1654700723.521086, "type": "archive_progress", "finished": false}
+{"type": "file_status", "status": "M", "path": "/Users/user/Documents/report.pdf"}
+{"time": 1654700723.764089, "type": "archive_progress", "finished": true}
+{"message": "Saving files cache", "operation": 2, "msgid": "cache.commit", "type": "progress_message", "finished": false, "time": 1654700723.790658}
+{"message": "Saving chunks cache", "operation": 2, "msgid": "cache.commit", "type": "progress_message", "finished": false, "time": 1654700723.8089201}
+{"name": "borg.repository", "time": 1654700723.81, "message": "Remote: Storage quota: 10.48 MB out of 1.00 GB used.", "type": "log_message", "levelname": "INFO"}

--- a/tests/unit/borg_json_output/create_12_stdout.json
+++ b/tests/unit/borg_json_output/create_12_stdout.json
@@ -1,0 +1,48 @@
+{
+  "archive": {
+    "command_line": [
+      "/Users/manu/.pyenv/versions/3.7.1/bin/borg",
+      "create",
+      "--list",
+      "--progress",
+      "--info",
+      "--log-json",
+      "--json",
+      "w66xh7lj@w66xh7lj.repo.borgbase.com:repo::test-snapadkkfdddasdf",
+      "/Users/manu/Documents/financial/Allianz"
+    ],
+    "duration": 4.454152,
+    "end": "2018-11-06T14:24:09.000000",
+    "id": "b7a67208a9329bc48f7e2953b9803ffe0175e776a49d7f1a9c07581e3e7b5a17",
+    "limits": {
+      "max_archive_size": 2.851491780813361e-05
+    },
+    "name": "test-snapadkkfdddasdf",
+    "start": "2018-11-06T14:24:04.000000",
+    "stats": {
+      "compressed_size": 2954077,
+      "deduplicated_size": 2954077,
+      "nfiles": 10,
+      "original_size": 3038309
+    }
+  },
+  "cache": {
+    "path": "/Users/manu/.cache/borg/daf2e2b94a1b57f0effc96939813ef58d0af04414f92f87c3e092a99adaa90eb",
+    "stats": {
+      "total_chunks": 97,
+      "total_csize": 23892256,
+      "total_size": 27955635,
+      "total_unique_chunks": 63,
+      "unique_csize": 13435127,
+      "unique_size": 15520474
+    }
+  },
+  "encryption": {
+    "mode": "repokey-blake2"
+  },
+  "repository": {
+    "id": "daf2e2b94a1b57f0effc96939813ef58d0af04414f92f87c3e092a99adaa90eb",
+    "last_modified": "2018-11-06T14:24:14.000000",
+    "location": "ssh://w66xh7lj@w66xh7lj.repo.borgbase.com/./repo"
+  }
+}

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -1,5 +1,9 @@
+import pytest
+from PyQt6 import QtCore
 from test_constants import TEST_SOURCE_DIR
 
+import vorta.application
+import vorta.borg.borg_job
 from vorta.borg.create import BorgCreateJob
 from vorta.store.models import BackupProfileModel, SourceFileModel
 
@@ -65,6 +69,34 @@ def test_prepare_returns_info_level_when_wifi_disallowed(mocker):
     )
     result = BorgCreateJob.prepare(default_profile)
     assert result.get('level') == 'info'
+
+
+def test_create_parses_borg_12_progress_output(qapp, borg_json_output, mocker, qtbot):
+    """
+    Borg 1.2 changed the JSON progress output: `archive_progress` lines gained a
+    `finished` key, and the final progress line only carries `{"finished": true}`
+    with no sizes. Regression test for #1354: unfinished lines must still emit a
+    progress message, and the minimal `finished` line must be skipped (previously
+    it would raise a KeyError on the missing `nfiles`/`original_size`).
+    """
+    main = qapp.main_window
+
+    stdout, stderr = borg_json_output('create_12')
+    popen_result = mocker.MagicMock(stdout=stdout, stderr=stderr, returncode=0)
+    mocker.patch.object(vorta.borg.borg_job, 'Popen', return_value=popen_result)
+    # The parser is what we test here; don't require a real borg binary.
+    mocker.patch.object(vorta.borg.create.BorgCreateJob, 'prepare_bin', return_value='borg')
+
+    progress_messages = []
+    qapp.backup_progress_event.connect(progress_messages.append)
+    try:
+        qtbot.mouseClick(main.createStartBtn, QtCore.Qt.MouseButton.LeftButton)
+        qtbot.waitUntil(lambda: 'Backup finished.' in main.progressText.text(), **pytest._wait_defaults)
+    finally:
+        qapp.backup_progress_event.disconnect(progress_messages.append)
+
+    files_progress = [m for m in progress_messages if 'Files:' in m]
+    assert len(files_progress) == 2  # one per unfinished archive_progress line
 
 
 def test_prepare_returns_info_level_when_metered_connection(mocker):


### PR DESCRIPTION
Closes #1354 — adds Borg 1.2.x JSON output sample files plus a regression test for the finished-key archive_progress handling.