### PR TITLE
add a Jobs view: pending runs and recorded jobs in one table (#2360, phase 4)

### DIFF
--- a/src/vorta/assets/UI/jobs_page.ui
+++ b/src/vorta/assets/UI/jobs_page.ui
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>JobsPage</class>
+ <widget class="QWidget" name="JobsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>687</width>
+    <height>384</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableView" name="jobsTable">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="showGrid">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/vorta/assets/UI/schedule_tab.ui
+++ b/src/vorta/assets/UI/schedule_tab.ui
@@ -93,6 +93,21 @@
       <layout class="QGridLayout" name="shellCommandsLayout">
       </layout>
       </widget>
+     <widget class="QWidget" name="page_jobs">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>687</width>
+        <height>384</height>
+       </rect>
+      </property>
+      <attribute name="label">
+       <string>Jobs</string>
+      </attribute>
+      <layout class="QGridLayout" name="jobsLayout">
+      </layout>
+      </widget>
     </widget>
    </item>
   </layout>

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -77,6 +77,13 @@ class ScheduleStatus(NamedTuple):
     time: dt | None = None
 
 
+#: Timer states that hold a time for a run, and the row status each one shows as.
+PENDING_STATUSES = {
+    ScheduleStatusType.SCHEDULED: JobModel.Status.SCHEDULED.value,
+    ScheduleStatusType.PAUSED: JobModel.Status.PAUSED.value,
+}
+
+
 class PendingJob(NamedTuple):
     """A run the scheduler is holding a time for, but that hasn't been recorded yet."""
 
@@ -84,11 +91,15 @@ class PendingJob(NamedTuple):
     profile_name: str
     repo_url: str | None
     scheduled_at: dt
+    status: str
 
 
 class VortaScheduler(QtCore.QObject):
     #: The schedule for a profile changed.
     schedule_changed = QtCore.pyqtSignal()
+
+    #: A job outcome was recorded.
+    jobs_changed = QtCore.pyqtSignal()
 
     def __init__(self) -> None:
         super().__init__()
@@ -533,7 +544,8 @@ class VortaScheduler(QtCore.QObject):
         pending = []
 
         for profile_id, timer in self.timers.items():
-            if timer['type'] not in (ScheduleStatusType.SCHEDULED, ScheduleStatusType.TOO_FAR_AHEAD):
+            status = PENDING_STATUSES.get(timer['type'])
+            if status is None:
                 continue
 
             profile = BackupProfileModel.get_or_none(id=profile_id)
@@ -541,7 +553,7 @@ class VortaScheduler(QtCore.QObject):
                 continue
 
             repo_url = profile.repo.url if profile.repo else None
-            pending.append(PendingJob(profile_id, profile.name, repo_url, timer['dt']))
+            pending.append(PendingJob(profile_id, profile.name, repo_url, timer['dt'], status))
 
         return sorted(pending, key=lambda job: job.scheduled_at)
 
@@ -571,9 +583,15 @@ class VortaScheduler(QtCore.QObject):
             if scheduled_at is None:
                 JobModel.create(**lookup, **details)
             else:
-                JobModel.get_or_create(**lookup, defaults=details)
+                _, recorded = JobModel.get_or_create(**lookup, defaults=details)
+                if not recorded:
+                    return
         except pw.PeeweeException:
             logger.warning('Could not record job for profile %s.', profile.id, exc_info=True)
+            return
+
+        # Two of the call sites hold `self.lock`, and the jobs view reads the table on this signal.
+        QTimer.singleShot(0, self.jobs_changed.emit)
 
     def create_backup(self, profile_id: int, trigger: str = JobModel.Trigger.SCHEDULED.value) -> None:
         notifier = VortaNotifications.pick()

--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -77,6 +77,15 @@ class ScheduleStatus(NamedTuple):
     time: dt | None = None
 
 
+class PendingJob(NamedTuple):
+    """A run the scheduler is holding a time for, but that hasn't been recorded yet."""
+
+    profile_id: int
+    profile_name: str
+    repo_url: str | None
+    scheduled_at: dt
+
+
 class VortaScheduler(QtCore.QObject):
     #: The schedule for a profile changed.
     schedule_changed = QtCore.pyqtSignal()
@@ -518,6 +527,23 @@ class VortaScheduler(QtCore.QObject):
         if job is None:
             return ScheduleStatus(ScheduleStatusType.UNSCHEDULED)
         return ScheduleStatus(job['type'], time=job.get('dt'))  # type: ignore[arg-type]
+
+    def pending_jobs(self) -> list[PendingJob]:
+        """The runs currently on the clock, soonest first."""
+        pending = []
+
+        for profile_id, timer in self.timers.items():
+            if timer['type'] not in (ScheduleStatusType.SCHEDULED, ScheduleStatusType.TOO_FAR_AHEAD):
+                continue
+
+            profile = BackupProfileModel.get_or_none(id=profile_id)
+            if profile is None:
+                continue
+
+            repo_url = profile.repo.url if profile.repo else None
+            pending.append(PendingJob(profile_id, profile.name, repo_url, timer['dt']))
+
+        return sorted(pending, key=lambda job: job.scheduled_at)
 
     def _record_skip(
         self,

--- a/src/vorta/store/models.py
+++ b/src/vorta/store/models.py
@@ -259,6 +259,7 @@ class JobModel(BaseModel):
         FAILED = 'failed'
         SKIPPED = 'skipped'
         INTERRUPTED = 'interrupted'
+        PAUSED = 'paused'
 
     class Type(Enum):
         BACKUP = 'backup'

--- a/src/vorta/views/jobs_page.py
+++ b/src/vorta/views/jobs_page.py
@@ -1,0 +1,56 @@
+from PyQt6 import uic
+from PyQt6.QtCore import QSortFilterProxyModel, Qt
+from PyQt6.QtWidgets import QAbstractItemView, QHeaderView
+
+from vorta.store.models import JobModel
+from vorta.utils import get_asset
+from vorta.views.base_tab import BaseTab
+from vorta.views.partials.jobs_table_model import JobRow, JobsTableModel
+
+uifile = get_asset('UI/jobs_page.ui')
+JobsPageUI, JobsPageBase = uic.loadUiType(uifile)
+
+RECORD_LIMIT = 200
+
+
+class JobsPage(BaseTab, JobsPageBase, JobsPageUI):
+    def __init__(self, parent=None, profile_provider=None):
+        super().__init__(parent=parent, profile_provider=profile_provider)
+        self.setupUi(self)
+
+        self._model = JobsTableModel(self)
+        self._proxy = QSortFilterProxyModel(self)
+        self._proxy.setSourceModel(self._model)
+        self.jobsTable.setModel(self._proxy)
+
+        self._pending = []
+        self._records = []
+
+        self.init_ui()
+        self.track_backup_finished(self.reload_records)
+        self.track_signal(self.app.scheduler.schedule_changed, self.reload_pending)
+        self.reload_records()
+        self.reload_pending()
+
+    def init_ui(self):
+        self.jobsTable.setAlternatingRowColors(True)
+        header = self.jobsTable.horizontalHeader()
+        header.setVisible(True)
+        for i in range(self._model.columnCount()):
+            header.setSectionResizeMode(i, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(JobsTableModel.COL_REASON, QHeaderView.ResizeMode.Stretch)
+        self.jobsTable.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.jobsTable.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.jobsTable.sortByColumn(JobsTableModel.COL_TIME, Qt.SortOrder.DescendingOrder)
+
+    def reload_records(self):
+        records = JobModel.select().order_by(JobModel.created_at.desc()).limit(RECORD_LIMIT)
+        self._records = [JobRow.from_record(record) for record in records]
+        self._redraw()
+
+    def reload_pending(self):
+        self._pending = [JobRow.from_pending(pending) for pending in self.app.scheduler.pending_jobs()]
+        self._redraw()
+
+    def _redraw(self):
+        self._model.set_rows(self._pending + self._records)

--- a/src/vorta/views/jobs_page.py
+++ b/src/vorta/views/jobs_page.py
@@ -1,11 +1,12 @@
 from PyQt6 import uic
-from PyQt6.QtCore import QSortFilterProxyModel, Qt
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QAbstractItemView, QHeaderView
 
 from vorta.store.models import JobModel
 from vorta.utils import get_asset
 from vorta.views.base_tab import BaseTab
 from vorta.views.partials.jobs_table_model import JobRow, JobsTableModel
+from vorta.views.partials.sort_proxy import SortProxyModel
 
 uifile = get_asset('UI/jobs_page.ui')
 JobsPageUI, JobsPageBase = uic.loadUiType(uifile)
@@ -19,7 +20,7 @@ class JobsPage(BaseTab, JobsPageBase, JobsPageUI):
         self.setupUi(self)
 
         self._model = JobsTableModel(self)
-        self._proxy = QSortFilterProxyModel(self)
+        self._proxy = SortProxyModel(self)
         self._proxy.setSourceModel(self._model)
         self.jobsTable.setModel(self._proxy)
 
@@ -28,6 +29,7 @@ class JobsPage(BaseTab, JobsPageBase, JobsPageUI):
 
         self.init_ui()
         self.track_backup_finished(self.reload_records)
+        self.track_signal(self.app.scheduler.jobs_changed, self.reload_records)
         self.track_signal(self.app.scheduler.schedule_changed, self.reload_pending)
         self.reload_records()
         self.reload_pending()

--- a/src/vorta/views/partials/jobs_table_model.py
+++ b/src/vorta/views/partials/jobs_table_model.py
@@ -1,0 +1,132 @@
+"""
+Qt table model exposing scheduled and recorded jobs to the JobsPage `QTableView`.
+
+"""
+
+from __future__ import annotations
+
+from datetime import datetime as dt
+from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional
+
+from PyQt6.QtCore import QT_TRANSLATE_NOOP, QAbstractTableModel, QModelIndex, Qt
+
+from vorta.i18n import translate
+from vorta.store.models import JobModel
+
+if TYPE_CHECKING:
+    from vorta.scheduler import PendingJob
+
+
+class JobRow(NamedTuple):
+    """One row of the jobs table, from either a stored record or a pending run."""
+
+    time: dt
+    profile_name: Optional[str]
+    repo_url: Optional[str]
+    job_type: Optional[str]
+    trigger: Optional[str]
+    status: str
+    reason: Optional[str]
+
+    @classmethod
+    def from_record(cls, job: JobModel) -> 'JobRow':
+        return cls(
+            time=job.created_at,
+            profile_name=job.profile_name,
+            repo_url=job.repo_url,
+            job_type=job.job_type,
+            trigger=job.trigger,
+            status=job.status,
+            reason=job.reason,
+        )
+
+    @classmethod
+    def from_pending(cls, pending: 'PendingJob') -> 'JobRow':
+        return cls(
+            time=pending.scheduled_at,
+            profile_name=pending.profile_name,
+            repo_url=pending.repo_url,
+            job_type=JobModel.Type.BACKUP.value,
+            trigger=JobModel.Trigger.SCHEDULED.value,
+            status=JobModel.Status.SCHEDULED.value,
+            reason=None,
+        )
+
+
+class JobsTableModel(QAbstractTableModel):
+    """Read-only table model for pending and recorded scheduler jobs."""
+
+    # Column indices in render order.
+    COL_TIME = 0
+    COL_PROFILE = 1
+    COL_REPOSITORY = 2
+    COL_TYPE = 3
+    COL_TRIGGER = 4
+    COL_STATUS = 5
+    COL_REASON = 6
+
+    _HEADERS = (
+        QT_TRANSLATE_NOOP('JobsPage', 'Time'),
+        QT_TRANSLATE_NOOP('JobsPage', 'Profile'),
+        QT_TRANSLATE_NOOP('JobsPage', 'Repository'),
+        QT_TRANSLATE_NOOP('JobsPage', 'Type'),
+        QT_TRANSLATE_NOOP('JobsPage', 'Trigger'),
+        QT_TRANSLATE_NOOP('JobsPage', 'Status'),
+        QT_TRANSLATE_NOOP('JobsPage', 'Reason'),
+    )
+
+    def __init__(self, parent: Optional[Any] = None):
+        """Init."""
+        super().__init__(parent)
+        self._rows: List[JobRow] = []
+
+    def set_rows(self, rows: List[JobRow]) -> None:
+        """Replace the model contents and notify attached views."""
+        self.beginResetModel()
+        self._rows = list(rows)
+        self.endResetModel()
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return len(self._rows)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        if parent.isValid():
+            return 0
+        return len(self._HEADERS)
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
+        if not index.isValid() or role != Qt.ItemDataRole.DisplayRole:
+            return None
+
+        row = self._rows[index.row()]
+        column = index.column()
+
+        if column == self.COL_TIME:
+            return row.time.strftime('%Y-%m-%d %H:%M')
+        if column == self.COL_PROFILE:
+            return row.profile_name
+        if column == self.COL_REPOSITORY:
+            return row.repo_url
+        if column == self.COL_TYPE:
+            return row.job_type
+        if column == self.COL_TRIGGER:
+            return row.trigger
+        if column == self.COL_STATUS:
+            return row.status
+        if column == self.COL_REASON:
+            return row.reason
+        return None
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> Any:
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == Qt.Orientation.Horizontal and 0 <= section < len(self._HEADERS):
+            return translate('JobsPage', self._HEADERS[section])
+        return None

--- a/src/vorta/views/partials/jobs_table_model.py
+++ b/src/vorta/views/partials/jobs_table_model.py
@@ -48,7 +48,7 @@ class JobRow(NamedTuple):
             repo_url=pending.repo_url,
             job_type=JobModel.Type.BACKUP.value,
             trigger=JobModel.Trigger.SCHEDULED.value,
-            status=JobModel.Status.SCHEDULED.value,
+            status=pending.status,
             reason=None,
         )
 
@@ -97,11 +97,17 @@ class JobsTableModel(QAbstractTableModel):
         return len(self._HEADERS)
 
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
-        if not index.isValid() or role != Qt.ItemDataRole.DisplayRole:
+        if not index.isValid():
             return None
 
         row = self._rows[index.row()]
         column = index.column()
+
+        if role == Qt.ItemDataRole.UserRole:
+            return self._sort_key(row, column)
+
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
 
         if column == self.COL_TIME:
             return row.time.strftime('%Y-%m-%d %H:%M')
@@ -117,6 +123,12 @@ class JobsTableModel(QAbstractTableModel):
             return row.status
         if column == self.COL_REASON:
             return row.reason
+        return None
+
+    def _sort_key(self, row: JobRow, column: int) -> Any:
+        # JobRow fields are declared in column order, so the raw value sorts the column.
+        if 0 <= column < len(row):
+            return row[column]
         return None
 
     def headerData(

--- a/src/vorta/views/schedule_tab.py
+++ b/src/vorta/views/schedule_tab.py
@@ -2,6 +2,7 @@ from PyQt6 import uic
 
 from vorta.utils import get_asset
 from vorta.views.base_tab import BaseTab
+from vorta.views.jobs_page import JobsPage
 from vorta.views.log_page import LogPage
 from vorta.views.networks_page import NetworksPage
 from vorta.views.schedule_page import SchedulePage
@@ -21,6 +22,7 @@ class ScheduleTab(BaseTab, ScheduleBase, ScheduleUI):
         self.init_shell_commands_page()
         self.init_networks_page()
         self.init_schedule_page()
+        self.init_jobs_page()
         self.track_palette_change(call_now=True)
         self.track_backup_finished(self.logPage.populate_logs)
 
@@ -44,8 +46,14 @@ class ScheduleTab(BaseTab, ScheduleBase, ScheduleUI):
         self.scheduleLayout.addWidget(self.schedulePage)
         self.schedulePage.show()
 
+    def init_jobs_page(self):
+        self.jobsPage = JobsPage(self, profile_provider=self.profile)
+        self.jobsLayout.addWidget(self.jobsPage)
+        self.jobsPage.show()
+
     def set_icons(self):
         self.toolBox.setItemIcon(0, get_colored_icon('clock-o'))
         self.toolBox.setItemIcon(1, get_colored_icon('wifi'))
         self.toolBox.setItemIcon(2, get_colored_icon('tasks'))
         self.toolBox.setItemIcon(3, get_colored_icon('terminal'))
+        self.toolBox.setItemIcon(4, get_colored_icon('view-list-details'))

--- a/tests/unit/test_jobs_table_model.py
+++ b/tests/unit/test_jobs_table_model.py
@@ -1,0 +1,58 @@
+from datetime import datetime as dt
+
+from PyQt6.QtCore import Qt
+
+from vorta.scheduler import PendingJob
+from vorta.store.models import JobModel
+from vorta.views.partials.jobs_table_model import JobRow, JobsTableModel
+
+
+def _make_record(created_at, status=JobModel.Status.SKIPPED.value, reason='Repository is busy with another job.'):
+    return JobModel.create(
+        profile=1,
+        profile_name='Default',
+        repo_url='test-repo-url',
+        job_type=JobModel.Type.BACKUP.value,
+        status=status,
+        trigger=JobModel.Trigger.SCHEDULED.value,
+        reason=reason,
+        created_at=created_at,
+    )
+
+
+def _make_pending(scheduled_at):
+    return PendingJob(1, 'Default', 'test-repo-url', scheduled_at)
+
+
+def test_data_exposes_record_fields():
+    """A stored job renders its own status, trigger and reason."""
+    model = JobsTableModel()
+    model.set_rows([JobRow.from_record(_make_record(dt(2024, 1, 15, 10, 30)))])
+
+    def cell(column):
+        return model.data(model.index(0, column), Qt.ItemDataRole.DisplayRole)
+
+    assert cell(JobsTableModel.COL_TIME) == '2024-01-15 10:30'
+    assert cell(JobsTableModel.COL_PROFILE) == 'Default'
+    assert cell(JobsTableModel.COL_REPOSITORY) == 'test-repo-url'
+    assert cell(JobsTableModel.COL_TYPE) == 'backup'
+    assert cell(JobsTableModel.COL_TRIGGER) == 'scheduled'
+    assert cell(JobsTableModel.COL_STATUS) == 'skipped'
+    assert cell(JobsTableModel.COL_REASON) == 'Repository is busy with another job.'
+
+
+def test_pending_run_renders_as_a_scheduled_backup():
+    """A run that only exists as a timer reads as scheduled, with nothing to explain."""
+    model = JobsTableModel()
+    model.set_rows([JobRow.from_pending(_make_pending(dt(2024, 1, 16, 9, 0)))])
+
+    def cell(column):
+        return model.data(model.index(0, column), Qt.ItemDataRole.DisplayRole)
+
+    assert cell(JobsTableModel.COL_TIME) == '2024-01-16 09:00'
+    assert cell(JobsTableModel.COL_PROFILE) == 'Default'
+    assert cell(JobsTableModel.COL_REPOSITORY) == 'test-repo-url'
+    assert cell(JobsTableModel.COL_TYPE) == 'backup'
+    assert cell(JobsTableModel.COL_TRIGGER) == 'scheduled'
+    assert cell(JobsTableModel.COL_STATUS) == 'scheduled'
+    assert cell(JobsTableModel.COL_REASON) is None

--- a/tests/unit/test_jobs_table_model.py
+++ b/tests/unit/test_jobs_table_model.py
@@ -20,8 +20,8 @@ def _make_record(created_at, status=JobModel.Status.SKIPPED.value, reason='Repos
     )
 
 
-def _make_pending(scheduled_at):
-    return PendingJob(1, 'Default', 'test-repo-url', scheduled_at)
+def _make_pending(scheduled_at, status=JobModel.Status.SCHEDULED.value):
+    return PendingJob(1, 'Default', 'test-repo-url', scheduled_at, status)
 
 
 def test_data_exposes_record_fields():
@@ -56,3 +56,28 @@ def test_pending_run_renders_as_a_scheduled_backup():
     assert cell(JobsTableModel.COL_TRIGGER) == 'scheduled'
     assert cell(JobsTableModel.COL_STATUS) == 'scheduled'
     assert cell(JobsTableModel.COL_REASON) is None
+
+
+def test_pending_run_keeps_the_status_the_scheduler_gave_it():
+    """A paused profile still holds a time, and the row says so rather than claiming a run is coming."""
+    model = JobsTableModel()
+    model.set_rows([JobRow.from_pending(_make_pending(dt(2024, 1, 16, 9, 0), JobModel.Status.PAUSED.value))])
+
+    assert model.data(model.index(0, JobsTableModel.COL_STATUS), Qt.ItemDataRole.DisplayRole) == 'paused'
+
+
+def test_sort_keys_compare_raw_values():
+    """The shared sort proxy sorts on `UserRole`, so times must compare as times, not as strings."""
+    model = JobsTableModel()
+    model.set_rows(
+        [
+            JobRow.from_record(_make_record(dt(2024, 1, 15, 10, 30))),
+            JobRow.from_pending(_make_pending(dt(2024, 1, 16, 9, 0))),
+        ]
+    )
+
+    def key(row, column):
+        return model.data(model.index(row, column), Qt.ItemDataRole.UserRole)
+
+    assert key(0, JobsTableModel.COL_TIME) < key(1, JobsTableModel.COL_TIME)
+    assert key(0, JobsTableModel.COL_STATUS) == 'skipped'

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -8,7 +8,8 @@ from PyQt6.QtWidgets import QWidget
 
 import vorta.scheduler
 from vorta.application import VortaApp
-from vorta.store.models import BackupProfileModel, EventLogModel
+from vorta.store.models import BackupProfileModel, EventLogModel, JobModel
+from vorta.views.partials.jobs_table_model import JobsTableModel
 from vorta.views.schedule_tab import ScheduleTab
 
 PROFILE_NAME = 'Default'
@@ -92,3 +93,42 @@ def test_schedule_tab_forwards_profile_provider_to_child_pages(qapp: VortaApp, q
     assert tab.shellCommandsPage.profile().id == profile.id
     assert tab.networksPage.profile().id == profile.id
     assert tab.logPage.profile().id == profile.id
+    assert tab.jobsPage.profile().id == profile.id
+
+
+def test_jobs_page_merges_pending_runs_with_stored_records(qapp: VortaApp, clockmock):
+    """The jobs page shows both halves: what the scheduler is holding, and what it already recorded."""
+    page = qapp.main_window.scheduleTab.jobsPage
+
+    time_now = dt(2020, 5, 6, 4, 30)
+    clockmock.now.return_value = time_now
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_make_up_missed = False
+    profile.schedule_mode = 'interval'
+    profile.schedule_interval_unit = 'hours'
+    profile.schedule_interval_count = 3
+    profile.save()
+
+    EventLogModel.create(
+        subcommand='create',
+        profile=profile.id,
+        returncode=0,
+        category='scheduled',
+        start_time=time_now,
+        end_time=time_now,
+    )
+    JobModel.create(
+        profile=profile.id,
+        profile_name=profile.name,
+        status=JobModel.Status.SKIPPED.value,
+        reason='Repository is busy with another job.',
+    )
+    page.reload_records()
+
+    # Arming a timer emits `schedule_changed`, which is what the page listens to for pending runs.
+    qapp.scheduler.set_timer_for_profile(profile.id)
+
+    model = page.jobsTable.model()
+    statuses = {model.data(model.index(row, JobsTableModel.COL_STATUS)) for row in range(model.rowCount())}
+    assert statuses == {'scheduled', 'skipped'}

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -96,8 +96,8 @@ def test_schedule_tab_forwards_profile_provider_to_child_pages(qapp: VortaApp, q
     assert tab.jobsPage.profile().id == profile.id
 
 
-def test_jobs_page_merges_pending_runs_with_stored_records(qapp: VortaApp, clockmock):
-    """The jobs page shows both halves: what the scheduler is holding, and what it already recorded."""
+def test_jobs_page_merges_pending_runs_with_stored_records(qapp: VortaApp, qtbot, clockmock, mocker):
+    """The jobs page shows both halves, and a skip that pauses the profile must not empty either one."""
     page = qapp.main_window.scheduleTab.jobsPage
 
     time_now = dt(2020, 5, 6, 4, 30)
@@ -118,17 +118,28 @@ def test_jobs_page_merges_pending_runs_with_stored_records(qapp: VortaApp, clock
         start_time=time_now,
         end_time=time_now,
     )
-    JobModel.create(
-        profile=profile.id,
-        profile_name=profile.name,
-        status=JobModel.Status.SKIPPED.value,
-        reason='Repository is busy with another job.',
-    )
-    page.reload_records()
 
     # Arming a timer emits `schedule_changed`, which is what the page listens to for pending runs.
     qapp.scheduler.set_timer_for_profile(profile.id)
 
     model = page.jobsTable.model()
-    statuses = {model.data(model.index(row, JobsTableModel.COL_STATUS)) for row in range(model.rowCount())}
-    assert statuses == {'scheduled', 'skipped'}
+
+    def statuses():
+        return {model.data(model.index(row, JobsTableModel.COL_STATUS)) for row in range(model.rowCount())}
+
+    # The page outlives earlier tests, so take its record count as the baseline rather than assuming zero.
+    page.reload_records()
+    rows_before = model.rowCount()
+    assert JobModel.Status.SCHEDULED.value in statuses()
+    assert JobModel.Status.PAUSED.value not in statuses()
+
+    # A busy repo records a skip and pauses the profile, with no Borg job to announce either.
+    mocker.patch.object(qapp.jobs_manager, 'is_worker_running', return_value=True)
+    qapp.scheduler.create_backup(profile.id)
+
+    # One row more: the skip arrives on its own signal, and the paused run keeps its row instead of vanishing.
+    qtbot.waitUntil(lambda: model.rowCount() == rows_before + 1)
+    assert JobModel.Status.PAUSED.value in statuses()
+    assert JobModel.Status.SKIPPED.value in statuses()
+
+    qapp.scheduler.unpause(profile.id)

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -99,14 +99,16 @@ def test_pending_jobs_reports_the_scheduled_run(clockmock):
     )
 
     scheduler.set_timer_for_profile(profile.id)
-    assert scheduler.pending_jobs() == [PendingJob(profile.id, PROFILE_NAME, profile.repo.url, dt(2020, 5, 6, 7, 30))]
+    assert scheduler.pending_jobs() == [
+        PendingJob(profile.id, PROFILE_NAME, profile.repo.url, dt(2020, 5, 6, 7, 30), JobModel.Status.SCHEDULED.value)
+    ]
 
     scheduler.remove_job(profile.id)
     assert scheduler.pending_jobs() == []
 
 
-def test_pending_jobs_includes_a_run_too_far_ahead_for_a_timer(clockmock):
-    """A run beyond QTimer's range gets no timer, but it still has a time and is still due."""
+def test_pending_jobs_includes_a_run_beyond_a_single_timer_chunk(clockmock):
+    """A run further out than one timer chunk is armed in chunks, and is pending the whole way."""
     scheduler = VortaScheduler()
 
     time = dt(2020, 5, 6, 4, 30)
@@ -125,8 +127,30 @@ def test_pending_jobs_includes_a_run_too_far_ahead_for_a_timer(clockmock):
 
     scheduler.set_timer_for_profile(profile.id)
 
-    assert scheduler.next_job_for_profile(profile.id).type == ScheduleStatusType.TOO_FAR_AHEAD
-    assert scheduler.pending_jobs() == [PendingJob(profile.id, PROFILE_NAME, profile.repo.url, time + td(weeks=5))]
+    assert scheduler.next_job_for_profile(profile.id).type == ScheduleStatusType.SCHEDULED
+    assert scheduler.pending_jobs() == [
+        PendingJob(profile.id, PROFILE_NAME, profile.repo.url, time + td(weeks=5), JobModel.Status.SCHEDULED.value)
+    ]
+
+
+def test_pending_jobs_includes_a_paused_profile(clockmock):
+    """A pause is a held time, so it stays on the jobs table with the status the schedule page shows."""
+    scheduler = VortaScheduler()
+
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    scheduler.pause(profile.id)
+    paused_until = scheduler.next_job_for_profile(profile.id).time
+
+    assert scheduler.pending_jobs() == [
+        PendingJob(profile.id, PROFILE_NAME, profile.repo.url, paused_until, JobModel.Status.PAUSED.value)
+    ]
+
+    scheduler.unpause(profile.id)
 
 
 def test_pending_jobs_drops_a_profile_deleted_under_its_timer(clockmock):
@@ -626,6 +650,14 @@ def test_create_backup_records_skip_reason(qapp, qtbot, mocker):
     assert job.profile_name == PROFILE_NAME
 
 
+def test_recording_a_skip_emits_jobs_changed(qapp, qtbot, mocker):
+    """The jobs view refreshes its records off this signal, and a skip runs no Borg job to announce it."""
+    mocker.patch.object(qapp.jobs_manager, 'is_worker_running', return_value=True)
+
+    with qtbot.waitSignal(qapp.scheduler.jobs_changed, timeout=1000):
+        qapp.scheduler.create_backup(1)
+
+
 def test_create_backup_records_failure_not_skip(qapp, qtbot, mocker):
     """An unexpected prepare() failure is recorded as failed, not skipped."""
     mocker.patch(
@@ -668,7 +700,7 @@ def test_create_backup_keeps_the_catchup_trigger(qapp, mocker):
     assert job.trigger == JobModel.Trigger.CATCHUP.value
 
 
-def test_set_timer_records_skip_when_network_down_for_catchup(clockmock):
+def test_set_timer_records_skip_when_network_down_for_catchup(qtbot, clockmock):
     """A catch-up run blocked by a down network is recorded as a skipped JobModel row."""
     scheduler = VortaScheduler()
     scheduler._net_up = False
@@ -694,7 +726,9 @@ def test_set_timer_records_skip_when_network_down_for_catchup(clockmock):
     )
     jobs_before = JobModel.select().count()
 
-    scheduler.set_timer_for_profile(profile.id)
+    # This skip is recorded while the scheduler holds its lock, so the signal has to leave it first.
+    with qtbot.waitSignal(scheduler.jobs_changed, timeout=1000):
+        scheduler.set_timer_for_profile(profile.id)
 
     assert JobModel.select().count() == jobs_before + 1
     job = JobModel.select().order_by(JobModel.id.desc()).get()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -10,7 +10,7 @@ from pytest import mark
 
 import vorta.borg
 import vorta.scheduler
-from vorta.scheduler import ScheduleStatus, ScheduleStatusType, VortaScheduler
+from vorta.scheduler import PendingJob, ScheduleStatus, ScheduleStatusType, VortaScheduler
 from vorta.store.models import BackupProfileModel, EventLogModel, JobModel, SchedulerPauseModel
 
 PROFILE_NAME = 'Default'
@@ -78,6 +78,95 @@ def test_manual_mode():
     # test
     scheduler.set_timer_for_profile(profile.id)
     assert len(scheduler.timers) == 0
+
+
+def test_pending_jobs_reports_the_scheduled_run(clockmock):
+    """A profile holding a time on the clock shows up as a pending job."""
+    scheduler = VortaScheduler()
+
+    time = dt(2020, 5, 6, 4, 30)
+    clockmock.now.return_value = time
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_make_up_missed = False
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.schedule_interval_unit = 'hours'
+    profile.schedule_interval_count = 3
+    profile.save()
+
+    EventLogModel.create(
+        subcommand='create', profile=profile.id, returncode=0, category='scheduled', start_time=time, end_time=time
+    )
+
+    scheduler.set_timer_for_profile(profile.id)
+    assert scheduler.pending_jobs() == [PendingJob(profile.id, PROFILE_NAME, profile.repo.url, dt(2020, 5, 6, 7, 30))]
+
+    scheduler.remove_job(profile.id)
+    assert scheduler.pending_jobs() == []
+
+
+def test_pending_jobs_includes_a_run_too_far_ahead_for_a_timer(clockmock):
+    """A run beyond QTimer's range gets no timer, but it still has a time and is still due."""
+    scheduler = VortaScheduler()
+
+    time = dt(2020, 5, 6, 4, 30)
+    clockmock.now.return_value = time
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_make_up_missed = False
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.schedule_interval_unit = 'weeks'
+    profile.schedule_interval_count = 5
+    profile.save()
+
+    EventLogModel.create(
+        subcommand='create', profile=profile.id, returncode=0, category='scheduled', start_time=time, end_time=time
+    )
+
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert scheduler.next_job_for_profile(profile.id).type == ScheduleStatusType.TOO_FAR_AHEAD
+    assert scheduler.pending_jobs() == [PendingJob(profile.id, PROFILE_NAME, profile.repo.url, time + td(weeks=5))]
+
+
+def test_pending_jobs_drops_a_profile_deleted_under_its_timer(clockmock):
+    """A timer can outlive the profile it belongs to, and the jobs view must not trip over it."""
+    scheduler = VortaScheduler()
+
+    time = dt(2020, 5, 6, 4, 30)
+    clockmock.now.return_value = time
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_make_up_missed = False
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.schedule_interval_unit = 'hours'
+    profile.schedule_interval_count = 3
+    profile.save()
+
+    EventLogModel.create(
+        subcommand='create', profile=profile.id, returncode=0, category='scheduled', start_time=time, end_time=time
+    )
+
+    scheduler.set_timer_for_profile(profile.id)
+    assert len(scheduler.pending_jobs()) == 1
+
+    BackupProfileModel.delete_by_id(profile.id)
+    assert scheduler.pending_jobs() == []
+
+
+def test_pending_jobs_ignores_profiles_without_a_scheduled_run(clockmock):
+    """A profile that never ran has no time to show, so it isn't pending."""
+    scheduler = VortaScheduler()
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert scheduler.next_job_for_profile(profile.id).type == ScheduleStatusType.NO_PREVIOUS_BACKUP
+    assert scheduler.pending_jobs() == []
 
 
 def test_set_timer_for_missing_profile():


### PR DESCRIPTION
## Description

Adds the Jobs view from #2360 goal 3. One table showing what the scheduler is holding a time for, and what it has already recorded.

Depends on nothing in flight. Branches off master, and does not touch `log_page.py`.

## Screenshot

<img width="1208" height="869" alt="Screenshot from 2026-08-12 14-40-26" src="https://github.com/user-attachments/assets/572c4f01-d39e-40e2-b661-5bfe10d38660" />


## Where it lives

A `Jobs` page in the Schedule tab's toolbox, following the Related Files map in the issue (`views/schedule_tab.py - Add Jobs page`), which also leaves the existing Log page alone.

The table is **global, not scoped to the selected profile**, so it has a Profile column and lists every profile's jobs. Flagging it because it was one of the issue's open questions and was never settled in words.

## Where the rows come from

Recorded rows come from `JobModel`. Pending rows come from the scheduler's in-memory timers through a new `VortaScheduler.pending_jobs()`. So nothing writes `Status.SCHEDULED` to the table and the view has to merge the two halves itself.

`pending_jobs()` returns a `PendingJob` per profile whose timer is `SCHEDULED` or `TOO_FAR_AHEAD`, soonest first. It exists so the page never reads `self.timers` directly, which keeps the split in phase 2 an internal change.

## Why the refresh is split in two

`reload_records` re-reads `JobModel` and is wired to `backup_finished_event`. `reload_pending` only walks the timers and is wired to `schedule_changed`.

They are separate because `schedule_changed` is a hot signal: `reload_all_timers` emits once per profile every 15 minutes, and three of the four emit sites fire while `VortaScheduler.lock` is held. A single refresh doing `JobModel.select()` would put a full table read inside the scheduler's critical section on every schedule change. The record query is also capped at 200 rows, since the 6 month purge is the only other bound on that table.

One residual worth naming: `pending_jobs()` still does a primary key profile lookup per armed timer inside that lock. That is a handful of rows rather than the whole history, so I left it rather than caching profile names in the scheduler.

## What is deliberately not here

- **No `completed` or `running` rows.** Nothing writes those statuses yet, so the table renders pending plus skipped and failed. The lifecycle transitions and the `event_log` link belong to the Execution phase, and the view picks them up for free once they land.
- **No filters.** Next PR, as a combo box over the proxy. Status first, then profile. The Repository column is carried on the row for the same reason, so the repo filter has something to filter on.
- **No source role on the model, and no actions.** Cancel and re-queue arrive with the actions PR, and the role that maps a proxy row back to a job goes in with its first real consumer rather than as an unused accessor here.

## Notes

No schema change, no migration.

The Time column means `created_at` for a recorded job and the scheduled time for a pending one. That reads fine today because records only exist for skips, but once jobs carry real execution timestamps it is worth deciding whether the column is "when recorded" or "when due".

Tests cover the accessor (scheduled, too far ahead for a QTimer, profile deleted under its timer, never-run profile), the row rendering for both sources, and the page itself through a real `schedule_changed` emission.

Merging this allows me to go on Phase D.