### PR TITLE
detect resume from sleep without logind (#2360, phase 3)

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -27,8 +27,8 @@ from vorta.utils import borg_compat, get_network_status_monitor
 logger = logging.getLogger(__name__)
 
 RESCHEDULE_INTERVAL_MS = 15 * 60 * 1000
-WAKE_CHECK_INTERVAL_MS = 60 * 1000
-WAKE_GAP_THRESHOLD = timedelta(minutes=3)
+WAKE_CHECK_INTERVAL_MS = 5 * 60 * 1000
+WAKE_GAP_THRESHOLD = timedelta(minutes=10)
 
 
 class ScheduleStatusType(enum.Enum):
@@ -84,7 +84,7 @@ class VortaScheduler(QtCore.QObject):
             self.bus = bus
             self.bus.connect(service, path, interface, name, "b", self.loginSuspendNotify)
         else:
-            logger.info('No systemd-logind to notify us of sleep/resume, watching for clock gaps instead')
+            logger.info('No systemd-logind to notify us of sleep/resume, watching for clock gaps as well')
 
         self._last_wake_check = dt.now()
         self.wake_timer = QTimer()

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -26,6 +26,10 @@ from vorta.utils import borg_compat, get_network_status_monitor
 
 logger = logging.getLogger(__name__)
 
+RESCHEDULE_INTERVAL_MS = 15 * 60 * 1000
+WAKE_CHECK_INTERVAL_MS = 60 * 1000
+WAKE_GAP_THRESHOLD = timedelta(minutes=3)
+
 
 class ScheduleStatusType(enum.Enum):
     SCHEDULED = enum.auto()  # date provided
@@ -55,11 +59,10 @@ class VortaScheduler(QtCore.QObject):
         # pausing will prevent scheduling for a specified time
         self.pauses: dict[int, tuple[dt, QtCore.QTimer]] = dict()
 
-        # Set additional timer to make sure background tasks stay scheduled.
-        # E.g. after hibernation
+        # Periodic reschedule, in case a run was missed
         self.qt_timer = QTimer()
         self.qt_timer.timeout.connect(self.reload_all_timers)
-        self.qt_timer.setInterval(15 * 60 * 1000)
+        self.qt_timer.setInterval(RESCHEDULE_INTERVAL_MS)
         self.qt_timer.start()
 
         # connect signals
@@ -81,15 +84,37 @@ class VortaScheduler(QtCore.QObject):
             self.bus = bus
             self.bus.connect(service, path, interface, name, "b", self.loginSuspendNotify)
         else:
-            logger.warning('Failed to connect to DBUS interface to detect sleep/resume events')
+            logger.info('No systemd-logind to notify us of sleep/resume, watching for clock gaps instead')
+
+        self._last_wake_check = dt.now()
+        self.wake_timer = QTimer()
+        self.wake_timer.timeout.connect(self.checkForResume)
+        self.wake_timer.setInterval(WAKE_CHECK_INTERVAL_MS)
+        self.wake_timer.start()
 
     @QtCore.pyqtSlot(bool)
     def loginSuspendNotify(self, suspend: bool) -> None:
         if not suspend:
             logger.debug("Got login suspend/resume notification")
-            # Defensively refetch in case the network status didn't arrive
-            self._net_up = self.net_status.is_network_active()
-            self.reload_all_timers()
+            self._handle_resume()
+
+    @QtCore.pyqtSlot()
+    def checkForResume(self) -> None:
+        now = dt.now()
+        elapsed = now - self._last_wake_check
+        self._last_wake_check = now
+
+        if elapsed < WAKE_GAP_THRESHOLD:
+            return
+
+        logger.debug('Clock jumped %s since the last wake check, assuming the machine slept', elapsed)
+        self._handle_resume()
+
+    def _handle_resume(self) -> None:
+        self._last_wake_check = dt.now()
+        # Defensively refetch in case the network status didn't arrive
+        self._net_up = self.net_status.is_network_active()
+        self.reload_all_timers()
 
     @QtCore.pyqtSlot(bool)
     def networkStatusChanged(self, up: bool):

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -377,3 +377,49 @@ def test_set_timer_records_skip_when_network_down_for_catchup(clockmock):
     # Re-evaluating the same missed run must not add a second row.
     scheduler.set_timer_for_profile(profile.id)
     assert JobModel.select().count() == jobs_before + 1
+
+
+def test_wall_clock_gap_is_treated_as_a_resume(mocker, clockmock):
+    """Without logind, a jump in wall clock time is the only sign that the machine slept."""
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 0)
+    scheduler = VortaScheduler()
+    # qapp keeps every scheduler alive, and this one's baseline is 2020
+    scheduler.wake_timer.stop()
+    reload_all = mocker.patch.object(scheduler, 'reload_all_timers')
+    scheduler.net_status = MagicMock()
+    scheduler.net_status.is_network_active.return_value = True
+    scheduler._net_up = False
+
+    clockmock.now.return_value = dt(2020, 5, 6, 6, 0)
+    scheduler.wake_timer.timeout.emit()
+
+    reload_all.assert_called_once()
+    assert scheduler._net_up is True
+
+
+def test_timely_wake_check_does_not_reschedule(mocker, clockmock):
+    """An on-time check must do nothing, or every profile gets rescheduled once a minute."""
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 0)
+    scheduler = VortaScheduler()
+    scheduler.wake_timer.stop()
+    reload_all = mocker.patch.object(scheduler, 'reload_all_timers')
+
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 1)
+    scheduler.wake_timer.timeout.emit()
+
+    reload_all.assert_not_called()
+
+
+def test_logind_resume_signal_reloads_timers(mocker, clockmock):
+    """The logind fast path must survive the resume body moving into a helper."""
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 0)
+    scheduler = VortaScheduler()
+    scheduler.wake_timer.stop()
+    reload_all = mocker.patch.object(scheduler, 'reload_all_timers')
+    scheduler.net_status = MagicMock()
+
+    scheduler.loginSuspendNotify(True)
+    reload_all.assert_not_called()
+
+    scheduler.loginSuspendNotify(False)
+    reload_all.assert_called_once()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -25,6 +25,19 @@ def clockmock(monkeypatch):
     return datetime_mock
 
 
