### PR TITLE
tests: keep the suite away from the developer's Login Items and autostart file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,13 @@ def pytest_configure(config):
     _original_getaddrinfo = socket.getaddrinfo
     socket.getaddrinfo = lambda *args, **kwargs: []
 
+    # Saving a SettingsModel row (init_db(), toggling a setting in the misc tab) applies the
+    # autostart setting via vorta.autostart.open_app_at_startup, which edits the developer's real
+    # Login Items on macOS and ~/.config/autostart on Linux. Keep the test suite away from those.
+    import vorta.store.connection
+
+    vorta.store.connection.open_app_at_startup = lambda enabled=True: None
+
     # Mock WiFi enumeration to prevent hangs on headless CI (utils.get_sorted_wifis)
     import vorta.utils
 

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -8,6 +8,8 @@ from PyQt6 import QtCore
 from PyQt6.QtGui import QCloseEvent
 from PyQt6.QtWidgets import QCheckBox, QFormLayout, QMessageBox
 
+import vorta.autostart
+import vorta.store.connection
 import vorta.store.models
 import vorta.views.partials.archive_table_model
 from vorta.store.models import SettingsModel
@@ -37,15 +39,16 @@ def test_toggle_all_settings(qapp, qtbot):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="testing autostart path for Linux only")
-def test_autostart_linux(qapp, qtbot):
+def test_autostart_linux(qapp, qtbot, monkeypatch, tmp_path):
     """Checks that autostart path is added correctly on Linux when setting is enabled."""
+    # conftest stubs out open_app_at_startup; use the real one here, but in a private config dir
+    monkeypatch.setattr(vorta.store.connection, 'open_app_at_startup', vorta.autostart.open_app_at_startup)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     setting = "Automatically start Vorta at login"
 
     # ensure file is present when autostart is enabled
     _click_toggle_setting(setting, qapp, qtbot)
-    autostart_path = (
-        Path(os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~") + '/.config') + "/autostart") / "vorta.desktop"
-    )
+    autostart_path = tmp_path / "autostart" / "vorta.desktop"
     qtbot.waitUntil(lambda: autostart_path.exists(), **pytest._wait_defaults)
     with open(autostart_path) as desktop_file:
         desktop_file_text = desktop_file.read()
@@ -53,8 +56,7 @@ def test_autostart_linux(qapp, qtbot):
 
     # ensure file is removed when autostart is disabled
     _click_toggle_setting(setting, qapp, qtbot)
-    if sys.platform == 'linux':
-        assert not os.path.exists(autostart_path)
+    assert not autostart_path.exists()
 
 
 def test_enable_background_question(qapp, monkeypatch, mocker):


### PR DESCRIPTION
### Description

Running the test suite changes the developer's system:

- `init_db()` saves every settings row (to refresh labels/tooltips). Each save fires the `post_save` hook that applies the `autostart` setting through `vorta.autostart.open_app_at_startup()`. Every test session therefore calls `open_app_at_startup(False)`, which on macOS removes any real `Vorta.app` entry from the user's Login Items and on Linux deletes the real `~/.config/autostart/vorta.desktop`.
- `test_toggle_all_settings` toggles the autostart setting on and off. On macOS the "on" half registers the test interpreter's `Python.app` as a Login Item, and the "off" half only removes items matching `Vorta.app`, so a stray "Python" Login Item is left behind.

This stubs `open_app_at_startup` out in `pytest_configure` (next to the existing D-Bus / DNS / Wi-Fi stubs) and lets `test_autostart_linux`, which is about that function, use the real one with `XDG_CONFIG_HOME` pointed at a temporary directory.

### Related Issue

Noticed while working on https://github.com/borgbase/vorta/pull/2551. No separate issue.

### Motivation and Context

Tests must not edit the developer's Login Items or autostart configuration.

### How Has This Been Tested?

- macOS 15, Python 3.11: full `pytest tests/unit` run against this branch — 264 passed, 7 skipped; Login Items verified unchanged before/after the run.
- Linux (Debian, Python 3.12, `QT_QPA_PLATFORM=offscreen`, in a container): `pytest tests/unit/test_misc.py -k "autostart or toggle_all"` — 2 passed (test_autostart_linux, test_toggle_all_settings); `$HOME/.config/autostart` did not exist afterwards.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
