### PR TITLE
macOS: keep a plain `vorta` run alive after its window is closed

### DIFF
--- a/src/vorta/application.py
+++ b/src/vorta/application.py
@@ -63,6 +63,13 @@ class VortaApp(QtSingleApplication):
         init_translations(self)
 
         self.setQuitOnLastWindowClosed(False)
+        if sys.platform == 'darwin' and not getattr(sys, 'frozen', False):
+            # The app bundle is an LSUIElement: no Dock icon, and it keeps running in the tray
+            # without windows. Give a plain `vorta` run the same activation policy, otherwise
+            # macOS sends the process a quit Apple Event ~2 s after its last window is closed.
+            from AppKit import NSApp, NSApplicationActivationPolicyAccessory
+
+            NSApp.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
         self.jobs_manager = JobsManager()
         self.scheduler = VortaScheduler()
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1,0 +1,11 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform != 'darwin', reason='macOS activation policy only')
+def test_runs_as_accessory_app(qapp):
+    """A plain `vorta` run must use the bundle's LSUIElement policy, or macOS quits it after the last window closes."""
+    from AppKit import NSApp, NSApplicationActivationPolicyAccessory
+
+    assert NSApp.activationPolicy() == NSApplicationActivationPolicyAccessory


### PR DESCRIPTION
### Description

Started from a venv (`vorta`, `vorta --development`, or the test suite) rather than from the app bundle, Vorta terminates about two seconds after its main window is closed instead of staying in the tray. The cause is outside Vorta: macOS sends a process that runs with the *Regular* activation policy (Dock icon) a `quit` Apple Event (`aevt/quit`, no sender PID) ~1.6 s after its last window goes away; AppKit turns that into `applicationShouldTerminate:` and Qt into a `QEvent::Quit`. The bundle has `LSUIElement=1`, runs with the *Accessory* policy, and is never asked. `setQuitOnLastWindowClosed(False)` has no say in this, and neither has `QEventLoopLocker` or `NSProcessInfo.disableAutomaticTermination:` (all tried).

This gives non-frozen macOS runs the bundle's policy right after the `QApplication` is created. Side effect, by design: a venv run no longer shows a Dock icon — exactly like the shipped app.

### Related Issue

Found while testing https://github.com/borgbase/vorta/pull/2555 from a venv; the behaviour is the same on `master`. No separate issue.

### Motivation and Context

Developers testing tray behaviour from a checkout currently get a spurious quit whenever they close the window.

### How Has This Been Tested?

- Reproduced with a 30-line PyQt6 script (tray icon + `QMainWindow`, `setQuitOnLastWindowClosed(False)`): hiding the window → `applicationShouldTerminateAfterLastWindowClosed:` (answered NO) → 1.6 s later an `aevt/quit` Apple Event → quit. Same on PyQt6 6.6.1, 6.10.0 and 6.11.0; gone with the Accessory policy.
- Real entry point (`vorta --development <dir>` from `vorta-env`, macOS 15.7): before, `aboutToQuit` 1.7 s after `close()` on both `master` and this branch's parent; with this change the app is still running 8 s after the close and opens the window again from the tray.
- New test `tests/unit/test_application.py` (macOS only) asserts the policy; `pytest tests/unit`: 265 passed, 7 skipped (macOS).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] I have read the [CONTRIBUTING](https://vorta.borgbase.com/contributing/) guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

*I provide my contribution under the terms of the [license](./../LICENSE.txt) of this repository and I affirm the [Developer Certificate of Origin][dco].*

[dco]: https://developercertificate.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
