### PR TITLE
schedule runs beyond QTimer's 24.8 day ceiling (#2360, phase C)

### DIFF
--- a/src/vorta/scheduler.py
+++ b/src/vorta/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import logging
 import threading
+from collections.abc import Callable
 from datetime import datetime as dt
 from datetime import timedelta
 from typing import Any, NamedTuple
@@ -30,11 +31,43 @@ RESCHEDULE_INTERVAL_MS = 15 * 60 * 1000
 WAKE_CHECK_INTERVAL_MS = 5 * 60 * 1000
 WAKE_GAP_THRESHOLD = timedelta(minutes=10)
 
+# A QTimer interval is a C++ int, so a single wait tops out at about 24.8 days.
+MAX_TIMER_MS = 2**31 - 1
+# Fire just after the deadline, so the handler always sees it as passed.
+TIMER_GRACE_MS = 100
+
+
+def arm_deadline_timer(deadline: dt, on_expiry: Callable[[], None]) -> QTimer:
+    """
+    Start a timer that calls `on_expiry` once `deadline` has passed.
+
+    Waits longer than `MAX_TIMER_MS` are split into chunks, and every chunk is measured
+    against the wall clock again, so the deadline holds however far ahead it is.
+    """
+    timer = QTimer()
+    timer.setSingleShot(True)
+
+    def remaining_ms() -> float:
+        return (deadline - dt.now()).total_seconds() * 1000 + TIMER_GRACE_MS
+
+    def rearm() -> None:
+        timer.setInterval(int(max(0, min(remaining_ms(), MAX_TIMER_MS))))
+        timer.start()
+
+    def on_timeout() -> None:
+        if remaining_ms() <= 0:
+            on_expiry()
+        else:
+            rearm()
+
+    timer.timeout.connect(on_timeout)
+    rearm()
+    return timer
+
 
 class ScheduleStatusType(enum.Enum):
     SCHEDULED = enum.auto()  # date provided
     UNSCHEDULED = enum.auto()  # Unknown
-    TOO_FAR_AHEAD = enum.auto()  # QTimer range exceeded, date provided
     NO_PREVIOUS_BACKUP = enum.auto()  # run a manual backup first
     PAUSED = enum.auto()  # paused after a failed or skipped run, date provided
 
@@ -186,13 +219,13 @@ class VortaScheduler(QtCore.QObject):
     def _set_pause(self, profile: BackupProfileModel, until: dt) -> None:
         """Arm the reschedule timer for a pause and store it, so it outlives the process."""
         profile_id = profile.id
+        replaced = self.pauses.get(profile_id)
+        if replaced is not None:
+            replaced[1].stop()
+
         # setting timer for reschedule is not possible if called
         # from a non-QThread -  it won't fail but won't work
-        timer_value = max(1, (until - dt.now()).total_seconds())
-        timer = QtCore.QTimer()
-        timer.setInterval(min(int(timer_value * 1000) + 100, 2**31 - 1))
-        timer.timeout.connect(lambda: self.set_timer_for_profile(profile_id))
-        timer.start()
+        timer = arm_deadline_timer(until, lambda: self.set_timer_for_profile(profile_id))
 
         self.pauses[profile_id] = (until, timer)
 
@@ -436,31 +469,13 @@ class VortaScheduler(QtCore.QObject):
                         next_time += timedelta(days=1)
 
             # start QTimer
-            timer_ms = (next_time - dt.now()).total_seconds() * 1000
+            logger.debug('Scheduling next run for %s', next_time)
 
-            if timer_ms < 2**31 - 1:
-                logger.debug('Scheduling next run for %s', next_time)
-
-                timer = QTimer()
-                timer.setSingleShot(True)
-                timer.setInterval(int(timer_ms))
-                timer.timeout.connect(lambda: self.create_backup(profile_id))
-                timer.start()
-
-                self.timers[profile_id] = {
-                    'qtt': timer,
-                    'dt': next_time,
-                    'type': ScheduleStatusType.SCHEDULED,
-                }
-            else:
-                # int to big to pass it to qt which expects a c++ int
-                # wait 15 min for regular reschedule
-                logger.debug(f"Couldn't schedule for {next_time} because " f"timer value {timer_ms} too large.")
-
-                self.timers[profile_id] = {
-                    'dt': next_time,
-                    'type': ScheduleStatusType.TOO_FAR_AHEAD,
-                }
+            self.timers[profile_id] = {
+                'qtt': arm_deadline_timer(next_time, lambda: self.create_backup(profile_id)),
+                'dt': next_time,
+                'type': ScheduleStatusType.SCHEDULED,
+            }
 
         # Emit signal so that e.g. the GUI can react to the new schedule
         self.schedule_changed.emit()

