### PR TITLE
Stop growing PATH on every Borg job on macOS

### DIFF
--- a/src/vorta/borg/borg_job.py
+++ b/src/vorta/borg/borg_job.py
@@ -207,8 +207,11 @@ class BorgJob(JobInterface):
         # More info at https://github.com/borgbase/vorta/issues/2100
         # Set the path to also find homebrew installs of Borg, and avoid falling back to the embedded binary.
         if sys.platform == 'darwin':
-            current_path = os.environ.get("PATH", "/usr/bin:/bin")
-            os.environ["PATH"] = f"{current_path}:/opt/homebrew/bin:/usr/local/bin"
+            # This runs for every job, so only add the directories that are still missing.
+            path_dirs = os.environ.get("PATH", "/usr/bin:/bin").split(os.pathsep)
+            missing_dirs = [d for d in ("/opt/homebrew/bin", "/usr/local/bin") if d not in path_dirs]
+            if missing_dirs:
+                os.environ["PATH"] = os.pathsep.join(path_dirs + missing_dirs)
         # Now continue looking for the borg binary to use
         borg_in_path = shutil.which('borg')
 

--- a/tests/unit/test_borg.py
+++ b/tests/unit/test_borg.py
@@ -1,7 +1,10 @@
+import os
+
 import pytest
 
 import vorta.borg
 import vorta.store.models
+from vorta.borg.borg_job import BorgJob
 from vorta.borg.prune import BorgPruneJob
 
 
@@ -18,3 +21,17 @@ def test_borg_prune(qapp, qtbot, mocker, borg_json_output):
         thread.run()
 
     assert blocker.args[0]['returncode'] == 0
+
+
+def test_prepare_bin_does_not_grow_path(monkeypatch):
+    """`prepare_bin()` runs for every job, so extending PATH has to be idempotent."""
+    monkeypatch.setenv('PATH', '/usr/bin:/bin')
+    BorgJob.prepare_bin()
+    path_after_first_call = os.environ['PATH']
+
+    for _ in range(3):
+        BorgJob.prepare_bin()
+
+    assert os.environ['PATH'] == path_after_first_call
+    path_dirs = path_after_first_call.split(os.pathsep)
+    assert len(path_dirs) == len(set(path_dirs))


### PR DESCRIPTION
### Description

`BorgJob.prepare_bin()` appended `:/opt/homebrew/bin:/usr/local/bin` to `os.environ['PATH']` unconditionally. It runs at least twice per job (`prepare()` and `__init__()`), so in a long-running instance PATH grows by ~60 bytes per Borg job for the lifetime of the process (11 KB after 150 backups in a test run) and the ever longer value is copied into the environment of every Borg subprocess. Now only the directories that are still missing are appended, so repeated calls are no-ops.

### Related Issue

Found while investigating Vorta's memory use for https://github.com/borgbackup/borg/discussions/10328 (see also https://github.com/borgbase/vorta/pull/2551). No separate issue; the change is a two-line fix with a regression test.

### Motivation and Context

Unbounded growth of a process-wide variable in a tray app that runs for weeks, and an ever-growing environment handed to `borg`.

### How Has This Been Tested?

- New test `test_prepare_bin_does_not_grow_path` in `tests/unit/test_borg.py`: PATH is unchanged by repeated calls and contains no duplicate entries.
- `pytest tests/unit/test_borg.py`: 2 passed (macOS 15, Python 3.11). `ruff check` / `ruff format --check` clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
