### PR TITLE
PyInstaller spec: collect assets/UI recursively (bundles built from master fail at startup)

### DIFF
--- a/package/vorta.spec
+++ b/package/vorta.spec
@@ -21,7 +21,9 @@ a = Analysis([os.path.join(SRC_DIR, '__main__.py')],
              pathex=[SRC_DIR],
              binaries=[],
              datas=[
-                (os.path.join(SRC_DIR, 'assets/UI/*'), 'assets/UI'),
+                # A directory (not a glob) is collected recursively with its layout intact;
+                # 'assets/UI/*' flattened the dialogs' subfolders into assets/UI.
+                (os.path.join(SRC_DIR, 'assets/UI'), 'assets/UI'),
                 (os.path.join(SRC_DIR, 'assets/icons/*'), 'assets/icons'),
                 (os.path.join(SRC_DIR, 'assets/exclusion_presets/*'), 'assets/exclusion_presets'),
                 (os.path.join(SRC_DIR, 'i18n/qm/*'), 'vorta/i18n/qm'),


### PR DESCRIPTION
### Description

The dialogs' `.ui` files live in `src/vorta/assets/UI/dialogs/{,archive,profile,repo}/` now, but `package/vorta.spec` still collects them with the glob `assets/UI/*`. When a glob match is a directory, PyInstaller walks it *relative to the matched directory*, so `assets/UI/dialogs/exception.ui` is copied to `assets/UI/exception.ui` — the `dialogs/` level is dropped. A bundle built from `master` therefore dies on the first `uic.loadUiType` with a subfolder path:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../Vorta.app/Contents/Frameworks/assets/UI/dialogs/exception.ui'
```

Passing the directory itself instead of a glob makes PyInstaller collect it recursively with the layout intact (that is the documented form for directories). The other `datas` entries point at flat directories and are unchanged.

### Related Issue

Found while building the app locally for https://github.com/borgbase/vorta/pull/2551. No separate issue; `make dist/Vorta.app` from `master` currently produces an app that cannot start.

### Motivation and Context

Release builds from the current tree need this; it only touches the packaging spec.

### How Has This Been Tested?

- Built with `pyinstaller --clean --noconfirm package/vorta.spec` (macOS 15, Python 3.11, PyQt6 6.6.1, PyInstaller 6.11), copied `Sparkle.framework` in as the Makefile does, launched under a scratch `$HOME`: the app starts and runs; before the change it exited at startup with the error above.
- All `.ui` files, including `assets/UI/dialogs/**`, are present in the built bundle at their original relative paths.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