--- a/src/vorta/views/schedule_page.py
+++ b/src/vorta/views/schedule_page.py
@@ -109,10 +109,7 @@ class SchedulePage(BaseTab, SchedulePageBase, SchedulePageUI):
 
     def draw_next_scheduled_backup(self):
         status = self.app.scheduler.next_job_for_profile(self.profile().id)
-        if status.type in (
-            ScheduleStatusType.SCHEDULED,
-            ScheduleStatusType.TOO_FAR_AHEAD,
-        ):
+        if status.type == ScheduleStatusType.SCHEDULED:
             time = QDateTime.fromMSecsSinceEpoch(int(status.time.timestamp() * 1000))
             text = get_locale().toString(time, QLocale.FormatType.LongFormat)
         elif status.type == ScheduleStatusType.PAUSED:

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -237,6 +237,121 @@ def test_simple_schedule(clockmock):
     assert scheduler.next_job_for_profile(profile.id) == ScheduleStatus(ScheduleStatusType.UNSCHEDULED)
 
 
+def test_schedule_past_the_qtimer_range(clockmock):
+    """A four-week interval is longer than a QTimer can wait, but still a scheduled run."""
+    scheduler = VortaScheduler()
+
+    time = dt(2020, 5, 6, 4, 30)
+    clockmock.now.return_value = time
+
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_make_up_missed = False
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.schedule_interval_unit = 'weeks'
+    profile.schedule_interval_count = 4
+    profile.save()
+
+    EventLogModel.create(
+        subcommand='create', profile=profile.id, returncode=0, category='scheduled', start_time=time, end_time=time
+    )
+
+    scheduler.set_timer_for_profile(profile.id)
+
+    assert scheduler.next_job_for_profile(profile.id) == ScheduleStatus(
+        ScheduleStatusType.SCHEDULED, time + td(weeks=4)
+    )
+    assert scheduler.timers[profile.id]['qtt'].interval() <= vorta.scheduler.MAX_TIMER_MS
+    assert scheduler.next_job().endswith('({})'.format(PROFILE_NAME))
+
+    scheduler.remove_job(profile.id)
+
+
+def test_deadline_timer_waits_in_chunks(clockmock):
+    """A wait past the QTimer range is split up, and only the last chunk fires."""
+    start = dt(2020, 5, 6, 4, 30)
+    deadline = start + td(days=30)
+    clockmock.now.return_value = start
+    fired = []
+
+    timer = vorta.scheduler.arm_deadline_timer(deadline, lambda: fired.append(True))
+    assert timer.interval() == vorta.scheduler.MAX_TIMER_MS
+
+    clockmock.now.return_value = start + td(days=29)
+    timer.timeout.emit()
+    assert fired == []
+    assert timer.interval() == int(td(days=1).total_seconds() * 1000) + vorta.scheduler.TIMER_GRACE_MS
+
+    clockmock.now.return_value = deadline + td(seconds=1)
+    timer.timeout.emit()
+    assert fired == [True]
+
+    timer.stop()
+
+
+def test_overriding_a_pause_stops_the_old_timer(clockmock):
+    """The replaced timer holds a reference cycle, so it has to be stopped, not just dropped."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+    scheduler = VortaScheduler()
+    scheduler.pause(profile.id)
+    replaced = scheduler.pauses[profile.id][1]
+
+    scheduler.pause(profile.id, until=dt(2020, 5, 6, 5, 30))
+
+    assert not replaced.isActive()
+    assert scheduler.pauses[profile.id][1] is not replaced
+
+    scheduler.clear_pause(profile.id)
+
+
+def test_deadline_timer_in_the_past_defers_to_the_event_loop(clockmock):
+    """Arming a passed deadline must not call back inline, which would re-enter the lock."""
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+    fired = []
+
+    timer = vorta.scheduler.arm_deadline_timer(dt(2020, 5, 6, 4, 0), lambda: fired.append(True))
+
+    assert fired == []
+    assert timer.interval() == 0
+
+    timer.timeout.emit()
+    assert fired == [True]
+
+    timer.stop()
+
+
+def test_far_future_pause_runs_its_full_length(clockmock):
+    """A restored pause past the QTimer range must re-arm, not end at the 24 day cap."""
+    profile = BackupProfileModel.get(name=PROFILE_NAME)
+    profile.schedule_mode = INTERVAL_SCHEDULE
+    profile.save()
+
+    until = dt(2020, 7, 6, 4, 30)
+    SchedulerPauseModel.replace(profile=profile.id, paused_until=until).execute()
+    clockmock.now.return_value = dt(2020, 5, 6, 4, 30)
+
+    scheduler = VortaScheduler()
+    timer = scheduler.pauses[profile.id][1]
+    assert scheduler.next_job_for_profile(profile.id) == ScheduleStatus(ScheduleStatusType.PAUSED, until)
+
+    # A day out, the chunk that ran out has to re-arm for what is left of the pause.
+    clockmock.now.return_value = until - td(days=1)
+    timer.timeout.emit()
+
+    assert scheduler.paused(profile.id)
+    assert timer.interval() == int(td(days=1).total_seconds() * 1000) + vorta.scheduler.TIMER_GRACE_MS
+
+    # Once it has actually passed, the same timer ends the pause.
+    clockmock.now.return_value = until + td(seconds=1)
+    timer.timeout.emit()
+
+    assert not scheduler.paused(profile.id)
+    assert SchedulerPauseModel.get_or_none(profile=profile.id) is None
+
+
 @mark.parametrize("scheduled", [True, False])
 @mark.parametrize(
     "passed_time, now, unit, count, added_time",


### PR DESCRIPTION
# Description

Phase C of #2360. Stacked on #2532, which is where `_set_pause` and its clamp come from.

A `QTimer` interval is a C++ `int`, so one wait tops out at `2**31 - 1` ms, about 24.855 days. Two places hit that, each worked around differently.

`set_timer_for_profile` stores `TOO_FAR_AHEAD` with no timer and leaves the 15 minute poll to pick the profile up once the wait fits. The unit list offers weeks and the count spinbox goes to 740, so `4 weeks` reaches this from the UI, and `next_job` skips entries with no active `qtt`, so the tray reads **"None scheduled"** for three days after each run while the schedule page shows the correct date beside it. A yearly schedule sits that way for eleven months. The run is not lost, just imprecise.

`_set_pause` clamps instead. A `paused_until` read back after a clock correction fires 24.8 days in, `set_timer_for_profile` finds the pause still running and re-marks it without arming anything, so the repeating timer ends it up to another 24.8 days late.

## The fix

`arm_deadline_timer(deadline, on_expiry)` replaces both: a single-shot timer of at most `MAX_TIMER_MS` that recomputes the remainder against the wall clock on each expiry and re-arms until the deadline has passed. `TOO_FAR_AHEAD` loses its writer and comes out with its branch in `schedule_page`.

Measuring per chunk also absorbs `CoarseTimer`'s 5% early fire, which the old single interval had nothing to catch, and lets a chunk spanning a suspend extend itself instead of running late.

A deadline already in the past arms a zero length timer rather than calling back inline, which keeps `set_timer_for_profile` from re-entering `self.lock` through `create_backup`.

## Notes

- **`_set_pause` now stops the timer it replaces.** Overriding a pause always orphaned the old one, harmlessly, because nothing held a reference to it afterwards. The chunked timer keeps a cycle through its own `timeout` connection, so an orphan would now outlive collection and fire one spurious reschedule.
- The pause timer is single-shot rather than repeating. Only the first fire was ever used, and the helper's 100 ms grace preserves the old `+ 100`.
- `pending_jobs` on #2538 lists `SCHEDULED` and `TOO_FAR_AHEAD`. Whichever lands second drops that one line.