### PR TITLE
Update macFUSE wording

### DIFF
--- a/src/vorta/views/archive_tab.py
+++ b/src/vorta/views/archive_tab.py
@@ -103,7 +103,7 @@ class ArchiveTab(BaseTab, ArchiveTabBase, ArchiveTabUI):
         delegate = IconDelegate(self.archiveTable)
         self.archiveTable.setItemDelegateForColumn(ArchiveTableModel.COL_TRIGGER, delegate)
 
-        self.mount_help_text = QT_TRANSLATE_NOOP('Form', 'To mount archives, first install "FUSE for macOS" from %1.')
+        self.mount_help_text = QT_TRANSLATE_NOOP('Form', 'To mount archives, first install macFUSE from %1.')
         self.mount_help_link_text = QT_TRANSLATE_NOOP('Form', 'here')
         self.pruning_help_text = QT_TRANSLATE_NOOP(
             'Form',


### PR DESCRIPTION
### Description

Updates the outdated `"FUSE for macOS"` wording in the archive mount help text to the current project name, `macFUSE`.

### Related Issue

Closes #2541

### Motivation and Context

The Vorta UI currently refers to the macOS FUSE implementation as `"FUSE for macOS"`, while the current name is `macFUSE`.

Updating the wording makes the UI clearer and consistent with the current macFUSE project name and Vorta's macOS documentation.

### How Has This Been Tested?

This is a one-line text-only change.

Tested with:

- `git diff --check`
- `uv run ruff check src/vorta/views/archive_tab.py`
- `uv run pre-commit run --all-files --show-diff-on-failure`

All of these checks passed.

The full Vorta test suite was not run because this change only updates UI wording.

### Screenshots (if appropriate):

Not applicable.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/