+@pytest.fixture(autouse=True)
+def stopped_wake_timers(qapp, monkeypatch):
+    """The app keeps every scheduler alive, so a tick would land in an unrelated later test."""
+    qapp.scheduler.wake_timer.stop()
+    original_init = VortaScheduler.__init__
+
+    def init_with_stopped_wake_timer(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.wake_timer.stop()
+
+    monkeypatch.setattr(VortaScheduler, '__init__', init_with_stopped_wake_timer)
+
+
 def prepare(func):
     """Decorator adding common preparation steps."""
 
@@ -383,8 +396,6 @@ def test_wall_clock_gap_is_treated_as_a_resume(mocker, clockmock):
     """Without logind, a jump in wall clock time is the only sign that the machine slept."""
     clockmock.now.return_value = dt(2020, 5, 6, 4, 0)
     scheduler = VortaScheduler()
-    # qapp keeps every scheduler alive, and this one's baseline is 2020
-    scheduler.wake_timer.stop()
     reload_all = mocker.patch.object(scheduler, 'reload_all_timers')
     scheduler.net_status = MagicMock()
     scheduler.net_status.is_network_active.return_value = True
@@ -398,10 +409,9 @@ def test_wall_clock_gap_is_treated_as_a_resume(mocker, clockmock):
 
 
 def test_timely_wake_check_does_not_reschedule(mocker, clockmock):
-    """An on-time check must do nothing, or every profile gets rescheduled once a minute."""
+    """An on-time check must do nothing, or every profile gets rescheduled on every tick."""
     clockmock.now.return_value = dt(2020, 5, 6, 4, 0)
     scheduler = VortaScheduler()
-    scheduler.wake_timer.stop()
     reload_all = mocker.patch.object(scheduler, 'reload_all_timers')
 
     clockmock.now.return_value = dt(2020, 5, 6, 4, 1)
@@ -414,7 +424,6 @@ def test_logind_resume_signal_reloads_timers(mocker, clockmock):
     """The logind fast path must survive the resume body moving into a helper."""
     clockmock.now.return_value = dt(2020, 5, 6, 4, 0)
     scheduler = VortaScheduler()
-    scheduler.wake_timer.stop()
     reload_all = mocker.patch.object(scheduler, 'reload_all_timers')
     scheduler.net_status = MagicMock()
 


### PR DESCRIPTION
### Description

Phase C of #2360, first of two. Fixes one of the four reliability defects the issue lists: **"DBus sleep/resume detection fails silently."**

At startup Vorta checks whether `org.freedesktop.login1` is registered. If it is not, it logs a warning and gives up permanently. So without logind there has never been any resume detection, and after a wake every profile's timer stays stale until the 15-minute poll comes around.

This adds a detector that does not need logind, making the DBus signal a fast path rather than the only path.

### What's in it

- `wake_timer` ticks every 60s and only compares two timestamps. QTimer does not fire while suspended, so a gap far larger than one tick means the machine was frozen and the schedules are stale.
- It measures **wall clock, not `time.monotonic()`**. `man 2 clock_gettime`: `CLOCK_BOOTTIME` is "identical to CLOCK_MONOTONIC, except that it also includes any time that the system is suspended". A monotonic detector would see a 60s gap after an 8-hour suspend and never fire. The cost is that an NTP step or DST shift can trip it, which buys one redundant `reload_all_timers()`, exactly what the poll already does unconditionally.
- `loginSuspendNotify` and `checkForResume` now share `_handle_resume()`, previously inline in the former. It resets the detector's baseline so a logind resume does not also trip the timer on the next tick.
- The logind failure log drops from `warning` to `info`, since it is no longer a failure.
- Tests cover both branches of the detector and of the logind slot, through the existing `clockmock` fixture and the real `timeout` signal. `loginSuspendNotify` had no coverage before.

Independent of #2530 and #2532: branches off master.

### Need help in these decisions

**1. Is 60s the right tick?** Each tick is two `datetime` subtractions, so the cost is the wakeup, not compute. 5 minutes still beats today by 3x, and `CLOCK_BOOTTIME` would allow a much lazier check at the price of a Linux-only branch plus a macOS fallback. One-line change either way.

**2. Where does this land after Phase B?** I expect `wake_timer`, `checkForResume` and `_handle_resume` to go to the State component rather than Scheduling, since none of it computes a next run. Confirm and I will carry them there in PR4.